### PR TITLE
Prover code for permutation argument

### DIFF
--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -5,6 +5,7 @@ use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 use anyhow::{ensure, Result};
+use itertools::Itertools;
 use plonky2_util::log2_strict;
 use serde::{Deserialize, Serialize};
 
@@ -26,8 +27,12 @@ impl<F: Field> PolynomialValues<F> {
         PolynomialValues { values }
     }
 
+    pub fn constant(value: F, len: usize) -> Self {
+        Self::new(vec![value; len])
+    }
+
     pub fn zero(len: usize) -> Self {
-        Self::new(vec![F::ZERO; len])
+        Self::constant(F::ZERO, len)
     }
 
     /// Returns the polynomial whole value is one at the given index, and zero elsewhere.
@@ -82,6 +87,14 @@ impl<F: Field> PolynomialValues<F> {
 
     pub fn degree_plus_one(&self) -> usize {
         self.clone().ifft().degree_plus_one()
+    }
+
+    /// Adds `rhs * rhs_weight` to `self`. Assumes `self.len() == rhs.len()`.
+    pub fn add_assign_scaled(&mut self, rhs: &Self, rhs_weight: F) {
+        self.values
+            .iter_mut()
+            .zip_eq(&rhs.values)
+            .for_each(|(self_v, rhs_v)| *self_v += *rhs_v * rhs_weight)
     }
 }
 

