### PR TITLE
`trim_to_len` helper function

### DIFF
--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -186,13 +186,13 @@ impl<F: Field> PolynomialCoeffs<F> {
         poly
     }
 
-    /// Removes any zero coefficients from the side associated with the highest exponents.
+    /// Removes any leading zero coefficients.
     pub fn trim(&mut self) {
         self.coeffs.truncate(self.degree_plus_one());
     }
 
-    /// Removes zero coefficients from the side associated with the highest exponents, such that a
-    /// desired length is reached. Fails if a nonzero coefficient is encountered before then.
+    /// Removes some leading zero coefficients, such that a desired length is reached. Fails if a
+    /// nonzero coefficient is encountered before then.
     pub fn trim_to_len(&mut self, len: usize) -> Result<()> {
         ensure!(self.len() >= len);
         ensure!(self.coeffs[len..].iter().all(F::is_zero));
@@ -200,7 +200,7 @@ impl<F: Field> PolynomialCoeffs<F> {
         Ok(())
     }
 
-    /// Removes leading zero coefficients.
+    /// Removes any leading zero coefficients.
     pub fn trimmed(&self) -> Self {
         let coeffs = self.coeffs[..self.degree_plus_one()].to_vec();
         Self { coeffs }

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -186,9 +186,18 @@ impl<F: Field> PolynomialCoeffs<F> {
         poly
     }
 
-    /// Removes leading zero coefficients.
+    /// Removes any zero coefficients from the side associated with the highest exponents.
     pub fn trim(&mut self) {
         self.coeffs.truncate(self.degree_plus_one());
+    }
+
+    /// Removes zero coefficients from the side associated with the highest exponents, such that a
+    /// desired length is reached. Fails if a nonzero coefficient is encountered before then.
+    pub fn trim_to_len(&mut self, len: usize) -> Result<()> {
+        ensure!(self.len() >= len);
+        ensure!(self.coeffs[len..].iter().all(F::is_zero));
+        self.coeffs.truncate(len);
+        Ok(())
     }
 
     /// Removes leading zero coefficients.

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -148,11 +148,10 @@ pub(crate) fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
         quotient_polys
             .into_par_iter()
             .flat_map(|mut quotient_poly| {
-                quotient_poly.trim();
-                quotient_poly.pad(quotient_degree).expect(
-                    "Quotient has failed, the vanishing polynomial is not divisible by `Z_H",
+                quotient_poly.trim_to_len(quotient_degree).expect(
+                    "Quotient has failed, the vanishing polynomial is not divisible by Z_H",
                 );
-                // Split t into degree-n chunks.
+                // Split quotient into degree-n chunks.
                 quotient_poly.chunks(degree)
             })
             .collect()

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -80,10 +80,9 @@ where
     let all_quotient_chunks = quotient_polys
         .into_par_iter()
         .flat_map(|mut quotient_poly| {
-            quotient_poly.trim();
             quotient_poly
-                .pad(degree * stark.quotient_degree_factor())
-                .expect("Quotient has failed, the vanishing polynomial is not divisible by `Z_H");
+                .trim_to_len(degree * stark.quotient_degree_factor())
+                .expect("Quotient has failed, the vanishing polynomial is not divisible by Z_H");
             // Split quotient into degree-n chunks.
             quotient_poly.chunks(degree)
         })


### PR DESCRIPTION
Seems a little nicer IMO to only remove a certain number of zeros, vs removing all trailing zeros then re-adding some.