### PR TITLE
Make all FFTs in-place

### DIFF
--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -205,7 +205,6 @@ pub(crate) fn fft_classic<F: Field>(values: &mut [F], r: usize, root_table: &Fft
     }
 }
 
-// JNTODO
 #[cfg(test)]
 mod tests {
     use plonky2_util::{log2_ceil, log2_strict};

--- a/field/src/interpolation.rs
+++ b/field/src/interpolation.rs
@@ -19,7 +19,7 @@ pub fn interpolant<F: Field>(points: &[(F, F)]) -> PolynomialCoeffs<F> {
         .map(|x| interpolate(points, x, &barycentric_weights))
         .collect();
 
-    let mut coeffs = ifft(&PolynomialValues {
+    let mut coeffs = ifft(PolynomialValues {
         values: subgroup_evals,
     });
     coeffs.trim();

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -31,12 +31,12 @@ impl<F: Field> PolynomialValues<F> {
         self.values.len()
     }
 
-    pub fn ifft(&self) -> PolynomialCoeffs<F> {
+    pub fn ifft(self) -> PolynomialCoeffs<F> {
         ifft(self)
     }
 
     /// Returns the polynomial whose evaluation on the coset `shift*H` is `self`.
-    pub fn coset_ifft(&self, shift: F) -> PolynomialCoeffs<F> {
+    pub fn coset_ifft(self, shift: F) -> PolynomialCoeffs<F> {
         let mut shifted_coeffs = self.ifft();
         shifted_coeffs
             .coeffs
@@ -52,9 +52,9 @@ impl<F: Field> PolynomialValues<F> {
         polys.into_iter().map(|p| p.lde(rate_bits)).collect()
     }
 
-    pub fn lde(&self, rate_bits: usize) -> Self {
+    pub fn lde(self, rate_bits: usize) -> Self {
         let coeffs = ifft(self).lde(rate_bits);
-        fft_with_options(&coeffs, Some(rate_bits), None)
+        fft_with_options(coeffs, Some(rate_bits), None)
     }
 
     pub fn degree(&self) -> usize {
@@ -64,7 +64,7 @@ impl<F: Field> PolynomialValues<F> {
     }
 
     pub fn degree_plus_one(&self) -> usize {
-        self.ifft().degree_plus_one()
+        self.clone().ifft().degree_plus_one()
     }
 }
 
@@ -213,12 +213,12 @@ impl<F: Field> PolynomialCoeffs<F> {
         Self::new(self.trimmed().coeffs.into_iter().rev().collect())
     }
 
-    pub fn fft(&self) -> PolynomialValues<F> {
+    pub fn fft(self) -> PolynomialValues<F> {
         fft(self)
     }
 
     pub fn fft_with_options(
-        &self,
+        self,
         zero_factor: Option<usize>,
         root_table: Option<&FftRootTable<F>>,
     ) -> PolynomialValues<F> {
@@ -386,7 +386,7 @@ impl<F: Field> Mul for &PolynomialCoeffs<F> {
             .zip(b_evals.values)
             .map(|(pa, pb)| pa * pb)
             .collect();
-        ifft(&mul_evals.into())
+        ifft(mul_evals.into())
     }
 }
 
@@ -454,7 +454,7 @@ mod tests {
         let n = 1 << k;
         let evals = PolynomialValues::new(F::rand_vec(n));
         let shift = F::rand();
-        let coeffs = evals.coset_ifft(shift);
+        let coeffs = evals.clone().coset_ifft(shift);
 
         let generator = F::primitive_root_of_unity(k);
         let naive_coset_evals = F::cyclic_subgroup_coset_known_order(generator, shift, n)

--- a/plonky2/benches/ffts.rs
+++ b/plonky2/benches/ffts.rs
@@ -11,7 +11,7 @@ pub(crate) fn bench_ffts<F: Field>(c: &mut Criterion) {
         let size = 1 << size_log;
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             let coeffs = PolynomialCoeffs::new(F::rand_vec(size));
-            b.iter(|| coeffs.fft_with_options(None, None));
+            b.iter(|| coeffs.clone().fft_with_options(None, None));
         });
     }
 }

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -47,7 +47,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         let coeffs = timed!(
             timing,
             "IFFT",
-            values.par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
+            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
         );
 
         Self::from_coeffs(

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -80,7 +80,7 @@ fn reverse_index_bits_large<T: Copy>(arr: &[T], n_power: usize) -> Vec<T> {
     result
 }
 
-pub fn reverse_index_bits_in_place<T>(arr: &mut Vec<T>) {
+pub fn reverse_index_bits_in_place<T>(arr: &mut [T]) {
     let n = arr.len();
     let n_power = log2_strict(n);
 
@@ -101,7 +101,7 @@ pub fn reverse_index_bits_in_place<T>(arr: &mut Vec<T>) {
    where reverse_bits(src, n_power) computes the n_power-bit reverse.
 */
 
-fn reverse_index_bits_in_place_small<T>(arr: &mut Vec<T>, n_power: usize) {
+fn reverse_index_bits_in_place_small<T>(arr: &mut [T], n_power: usize) {
     let n = arr.len();
     // BIT_REVERSE_6BIT holds 6-bit reverses. This shift makes them n_power-bit reverses.
     let dst_shr_amt = 6 - n_power;
@@ -113,7 +113,7 @@ fn reverse_index_bits_in_place_small<T>(arr: &mut Vec<T>, n_power: usize) {
     }
 }
 
-fn reverse_index_bits_in_place_large<T>(arr: &mut Vec<T>, n_power: usize) {
+fn reverse_index_bits_in_place_large<T>(arr: &mut [T], n_power: usize) {
     let n = arr.len();
     // LLVM does not know that it does not need to reverse src at each iteration (which is expensive
     // on x86). We take advantage of the fact that the low bits of dst change rarely and the high


### PR DESCRIPTION
Perform FFTs without cloning vectors.

While it is ready for review, this PR should not be merged yet. It turns out that `reverse_index_bits_in_place` is significantly slower than its out-of-place counterpart. This disparity can and should be fixed, but until that happens, merging this PR would actually make proofs slower.