### PR TITLE
Move profile definitions to root workspace toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,10 @@
 [workspace]
 members = ["field", "insertion", "plonky2", "util", "waksman"]
+
+[profile.release]
+opt-level = 3
+#lto = "fat"
+#codegen-units = 1
+
+[profile.bench]
+opt-level = 3

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -55,11 +55,3 @@ harness = false
 [[bench]]
 name = "transpose"
 harness = false
-
-[profile.release]
-opt-level = 3
-#lto = "fat"
-#codegen-units = 1
-
-[profile.bench]
-opt-level = 3


### PR DESCRIPTION
This fixes a warning about the profiles in the [`plonky2/Cargo.toml`](https://github.com/mir-protocol/plonky2/blob/main/plonky2/Cargo.toml) file by moving them to the to the top level workspace toml file (this issue probably arose in the recent crate refactor). The profiles themselves just set optimisation levels to the defaults, and so the fact that they were ignored didn't cause any issues.

The only concern might be publishing "subcrates", which might not inherit the profile correctly, as described in
https://github.com/rust-lang/cargo/issues/8264.