### PR TITLE
Standardize `set_*` method parameter order

### DIFF
--- a/plonky2/src/fri/witness_util.rs
+++ b/plonky2/src/fri/witness_util.rs
@@ -9,8 +9,8 @@ use crate::plonk::config::AlgebraicHasher;
 /// Set the targets in a `FriProofTarget` to their corresponding values in a `FriProof`.
 pub fn set_fri_proof_target<F, W, H, const D: usize>(
     witness: &mut W,
-    fri_proof: &FriProof<F, H, D>,
     fri_proof_target: &FriProofTarget<D>,
+    fri_proof: &FriProof<F, H, D>,
 ) where
     F: RichField + Extendable<D>,
     W: Witness<F> + ?Sized,

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -162,8 +162,8 @@ pub trait Witness<F: Field> {
     /// `ProofWithPublicInputs`.
     fn set_proof_with_pis_target<C: GenericConfig<D, F = F>, const D: usize>(
         &mut self,
-        proof_with_pis: &ProofWithPublicInputs<F, C, D>,
         proof_with_pis_target: &ProofWithPublicInputsTarget<D>,
+        proof_with_pis: &ProofWithPublicInputs<F, C, D>,
     ) where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
@@ -182,14 +182,14 @@ pub trait Witness<F: Field> {
             self.set_target(pi_t, pi);
         }
 
-        self.set_proof_target(proof, pt);
+        self.set_proof_target(pt, proof);
     }
 
     /// Set the targets in a `ProofTarget` to their corresponding values in a `Proof`.
     fn set_proof_target<C: GenericConfig<D, F = F>, const D: usize>(
         &mut self,
-        proof: &Proof<F, C, D>,
         proof_target: &ProofTarget<D>,
+        proof: &Proof<F, C, D>,
     ) where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
@@ -258,7 +258,7 @@ pub trait Witness<F: Field> {
             self.set_extension_target(t, x);
         }
 
-        set_fri_proof_target(self, &proof.opening_proof, &proof_target.opening_proof);
+        set_fri_proof_target(self, &proof_target.opening_proof, &proof.opening_proof);
     }
 
     fn set_wire(&mut self, wire: Wire, value: F) {

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -382,7 +382,7 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
         let pt = builder.add_virtual_proof_with_pis(&inner_cd);
-        pw.set_proof_with_pis_target(&inner_proof, &pt);
+        pw.set_proof_with_pis_target(&pt, &inner_proof);
 
         let inner_data = VerifierCircuitTarget {
             constants_sigmas_cap: builder.add_virtual_cap(inner_cd.config.fri_config.cap_height),


### PR DESCRIPTION
Most functions used to fill the witness are of the form `set_X_target(xt: XTarget, x: X)`.
`set_proof_target`, `set_proof_with_pis_target`, and `set_fri_proof_target` currently use the opposite parameter order.
This PR fixes that.