### PR TITLE
make `HashOutTarget`'s `elements` public

### DIFF
--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -94,18 +94,18 @@ impl<F: Field> Default for HashOut<F> {
 /// Represents a ~256 bit hash output.
 #[derive(Copy, Clone, Debug)]
 pub struct HashOutTarget {
-    pub(crate) elements: [Target; 4],
+    pub elements: [Target; 4],
 }
 
 impl HashOutTarget {
-    pub(crate) fn from_vec(elements: Vec<Target>) -> Self {
+    pub fn from_vec(elements: Vec<Target>) -> Self {
         debug_assert!(elements.len() == 4);
         Self {
             elements: elements.try_into().unwrap(),
         }
     }
 
-    pub(crate) fn from_partial(mut elements: Vec<Target>, zero: Target) -> Self {
+    pub fn from_partial(mut elements: Vec<Target>, zero: Target) -> Self {
         debug_assert!(elements.len() <= 4);
         while elements.len() < 4 {
             elements.push(zero);


### PR DESCRIPTION
`CircuitBuilder`'s hashing gadgets currently take a `Vec<Target>` and return a `HashOutTarget` but there's no way to turn the `HashOutTarget` back into a `Vec<Target>`.

I made `elements` public so the user can do `hash_out.elements.to_vec()`. I also made `from_vec` and `from_partial` public for the same reason.