### PR TITLE
`from_partial` now takes in a slice

### DIFF
--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -31,14 +31,12 @@ impl<F: Field> HashOut<F> {
         }
     }
 
-    pub fn from_partial(mut elements: Vec<F>) -> Self {
-        debug_assert!(elements.len() <= 4);
-        while elements.len() < 4 {
-            elements.push(F::ZERO);
-        }
-        Self {
-            elements: [elements[0], elements[1], elements[2], elements[3]],
-        }
+    pub fn from_partial(elements_in: &[F]) -> Self {
+        debug_assert!(elements_in.len() <= 4);
+
+        let mut elements = [F::ZERO; 4];
+        elements[0..elements_in.len()].copy_from_slice(elements_in);
+        Self { elements }
     }
 
     pub fn rand_from_rng<R: Rng>(rng: &mut R) -> Self {

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -32,8 +32,6 @@ impl<F: Field> HashOut<F> {
     }
 
     pub fn from_partial(elements_in: &[F]) -> Self {
-        debug_assert!(elements_in.len() <= 4);
-
         let mut elements = [F::ZERO; 4];
         elements[0..elements_in.len()].copy_from_slice(elements_in);
         Self { elements }
@@ -102,14 +100,10 @@ impl HashOutTarget {
         }
     }
 
-    pub fn from_partial(mut elements: Vec<Target>, zero: Target) -> Self {
-        debug_assert!(elements.len() <= 4);
-        while elements.len() < 4 {
-            elements.push(zero);
-        }
-        Self {
-            elements: [elements[0], elements[1], elements[2], elements[3]],
-        }
+    pub fn from_partial(elements_in: &[Target], zero: Target) -> Self {
+        let mut elements = [zero; 4];
+        elements[0..elements_in.len()].copy_from_slice(elements_in);
+        Self { elements }
     }
 }
 

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -14,11 +14,11 @@ pub const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 
 /// Hash the vector if necessary to reduce its length to ~256 bits. If it already fits, this is a
 /// no-op.
-pub fn hash_or_noop<F: RichField, P: PlonkyPermutation<F>>(inputs: Vec<F>) -> HashOut<F> {
+pub fn hash_or_noop<F: RichField, P: PlonkyPermutation<F>>(inputs: &[F]) -> HashOut<F> {
     if inputs.len() <= 4 {
         HashOut::from_partial(inputs)
     } else {
-        hash_n_to_hash_no_pad::<F, P>(&inputs)
+        hash_n_to_hash_no_pad::<F, P>(inputs)
     }
 }
 

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -12,7 +12,7 @@ pub(crate) const SPONGE_RATE: usize = 8;
 pub(crate) const SPONGE_CAPACITY: usize = 4;
 pub const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 
-/// Hash the vector if necessary to reduce its length to ~256 bits. If it already fits, this is a
+/// Hash the slice if necessary to reduce its length to ~256 bits. If it already fits, this is a
 /// no-op.
 pub fn hash_or_noop<F: RichField, P: PlonkyPermutation<F>>(inputs: &[F]) -> HashOut<F> {
     if inputs.len() <= 4 {
@@ -26,7 +26,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn hash_or_noop<H: AlgebraicHasher<F>>(&mut self, inputs: Vec<Target>) -> HashOutTarget {
         let zero = self.zero();
         if inputs.len() <= 4 {
-            HashOutTarget::from_partial(inputs, zero)
+            HashOutTarget::from_partial(&inputs, zero)
         } else {
             self.hash_n_to_hash_no_pad::<H>(inputs)
         }


### PR DESCRIPTION
This was causing a few calls in the client to allocate a `Vec` when we didn't need to.