--- a/starky/src/get_challenges.rs
+++ b/starky/src/get_challenges.rs
@@ -8,7 +8,7 @@ use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
 
 use crate::config::StarkConfig;
 use crate::proof::{
@@ -16,9 +16,12 @@ use crate::proof::{
     StarkProofChallengesTarget, StarkProofTarget, StarkProofWithPublicInputs,
     StarkProofWithPublicInputsTarget,
 };
+use crate::stark::{PermutationChallenge, PermutationChallengeSet, Stark};
 
-fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+fn get_challenges<F, C, S, const D: usize>(
+    stark: &S,
     trace_cap: &MerkleCap<F, C::Hasher>,
+    permutation_zs_cap: Option<&MerkleCap<F, C::Hasher>>,
     quotient_polys_cap: &MerkleCap<F, C::Hasher>,
     openings: &StarkOpeningSet<F, D>,
     commit_phase_merkle_caps: &[MerkleCap<F, C::Hasher>],
@@ -26,12 +29,33 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
     pow_witness: F,
     config: &StarkConfig,
     degree_bits: usize,
-) -> Result<StarkProofChallenges<F, D>> {
+) -> Result<StarkProofChallenges<F, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
     let num_challenges = config.num_challenges;
 
     let mut challenger = Challenger::<F, C::Hasher>::new();
 
     challenger.observe_cap(trace_cap);
+
+    let permutation_challenge_sets = if stark.uses_permutation_args() {
+        get_n_permutation_challenge_sets(
+            &mut challenger,
+            num_challenges,
+            stark.permutation_batch_size(),
+        )
+    } else {
+        vec![]
+    };
+    if stark.uses_permutation_args() {
+        let cap =
+            permutation_zs_cap.ok_or_else(|| anyhow::Error::msg("expected permutation_zs_cap"));
+        challenger.observe_cap(cap?);
+    }
+
     let stark_alphas = challenger.get_n_challenges(num_challenges);
 
     challenger.observe_cap(quotient_polys_cap);
@@ -40,6 +64,7 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
     challenger.observe_openings(&openings.to_fri_openings());
 
     Ok(StarkProofChallenges {
+        permutation_challenge_sets,
         stark_alphas,
         stark_zeta,
         fri_challenges: challenger.fri_challenges::<C, D>(
@@ -52,28 +77,33 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
     })
 }
 
-impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
-    StarkProofWithPublicInputs<F, C, D>
+impl<F, C, const D: usize> StarkProofWithPublicInputs<F, C, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
 {
-    pub(crate) fn fri_query_indices(
+    pub(crate) fn fri_query_indices<S: Stark<F, D>>(
         &self,
+        stark: &S,
         config: &StarkConfig,
         degree_bits: usize,
     ) -> anyhow::Result<Vec<usize>> {
         Ok(self
-            .get_challenges(config, degree_bits)?
+            .get_challenges(stark, config, degree_bits)?
             .fri_challenges
             .fri_query_indices)
     }
 
     /// Computes all Fiat-Shamir challenges used in the STARK proof.
-    pub(crate) fn get_challenges(
+    pub(crate) fn get_challenges<S: Stark<F, D>>(
         &self,
+        stark: &S,
         config: &StarkConfig,
         degree_bits: usize,
     ) -> Result<StarkProofChallenges<F, D>> {
         let StarkProof {
             trace_cap,
+            permutation_zs_cap,
             quotient_polys_cap,
             openings,
             opening_proof:
@@ -85,8 +115,10 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 },
         } = &self.proof;
 
-        get_challenges::<F, C, D>(
+        get_challenges::<F, C, S, D>(
+            stark,
             trace_cap,
+            permutation_zs_cap.as_ref(),
             quotient_polys_cap,
             openings,
             commit_phase_merkle_caps,
@@ -283,3 +315,31 @@ impl<const D: usize> StarkProofWithPublicInputsTarget<D> {
 //         FriInferredElements(fri_inferred_elements)
 //     }
 // }
+
+fn get_permutation_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+) -> PermutationChallenge<F> {
+    let beta = challenger.get_challenge();
+    let gamma = challenger.get_challenge();
+    PermutationChallenge { beta, gamma }
+}
+
+fn get_permutation_challenge_set<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+    num_challenges: usize,
+) -> PermutationChallengeSet<F> {
+    let challenges = (0..num_challenges)
+        .map(|_| get_permutation_challenge(challenger))
+        .collect();
+    PermutationChallengeSet { challenges }
+}
+
+pub(crate) fn get_n_permutation_challenge_sets<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+    num_challenges: usize,
+    num_sets: usize,
+) -> Vec<PermutationChallengeSet<F>> {
+    (0..num_sets)
+        .map(|_| get_permutation_challenge_set(challenger, num_challenges))
+        .collect()
+}

--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod config;
 pub mod constraint_consumer;
 mod get_challenges;
+pub mod permutation;
 pub mod proof;
 pub mod prover;
 pub mod recursive_verifier;

--- a/starky/src/permutation.rs
+++ b/starky/src/permutation.rs
@@ -1,0 +1,149 @@
+//! Permutation arguments.
+
+use itertools::Itertools;
+use plonky2::field::batch_util::batch_multiply_inplace;
+use plonky2::field::extension_field::Extendable;
+use plonky2::field::field_types::Field;
+use plonky2::field::polynomial::PolynomialValues;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::challenger::Challenger;
+use plonky2::plonk::config::{GenericConfig, Hasher};
+use rayon::prelude::*;
+
+use crate::config::StarkConfig;
+use crate::stark::Stark;
+
+/// A pair of lists of columns, `lhs` and `rhs`, that should be permutations of one another.
+/// In particular, there should exist some permutation `pi` such that for any `i`,
+/// `trace[lhs[i]] = pi(trace[rhs[i]])`. Here `trace` denotes the trace in column-major form, so
+/// `trace[col]` is a column vector.
+pub struct PermutationPair {
+    /// Each entry contains two column indices, representing two columns which should be
+    /// permutations of one another.
+    pub column_pairs: Vec<(usize, usize)>,
+}
+
+/// A single instance of a permutation check protocol.
+pub(crate) struct PermutationInstance<'a, F: Field> {
+    pub(crate) pair: &'a PermutationPair,
+    pub(crate) challenge: PermutationChallenge<F>,
+}
+
+/// Randomness for a single instance of a permutation check protocol.
+#[derive(Copy, Clone)]
+pub(crate) struct PermutationChallenge<F: Field> {
+    /// Randomness used to combine multiple columns into one.
+    pub(crate) beta: F,
+    /// Random offset that's added to the beta-reduced column values.
+    pub(crate) gamma: F,
+}
+
+/// Like `PermutationChallenge`, but with `num_challenges` copies to boost soundness.
+pub(crate) struct PermutationChallengeSet<F: Field> {
+    pub(crate) challenges: Vec<PermutationChallenge<F>>,
+}
+
+/// Compute all Z polynomials (for permutation arguments).
+pub(crate) fn compute_permutation_z_polys<F, C, S, const D: usize>(
+    stark: &S,
+    config: &StarkConfig,
+    challenger: &mut Challenger<F, C::Hasher>,
+    trace_poly_values: &[PolynomialValues<F>],
+) -> Vec<PolynomialValues<F>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
+    let permutation_pairs = stark.permutation_pairs();
+    let permutation_challenge_sets = get_n_permutation_challenge_sets(
+        challenger,
+        config.num_challenges,
+        stark.permutation_batch_size(),
+    );
+
+    // Get a list of instances of our batch-permutation argument. These are permutation arguments
+    // where the same `Z(x)` polynomial is used to check more than one permutation.
+    // Before batching, each permutation pair leads to `num_challenges` permutation arguments, so we
+    // start with the cartesian product of `permutation_pairs` and `0..num_challenges`. Then we
+    // chunk these arguments based on our batch size.
+    let permutation_instances = permutation_pairs
+        .iter()
+        .cartesian_product(0..config.num_challenges)
+        .chunks(stark.permutation_batch_size())
+        .into_iter()
+        .flat_map(|batch| {
+            batch.enumerate().map(|(i, (pair, chal))| {
+                let challenge = permutation_challenge_sets[i].challenges[chal];
+                PermutationInstance { pair, challenge }
+            })
+        })
+        .collect_vec();
+
+    permutation_instances
+        .into_par_iter()
+        .map(|instance| compute_permutation_z_poly(instance, trace_poly_values))
+        .collect()
+}
+
+/// Compute a single Z polynomial.
+// TODO: Change this to handle a batch of `PermutationInstance`s.
+fn compute_permutation_z_poly<F: Field>(
+    instance: PermutationInstance<F>,
+    trace_poly_values: &[PolynomialValues<F>],
+) -> PolynomialValues<F> {
+    let PermutationInstance { pair, challenge } = instance;
+    let PermutationPair { column_pairs } = pair;
+    let PermutationChallenge { beta, gamma } = challenge;
+
+    let degree = trace_poly_values[0].len();
+    let mut reduced_lhs = PolynomialValues::constant(gamma, degree);
+    let mut reduced_rhs = PolynomialValues::constant(gamma, degree);
+
+    for ((lhs, rhs), weight) in column_pairs.iter().zip(beta.powers()) {
+        reduced_lhs.add_assign_scaled(&trace_poly_values[*lhs], weight);
+        reduced_rhs.add_assign_scaled(&trace_poly_values[*rhs], weight);
+    }
+
+    // Compute the quotients.
+    let reduced_rhs_inverses = F::batch_multiplicative_inverse(&reduced_rhs.values);
+    let mut quotients = reduced_lhs.values;
+    batch_multiply_inplace(&mut quotients, &reduced_rhs_inverses);
+
+    // Compute Z, which contains partial products of the quotients.
+    let mut partial_products = Vec::with_capacity(degree);
+    let mut acc = F::ONE;
+    for q in quotients {
+        partial_products.push(acc);
+        acc *= q;
+    }
+    PolynomialValues::new(partial_products)
+}
+
+fn get_permutation_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+) -> PermutationChallenge<F> {
+    let beta = challenger.get_challenge();
+    let gamma = challenger.get_challenge();
+    PermutationChallenge { beta, gamma }
+}
+
+fn get_permutation_challenge_set<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+    num_challenges: usize,
+) -> PermutationChallengeSet<F> {
+    let challenges = (0..num_challenges)
+        .map(|_| get_permutation_challenge(challenger))
+        .collect();
+    PermutationChallengeSet { challenges }
+}
+
+pub(crate) fn get_n_permutation_challenge_sets<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
+    num_challenges: usize,
+    num_sets: usize,
+) -> Vec<PermutationChallengeSet<F>> {
+    (0..num_sets)
+        .map(|_| get_permutation_challenge_set(challenger, num_challenges))
+        .collect()
+}

