### PR TITLE
Fix degree of polynomial used in LDT

### DIFF
--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -154,6 +154,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             alpha.shift_poly(&mut final_poly);
             final_poly += quotient;
         }
+        final_poly.trim();
+        let mut final_poly_coeffs = final_poly.coeffs;
+        final_poly_coeffs.insert(0, F::Extension::ZERO);
+        final_poly = PolynomialCoeffs {
+            coeffs: final_poly_coeffs,
+        };
 
         let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);
         let lde_final_values = timed!(

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -156,7 +156,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         }
         final_poly.trim();
         // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
-        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/434 for details.
+        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
         final_poly.coeffs.insert(0, F::Extension::ZERO);
 
         let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -155,11 +155,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             final_poly += quotient;
         }
         final_poly.trim();
-        let mut final_poly_coeffs = final_poly.coeffs;
-        final_poly_coeffs.insert(0, F::Extension::ZERO);
-        final_poly = PolynomialCoeffs {
-            coeffs: final_poly_coeffs,
-        };
+        final_poly.coeffs.insert(0, F::Extension::ZERO);
 
         let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);
         let lde_final_values = timed!(

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -155,6 +155,8 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             final_poly += quotient;
         }
         final_poly.trim();
+        // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
+        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/434 for details.
         final_poly.coeffs.insert(0, F::Extension::ZERO);
 
         let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -281,7 +281,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             sum = self.div_add_extension(numerator, denominator, sum);
         }
 
-        sum
+        self.mul_extension(sum, subgroup_x)
     }
 
     fn fri_verifier_query_round<C: GenericConfig<D, F = F>>(

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -281,6 +281,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             sum = self.div_add_extension(numerator, denominator, sum);
         }
 
+        // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
+        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
         self.mul_extension(sum, subgroup_x)
     }
 

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -160,6 +160,8 @@ pub(crate) fn fri_combine_initial<
         sum += numerator / denominator;
     }
 
+    // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
+    // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
     sum * subgroup_x
 }
 

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -160,7 +160,7 @@ pub(crate) fn fri_combine_initial<
         sum += numerator / denominator;
     }
 
-    sum
+    sum * subgroup_x
 }
 
 fn fri_verifier_query_round<


### PR DESCRIPTION
In our FRI-based polynomial commitment, we commit to polynomials of degree `< n` and use a low-degree test to check that `(f - f(z)) / (X - z)` has degree `< n` (where `f` is a linear combination of the original polynomials). 
However, this quotient polynomial has degree `deg(f)-1`. So by starting with polynomials of degree `n`, the LDT would pass. This could potentially be exploited.

This PR fixes this by multiplying the quotient by `X`, so that the LDT actually checks that the quotient has degree `< n-1`.