### PR TITLE
Added `Debug`, `Clone`, and `Copy` to ecdsa types

### DIFF
--- a/plonky2/src/curve/ecdsa.rs
+++ b/plonky2/src/curve/ecdsa.rs
@@ -2,12 +2,16 @@ use crate::curve::curve_msm::msm_parallel;
 use crate::curve::curve_types::{base_to_scalar, AffinePoint, Curve, CurveScalar};
 use crate::field::field_types::Field;
 
+#[derive(Copy, Clone, Debug)]
 pub struct ECDSASignature<C: Curve> {
     pub r: C::ScalarField,
     pub s: C::ScalarField,
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct ECDSASecretKey<C: Curve>(pub C::ScalarField);
+
+#[derive(Copy, Clone, Debug)]
 pub struct ECDSAPublicKey<C: Curve>(pub AffinePoint<C>);
 
 pub fn sign_message<C: Curve>(msg: C::ScalarField, sk: ECDSASecretKey<C>) -> ECDSASignature<C> {

--- a/plonky2/src/gadgets/ecdsa.rs
+++ b/plonky2/src/gadgets/ecdsa.rs
@@ -7,9 +7,13 @@ use crate::gadgets::nonnative::NonNativeTarget;
 use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_builder::CircuitBuilder;
 
+#[derive(Clone, Debug)]
 pub struct ECDSASecretKeyTarget<C: Curve>(NonNativeTarget<C::ScalarField>);
+
+#[derive(Clone, Debug)]
 pub struct ECDSAPublicKeyTarget<C: Curve>(AffinePointTarget<C>);
 
+#[derive(Clone, Debug)]
 pub struct ECDSASignatureTarget<C: Curve> {
     pub r: NonNativeTarget<C::ScalarField>,
     pub s: NonNativeTarget<C::ScalarField>,


### PR DESCRIPTION
Derives a few traits for the ecdsa types. `Debug` was the one that was causing a few problems in the client, but I thought we might as well also derive the traits that are derived on the underlying types.