--- a/starky/src/proof.rs
+++ b/starky/src/proof.rs
@@ -14,11 +14,14 @@ use plonky2::plonk::config::GenericConfig;
 use rayon::prelude::*;
 
 use crate::config::StarkConfig;
+use crate::stark::PermutationChallengeSet;
 
 #[derive(Debug, Clone)]
 pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     /// Merkle cap of LDEs of trace values.
     pub trace_cap: MerkleCap<F, C::Hasher>,
+    /// Merkle cap of LDEs of permutation Z values.
+    pub permutation_zs_cap: Option<MerkleCap<F, C::Hasher>>,
     /// Merkle cap of LDEs of trace values.
     pub quotient_polys_cap: MerkleCap<F, C::Hasher>,
     /// Purported values of each polynomial at the challenge point.
@@ -95,6 +98,9 @@ pub struct CompressedStarkProofWithPublicInputs<
 }
 
 pub(crate) struct StarkProofChallenges<F: RichField + Extendable<D>, const D: usize> {
+    /// Randomness used in any permutation arguments.
+    pub permutation_challenge_sets: Vec<PermutationChallengeSet<F>>,
+
     /// Random values used to combine STARK constraints.
     pub stark_alphas: Vec<F>,
 

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -2,7 +2,6 @@ use std::iter::once;
 
 use anyhow::{ensure, Result};
 use itertools::Itertools;
-use plonky2::field::batch_util::batch_multiply_inplace;
 use plonky2::field::extension_field::Extendable;
 use plonky2::field::field_types::Field;
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
@@ -19,9 +18,9 @@ use rayon::prelude::*;
 
 use crate::config::StarkConfig;
 use crate::constraint_consumer::ConstraintConsumer;
-use crate::get_challenges::get_n_permutation_challenge_sets;
+use crate::permutation::compute_permutation_z_polys;
 use crate::proof::{StarkOpeningSet, StarkProof, StarkProofWithPublicInputs};
-use crate::stark::{PermutationChallenge, PermutationInstance, PermutationPair, Stark};
+use crate::stark::Stark;
 use crate::vars::StarkEvaluationVars;
 
 pub fn prove<F, C, S, const D: usize>(
@@ -61,7 +60,7 @@ where
         "compute trace commitment",
         PolynomialBatch::<F, C, D>::from_values(
             // TODO: Cloning this isn't great; consider having `from_values` accept a reference,
-            // or having `compute_z_poly` read trace values from the `PolynomialBatch`.
+            // or having `compute_permutation_z_polys` read trace values from the `PolynomialBatch`.
             trace_poly_values.clone(),
             rate_bits,
             false,
@@ -76,14 +75,18 @@ where
     challenger.observe_cap(&trace_cap);
 
     // Permutation arguments.
-    let z_commitment = if stark.uses_permutation_args() {
-        let z_polys =
-            compute_z_polys::<F, C, S, D>(&stark, config, &mut challenger, &trace_poly_values);
+    let permutation_zs_commitment = if stark.uses_permutation_args() {
+        let permutation_z_polys = compute_permutation_z_polys::<F, C, S, D>(
+            &stark,
+            config,
+            &mut challenger,
+            &trace_poly_values,
+        );
         timed!(
             timing,
             "compute permutation Z commitments",
             Some(PolynomialBatch::from_values(
-                z_polys,
+                permutation_z_polys,
                 rate_bits,
                 false,
                 config.fri_config.cap_height,
@@ -94,7 +97,7 @@ where
     } else {
         None
     };
-    let permutation_zs_cap = z_commitment
+    let permutation_zs_cap = permutation_zs_commitment
         .as_ref()
         .map(|commit| commit.merkle_tree.cap.clone());
     for cap in &permutation_zs_cap {
@@ -144,11 +147,17 @@ where
         zeta.exp_power_of_2(degree_bits) != F::Extension::ONE,
         "Opening point is in the subgroup."
     );
-    let openings = StarkOpeningSet::new(zeta, g, &trace_commitment, &quotient_commitment);
+    let openings = StarkOpeningSet::new(
+        zeta,
+        g,
+        &trace_commitment,
+        permutation_zs_commitment.as_ref(),
+        &quotient_commitment,
+    );
     challenger.observe_openings(&openings.to_fri_openings());
 
     let initial_merkle_trees = once(&trace_commitment)
-        .chain(z_commitment.as_ref())
+        .chain(permutation_zs_commitment.as_ref())
         .chain(once(&quotient_commitment))
         .collect_vec();
     let fri_params = config.fri_params(degree_bits);
@@ -176,81 +185,6 @@ where
         proof,
         public_inputs: public_inputs.to_vec(),
     })
-}
-
-/// Compute all Z polynomials (for permutation arguments).
-fn compute_z_polys<F, C, S, const D: usize>(
-    stark: &S,
-    config: &StarkConfig,
-    challenger: &mut Challenger<F, C::Hasher>,
-    trace_poly_values: &[PolynomialValues<F>],
-) -> Vec<PolynomialValues<F>>
-where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    S: Stark<F, D>,
-{
-    let permutation_pairs = stark.permutation_pairs();
-    let permutation_challenge_sets = get_n_permutation_challenge_sets(
-        challenger,
-        config.num_challenges,
-        stark.permutation_batch_size(),
-    );
-
-    let permutation_instances = permutation_pairs
-        .iter()
-        .cartesian_product(0..config.num_challenges)
-        .chunks(stark.permutation_batch_size())
-        .into_iter()
-        .flat_map(|batch| {
-            batch.enumerate().map(|(i, (pair, chal))| {
-                let challenge = permutation_challenge_sets[i].challenges[chal];
-                PermutationInstance { pair, challenge }
-            })
-        })
-        .collect_vec();
-
-    permutation_instances
-        .into_par_iter()
-        .map(|instance| compute_z_poly(instance, trace_poly_values))
-        .collect()
-}
-
-/// Compute a single Z polynomial.
-fn compute_z_poly<F: Field>(
-    instance: PermutationInstance<F>,
-    trace_poly_values: &[PolynomialValues<F>],
-) -> PolynomialValues<F> {
-    let PermutationInstance { pair, challenge } = instance;
-    let PermutationPair {
-        lhs_columns,
-        rhs_columns,
-    } = pair;
-    let PermutationChallenge { beta, gamma } = challenge;
-
-    let degree = trace_poly_values[0].len();
-    let mut reduced_lhs = PolynomialValues::constant(gamma, degree);
-    let mut reduced_rhs = PolynomialValues::constant(gamma, degree);
-
-    let both_cols = lhs_columns.iter().zip_eq(rhs_columns);
-    for ((lhs, rhs), weight) in both_cols.zip(beta.powers()) {
-        reduced_lhs.add_assign_scaled(&trace_poly_values[*lhs], weight);
-        reduced_rhs.add_assign_scaled(&trace_poly_values[*rhs], weight);
-    }
-
-    // Compute the quotients.
-    let reduced_rhs_inverses = F::batch_multiplicative_inverse(&reduced_rhs.values);
-    let mut quotients = reduced_lhs.values;
-    batch_multiply_inplace(&mut quotients, &reduced_rhs_inverses);
-
-    // Compute Z, which contains partial products of the quotients.
-    let mut partial_products = Vec::with_capacity(degree);
-    let mut acc = F::ONE;
-    for q in quotients {
-        partial_products.push(acc);
-        acc *= q;
-    }
-    PolynomialValues::new(partial_products)
 }
 
 /// Computes the quotient polynomials `(sum alpha^i C_i(x)) / Z_H(x)` for `alpha` in `alphas`,
@@ -318,6 +252,7 @@ where
                 public_inputs: &public_inputs,
             };
             stark.eval_packed_base(vars, &mut consumer);
+            // TODO: Add in constraints for permutation arguments.
             // TODO: Fix this once we use a genuine `PackedField`.
             let mut constraints_evals = consumer.accumulators();
             // We divide the constraints evaluations by `Z_H(x)`.

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -124,7 +124,7 @@ fn recursively_verify_stark_proof_with_challenges<
         builder,
         challenges.stark_zeta,
         F::primitive_root_of_unity(degree_bits),
-        inner_config.num_challenges,
+        inner_config,
     );
     builder.verify_fri_proof::<C>(
         &fri_instance,

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -1,3 +1,5 @@
+use std::iter::once;
+
 use itertools::Itertools;
 use plonky2::field::extension_field::Extendable;
 use plonky2::field::field_types::Field;
@@ -103,6 +105,7 @@ fn recursively_verify_stark_proof_with_challenges<
         l_last,
     );
     stark.eval_ext_recursively(builder, vars, &mut consumer);
+    // TODO: Add in constraints for permutation arguments.
     let vanishing_polys_zeta = consumer.accumulators();
 
     // Check each polynomial identity, of the form `vanishing(x) = Z_H(x) quotient(x)`, at zeta.
@@ -117,8 +120,10 @@ fn recursively_verify_stark_proof_with_challenges<
         builder.connect_extension(vanishing_polys_zeta[i], computed_vanishing_poly);
     }
 
-    // TODO: Permutation polynomials.
-    let merkle_caps = &[proof.trace_cap, proof.quotient_polys_cap];
+    let merkle_caps = once(proof.trace_cap)
+        .chain(proof.permutation_zs_cap)
+        .chain(once(proof.quotient_polys_cap))
+        .collect_vec();
 
     let fri_instance = stark.fri_instance_target(
         builder,
@@ -130,7 +135,7 @@ fn recursively_verify_stark_proof_with_challenges<
         &fri_instance,
         &proof.openings.to_fri_openings(),
         &challenges.fri_challenges,
-        merkle_caps,
+        &merkle_caps,
         &proof.opening_proof,
         &inner_config.fri_params(degree_bits),
     );
@@ -188,8 +193,15 @@ pub fn add_virtual_stark_proof<F: RichField + Extendable<D>, S: Stark<F, D>, con
         stark.quotient_degree_factor() * config.num_challenges,
     ];
 
