### PR TITLE
Replace `proof_to_proof_target`

### DIFF
--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -26,7 +26,7 @@ pub struct FriQueryStep<F: RichField + Extendable<D>, H: Hasher<F>, const D: usi
     pub merkle_proof: MerkleProof<F, H>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FriQueryStepTarget<const D: usize> {
     pub evals: Vec<ExtensionTarget<D>>,
     pub merkle_proof: MerkleProofTarget,
@@ -51,7 +51,7 @@ impl<F: RichField, H: Hasher<F>> FriInitialTreeProof<F, H> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FriInitialTreeProofTarget {
     pub evals_proofs: Vec<(Vec<Target>, MerkleProofTarget)>,
 }
@@ -80,7 +80,7 @@ pub struct FriQueryRound<F: RichField + Extendable<D>, H: Hasher<F>, const D: us
     pub steps: Vec<FriQueryStep<F, H, D>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FriQueryRoundTarget<const D: usize> {
     pub initial_trees_proof: FriInitialTreeProofTarget,
     pub steps: Vec<FriQueryStepTarget<D>>,
@@ -111,6 +111,7 @@ pub struct FriProof<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> 
     pub pow_witness: F,
 }
 
+#[derive(Debug)]
 pub struct FriProofTarget<const D: usize> {
     pub commit_phase_merkle_caps: Vec<MerkleCapTarget>,
     pub query_round_proofs: Vec<FriQueryRoundTarget<D>>,

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -72,9 +72,8 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
     let mut trees = Vec::new();
 
     let mut shift = F::MULTIPLICATIVE_GROUP_GENERATOR;
-    let num_reductions = fri_params.reduction_arity_bits.len();
-    for i in 0..num_reductions {
-        let arity = 1 << fri_params.reduction_arity_bits[i];
+    for arity_bits in &fri_params.reduction_arity_bits {
+        let arity = 1 << arity_bits;
 
         reverse_index_bits_in_place(&mut values.values);
         let chunked_values = values

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -6,6 +6,7 @@ use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::util::reducing::ReducingFactorTarget;
 
+#[derive(Debug)]
 pub struct PolynomialCoeffsExtTarget<const D: usize>(pub Vec<ExtensionTarget<D>>);
 
 impl<const D: usize> PolynomialCoeffsExtTarget<D> {

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -17,7 +17,7 @@ pub struct MerkleProof<F: RichField, H: Hasher<F>> {
     pub siblings: Vec<H::Hash>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MerkleProofTarget {
     /// The Merkle digest of each sibling subtree, staying from the bottommost layer.
     pub siblings: Vec<HashOutTarget>,

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -234,6 +234,8 @@ pub struct CommonCircuitData<
 
     pub(crate) num_virtual_targets: usize,
 
+    pub(crate) num_public_inputs: usize,
+
     /// The `{k_i}` valued used in `S_ID_i` in Plonk's permutation argument.
     pub(crate) k_is: Vec<F>,
 
@@ -341,11 +343,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 
     fn fri_preprocessed_polys(&self) -> Vec<FriPolynomialInfo> {
-        let num_preprocessed_polys = self.sigmas_range().end;
         FriPolynomialInfo::from_range(
             PlonkOracle::CONSTANTS_SIGMAS.index,
-            0..num_preprocessed_polys,
+            0..self.num_preprocessed_polys(),
         )
+    }
+
+    pub(crate) fn num_preprocessed_polys(&self) -> usize {
+        self.sigmas_range().end
     }
 
     fn fri_wire_polys(&self) -> Vec<FriPolynomialInfo> {
@@ -354,12 +359,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 
     fn fri_zs_partial_products_polys(&self) -> Vec<FriPolynomialInfo> {
-        let num_zs_partial_products_polys =
-            self.config.num_challenges * (1 + self.num_partial_products);
         FriPolynomialInfo::from_range(
             PlonkOracle::ZS_PARTIAL_PRODUCTS.index,
-            0..num_zs_partial_products_polys,
+            0..self.num_zs_partial_products_polys(),
         )
+    }
+
+    pub(crate) fn num_zs_partial_products_polys(&self) -> usize {
+        self.config.num_challenges * (1 + self.num_partial_products)
     }
 
     fn fri_zs_polys(&self) -> Vec<FriPolynomialInfo> {
@@ -367,8 +374,11 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 
     fn fri_quotient_polys(&self) -> Vec<FriPolynomialInfo> {
-        let num_quotient_polys = self.config.num_challenges * self.quotient_degree_factor;
-        FriPolynomialInfo::from_range(PlonkOracle::QUOTIENT.index, 0..num_quotient_polys)
+        FriPolynomialInfo::from_range(PlonkOracle::QUOTIENT.index, 0..self.num_quotient_polys())
+    }
+
+    pub(crate) fn num_quotient_polys(&self) -> usize {
+        self.config.num_challenges * self.quotient_degree_factor
     }
 
     fn fri_all_polys(&self) -> Vec<FriPolynomialInfo> {

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -32,6 +32,7 @@ pub struct Proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
     pub opening_proof: FriProof<F, C::Hasher, D>,
 }
 
+#[derive(Debug)]
 pub struct ProofTarget<const D: usize> {
     pub wires_cap: MerkleCapTarget,
     pub plonk_zs_partial_products_cap: MerkleCapTarget,
@@ -255,6 +256,7 @@ pub(crate) struct FriInferredElements<F: RichField + Extendable<D>, const D: usi
     pub Vec<F::Extension>,
 );
 
+#[derive(Debug)]
 pub struct ProofWithPublicInputsTarget<const D: usize> {
     pub proof: ProofTarget<D>,
     pub public_inputs: Vec<Target>,

--- a/plonky2/src/plonk/verifier.rs
+++ b/plonky2/src/plonk/verifier.rs
@@ -30,6 +30,10 @@ pub(crate) fn verify_with_challenges<
     verifier_data: &VerifierOnlyCircuitData<C, D>,
     common_data: &CommonCircuitData<F, C, D>,
 ) -> Result<()> {
+    assert_eq!(
+        proof_with_pis.public_inputs.len(),
+        common_data.num_public_inputs
+    );
     let public_inputs_hash = &proof_with_pis.get_public_inputs_hash();
 
     let ProofWithPublicInputs { proof, .. } = proof_with_pis;


### PR DESCRIPTION
With a `add_virtual_proof_with_pis` method that uses the inner circuit data, but does not require constructing a proof.

Note that this doesn't support IVC type patterns (where a single circuit can be used for any proof in a PCD graph) yet. For that, I think we can add a variant of `add_virtual_proof_with_pis` that takes several parameters like FRI arities, but does not involve `CommonCircuitData` (since no circuit has been build yet). It might also be best to avoid large objects like `FriParams`, and pass just the data we need.

Then there will be some nontrivial work to do recursion with "estimated" parameters (degree, arities, etc), check if the estimates were correct, and try again if not.