### PR TITLE
Merkle tree optimizations

### DIFF
--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -69,7 +69,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
 
         // Squeeze until we have the desired number of outputs.
-        let mut outputs = Vec::new();
+        let mut outputs = Vec::with_capacity(num_outputs);
         loop {
             for i in 0..SPONGE_RATE {
                 outputs.push(state[i]);

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -2,6 +2,7 @@ use std::mem::MaybeUninit;
 use std::slice;
 
 use plonky2_util::log2_strict;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::hash::hash_types::RichField;


### PR DESCRIPTION
Getting around the overhead of Rayon's parallel iterators when building Merkle Trees. These changes speed up Merkle Tree benchmarks by 5% for width 2 ** 15 and 8% for width 2 ** 13 (both on Poseidon) on my machine. Speeds up proofs by 2%. (In general, there's more benefit for smaller trees and for machines with more cores.)