+    let permutation_zs_cap = if stark.uses_permutation_args() {
+        Some(builder.add_virtual_cap(cap_height))
+    } else {
+        None
+    };
+
     StarkProofTarget {
         trace_cap: builder.add_virtual_cap(cap_height),
+        permutation_zs_cap,
         quotient_polys_cap: builder.add_virtual_cap(cap_height),
         openings: add_stark_opening_set::<F, S, D>(builder, stark, config),
         opening_proof: builder.add_virtual_fri_proof(num_leaves_per_oracle, &fri_params),

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -1,5 +1,4 @@
 use plonky2::field::extension_field::{Extendable, FieldExtension};
-use plonky2::field::field_types::Field;
 use plonky2::field::packed_field::PackedField;
 use plonky2::fri::structure::{
     FriBatchInfo, FriBatchInfoTarget, FriInstanceInfo, FriInstanceInfoTarget, FriOracleInfo,
@@ -12,6 +11,7 @@ use plonky2_util::ceil_div_usize;
 
 use crate::config::StarkConfig;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
+use crate::permutation::PermutationPair;
 use crate::vars::StarkEvaluationTargets;
 use crate::vars::StarkEvaluationVars;
 
@@ -78,7 +78,6 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
     }
 
     /// Computes the FRI instance used to prove this Stark.
-    // TODO: Permutation polynomials.
     fn fri_instance(
         &self,
         zeta: F::Extension,
@@ -201,33 +200,4 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
             self.permutation_batch_size(),
         )
     }
