### PR TITLE
Ignore `test_curve_mul` and unignore recursive tests

### DIFF
--- a/plonky2/src/gadgets/curve.rs
+++ b/plonky2/src/gadgets/curve.rs
@@ -296,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_curve_mul() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -215,7 +215,6 @@ mod tests {
     use crate::util::timing::TimingTree;
 
     #[test]
-    #[ignore]
     fn test_recursive_verifier() -> Result<()> {
         init_logger();
         const D: usize = 2;
@@ -232,7 +231,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_recursive_recursive_verifier() -> Result<()> {
         init_logger();
         const D: usize = 2;
@@ -317,7 +315,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_recursive_verifier_multi_hash() -> Result<()> {
         init_logger();
         const D: usize = 2;


### PR DESCRIPTION
`test_curve_mul` takes quite some time in the CI. Recursive tests should be pretty fast now that we run the tests with `opt-level=3`.