-}
-
-/// A pair of lists of columns, `lhs` and `rhs`, that should be permutations of one another.
-/// In particular, there should exist some permutation `pi` such that for any `i`,
-/// `trace[lhs[i]] = pi(trace[rhs[i]])`. Here `trace` denotes the trace in column-major form, so
-/// `trace[col]` is a column vector.
-pub struct PermutationPair {
-    pub lhs_columns: Vec<usize>,
-    pub rhs_columns: Vec<usize>,
-}
-
-/// A single instance of a permutation check protocol.
-pub(crate) struct PermutationInstance<'a, F: Field> {
-    pub(crate) pair: &'a PermutationPair,
-    pub(crate) challenge: PermutationChallenge<F>,
-}
-
-/// Randomness for a single instance of a permutation check protocol.
-#[derive(Copy, Clone)]
-pub(crate) struct PermutationChallenge<F: Field> {
-    /// Randomness used to combine multiple columns into one.
-    pub(crate) beta: F,
-    /// Random offset that's added to the beta-reduced column values.
-    pub(crate) gamma: F,
-}
-
-/// Like `PermutationChallenge`, but with `num_challenges` copies to boost soundness.
-pub(crate) struct PermutationChallengeSet<F: Field> {
-    pub(crate) challenges: Vec<PermutationChallenge<F>>,
 }

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -1,4 +1,5 @@
 use plonky2::field::extension_field::{Extendable, FieldExtension};
+use plonky2::field::field_types::Field;
 use plonky2::field::packed_field::PackedField;
 use plonky2::fri::structure::{
     FriBatchInfo, FriBatchInfoTarget, FriInstanceInfo, FriInstanceInfoTarget, FriOracleInfo,
@@ -7,7 +8,9 @@ use plonky2::fri::structure::{
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2_util::ceil_div_usize;
 
+use crate::config::StarkConfig;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use crate::vars::StarkEvaluationTargets;
 use crate::vars::StarkEvaluationVars;
@@ -80,51 +83,151 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
         &self,
         zeta: F::Extension,
         g: F,
-        num_challenges: usize,
+        config: &StarkConfig,
     ) -> FriInstanceInfo<F, D> {
         let no_blinding_oracle = FriOracleInfo { blinding: false };
-        let trace_info = FriPolynomialInfo::from_range(0, 0..Self::COLUMNS);
-        let quotient_info =
-            FriPolynomialInfo::from_range(1, 0..self.quotient_degree_factor() * num_challenges);
+        let mut oracle_indices = 0..;
+
+        let trace_info =
+            FriPolynomialInfo::from_range(oracle_indices.next().unwrap(), 0..Self::COLUMNS);
+
+        let permutation_zs_info = if self.uses_permutation_args() {
+            FriPolynomialInfo::from_range(
+                oracle_indices.next().unwrap(),
+                0..self.num_permutation_batches(config),
+            )
+        } else {
+            vec![]
+        };
+
+        let quotient_info = FriPolynomialInfo::from_range(
+            oracle_indices.next().unwrap(),
+            0..self.quotient_degree_factor() * config.num_challenges,
+        );
+
         let zeta_batch = FriBatchInfo {
             point: zeta,
-            polynomials: [trace_info.clone(), quotient_info].concat(),
+            polynomials: [
+                trace_info.clone(),
+                permutation_zs_info.clone(),
+                quotient_info,
+            ]
+            .concat(),
         };
-        let zeta_right_batch = FriBatchInfo::<F, D> {
+        let zeta_right_batch = FriBatchInfo {
             point: zeta.scalar_mul(g),
-            polynomials: trace_info,
+            polynomials: [trace_info, permutation_zs_info].concat(),
         };
         FriInstanceInfo {
-            oracles: vec![no_blinding_oracle; 3],
+            oracles: vec![no_blinding_oracle; oracle_indices.next().unwrap()],
             batches: vec![zeta_batch, zeta_right_batch],
         }
     }
 
     /// Computes the FRI instance used to prove this Stark.
-    // TODO: Permutation polynomials.
     fn fri_instance_target(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         zeta: ExtensionTarget<D>,
         g: F,
-        num_challenges: usize,
+        config: &StarkConfig,
     ) -> FriInstanceInfoTarget<D> {
         let no_blinding_oracle = FriOracleInfo { blinding: false };
-        let trace_info = FriPolynomialInfo::from_range(0, 0..Self::COLUMNS);
-        let quotient_info =
-            FriPolynomialInfo::from_range(1, 0..self.quotient_degree_factor() * num_challenges);
+        let mut oracle_indices = 0..;
+
+        let trace_info =
+            FriPolynomialInfo::from_range(oracle_indices.next().unwrap(), 0..Self::COLUMNS);
+
+        let permutation_zs_info = if self.uses_permutation_args() {
+            FriPolynomialInfo::from_range(
+                oracle_indices.next().unwrap(),
+                0..self.num_permutation_batches(config),
+            )
+        } else {
+            vec![]
+        };
+
+        let quotient_info = FriPolynomialInfo::from_range(
+            oracle_indices.next().unwrap(),
+            0..self.quotient_degree_factor() * config.num_challenges,
+        );
+
         let zeta_batch = FriBatchInfoTarget {
             point: zeta,
-            polynomials: [trace_info.clone(), quotient_info].concat(),
+            polynomials: [
+                trace_info.clone(),
+                permutation_zs_info.clone(),
+                quotient_info,
+            ]
+            .concat(),
         };
         let zeta_right = builder.mul_const_extension(g, zeta);
         let zeta_right_batch = FriBatchInfoTarget {
             point: zeta_right,
-            polynomials: trace_info,
+            polynomials: [trace_info, permutation_zs_info].concat(),
         };
         FriInstanceInfoTarget {
-            oracles: vec![no_blinding_oracle; 3],
+            oracles: vec![no_blinding_oracle; oracle_indices.next().unwrap()],
             batches: vec![zeta_batch, zeta_right_batch],
         }
     }
+
+    /// Pairs of lists of columns that should be permutations of one another. A permutation argument
+    /// will be used for each such pair. Empty by default.
+    fn permutation_pairs(&self) -> Vec<PermutationPair> {
+        vec![]
+    }
+
+    fn uses_permutation_args(&self) -> bool {
+        !self.permutation_pairs().is_empty()
+    }
+
+    /// The number of permutation argument instances that can be combined into a single constraint.
+    fn permutation_batch_size(&self) -> usize {
+        // The permutation argument constraints look like
+        //     Z(x) \prod(...) = Z(g x) \prod(...)
+        // where each product has a number of terms equal to the batch size. So our batch size
+        // should be one less than our constraint degree, which happens to be our quotient degree.
+        self.quotient_degree_factor()
+    }
+
+    fn num_permutation_instances(&self, config: &StarkConfig) -> usize {
+        self.permutation_pairs().len() * config.num_challenges
+    }
+
+    fn num_permutation_batches(&self, config: &StarkConfig) -> usize {
+        ceil_div_usize(
+            self.num_permutation_instances(config),
+            self.permutation_batch_size(),
+        )
+    }
+}
+
+/// A pair of lists of columns, `lhs` and `rhs`, that should be permutations of one another.
+/// In particular, there should exist some permutation `pi` such that for any `i`,
+/// `trace[lhs[i]] = pi(trace[rhs[i]])`. Here `trace` denotes the trace in column-major form, so
+/// `trace[col]` is a column vector.
+pub struct PermutationPair {
+    pub lhs_columns: Vec<usize>,
+    pub rhs_columns: Vec<usize>,
+}
+
+/// A single instance of a permutation check protocol.
+pub(crate) struct PermutationInstance<'a, F: Field> {
+    pub(crate) pair: &'a PermutationPair,
+    pub(crate) challenge: PermutationChallenge<F>,
+}
+
+/// Randomness for a single instance of a permutation check protocol.
+#[derive(Copy, Clone)]
+pub(crate) struct PermutationChallenge<F: Field> {
+    /// Randomness used to combine multiple columns into one.
+    pub(crate) beta: F,
+    /// Random offset that's added to the beta-reduced column values.
+    pub(crate) gamma: F,
+}
+
+/// Like `PermutationChallenge`, but with `num_challenges` copies to boost soundness.
+pub(crate) struct PermutationChallengeSet<F: Field> {
+    pub(crate) challenges: Vec<PermutationChallenge<F>>,
 }

--- a/starky/src/verifier.rs
+++ b/starky/src/verifier.rs
@@ -89,6 +89,7 @@ where
         l_last,
     );
     stark.eval_ext(vars, &mut consumer);
+    // TODO: Add in constraints for permutation arguments.
     let vanishing_polys_zeta = consumer.accumulators();
 
     // Check each polynomial identity, of the form `vanishing(x) = Z_H(x) quotient(x)`, at zeta.

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -5,7 +5,7 @@ use plonky2::field::packed_field::PackedField;
 use plonky2::hash::hash_types::RichField;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
-use starky::stark::Stark;
+use starky::stark::{PermutationPair, Stark};
 use starky::vars::StarkEvaluationTargets;
 use starky::vars::StarkEvaluationVars;
 
@@ -102,6 +102,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for SystemZero<F,
 
     fn constraint_degree(&self) -> usize {
         3
+    }
+
+    fn permutation_pairs(&self) -> Vec<PermutationPair> {
+        // TODO: Add permutation pairs for memory.
+        // TODO: Add permutation pairs for range checks.
+        vec![]
     }
 }
 

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -5,7 +5,8 @@ use plonky2::field::packed_field::PackedField;
 use plonky2::hash::hash_types::RichField;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
-use starky::stark::{PermutationPair, Stark};
+use starky::permutation::PermutationPair;
+use starky::stark::Stark;
 use starky::vars::StarkEvaluationTargets;
 use starky::vars::StarkEvaluationVars;
 


### PR DESCRIPTION
It's slightly complex because we batch `constraint_degree - 1` permutation arguments into a single `Z` polynomial. This is a slight generalization of the [technique](https://zcash.github.io/halo2/design/proving-system/lookup.html) described in the Halo2 book.

Without this batching, we would simply have `num_challenges` random challenges (betas and gammas). With this batching, however, we need to use different randomness for each permutation argument within the same batch. Hence we end up generating `batch_size * num_challenges` challenges for all permutation arguments.