### PR TITLE
Derived more traits for ecdsa types

### DIFF
--- a/plonky2/src/curve/curve_types.rs
+++ b/plonky2/src/curve/curve_types.rs
@@ -3,6 +3,7 @@ use std::ops::Neg;
 
 use plonky2_field::field_types::{Field, PrimeField};
 use plonky2_field::ops::Square;
+use serde::{Deserialize, Serialize};
 
 // To avoid implementation conflicts from associated types,
 // see https://github.com/rust-lang/rust/issues/20400
@@ -36,7 +37,7 @@ pub trait Curve: 'static + Sync + Sized + Copy + Debug {
 }
 
 /// A point on a short Weierstrass curve, represented in affine coordinates.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub struct AffinePoint<C: Curve> {
     pub x: C::BaseField,
     pub y: C::BaseField,

--- a/plonky2/src/curve/ecdsa.rs
+++ b/plonky2/src/curve/ecdsa.rs
@@ -1,17 +1,19 @@
+use serde::{Deserialize, Serialize};
+
 use crate::curve::curve_msm::msm_parallel;
 use crate::curve::curve_types::{base_to_scalar, AffinePoint, Curve, CurveScalar};
 use crate::field::field_types::Field;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ECDSASignature<C: Curve> {
     pub r: C::ScalarField,
     pub s: C::ScalarField,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ECDSASecretKey<C: Curve>(pub C::ScalarField);
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ECDSAPublicKey<C: Curve>(pub AffinePoint<C>);
 
 pub fn sign_message<C: Curve>(msg: C::ScalarField, sk: ECDSASecretKey<C>) -> ECDSASignature<C> {

--- a/plonky2/src/curve/secp256k1.rs
+++ b/plonky2/src/curve/secp256k1.rs
@@ -1,10 +1,11 @@
 use plonky2_field::field_types::Field;
 use plonky2_field::secp256k1_base::Secp256K1Base;
 use plonky2_field::secp256k1_scalar::Secp256K1Scalar;
+use serde::{Deserialize, Serialize};
 
 use crate::curve::curve_types::{AffinePoint, Curve};
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Secp256K1;
 
 impl Curve for Secp256K1 {


### PR DESCRIPTION
The client needed a few more derives on the ecdsa types. `Serialize` & `Deserialze` were the critical ones, but I also thought it was a good idea to also derive `PartialEq`, `Eq`, and `Hash` where I could.

Few notes:

- I didn't add any of the derives on the circuit versions since it was going to require adding a lot more derives on types that I wasn't sure should be implementing the traits.
- Not sure if it makes sense to derive `PartialEq` & `Eq` on `Secp256K1`, a unit struct. It seems wrong to declare that you can compare two unit structs against each other, but this seems to be required if we want to construct `ECDSASecretKey<Secp256K1>`.
- Right now since we're deriving these traits directly on the ecdsa types, we're enforcing that any curves used also implement these traits. If we don't want to require this, we can replace the derive impls with more verbose trait impls that only impl if the underlying trait impls the trait as well:
```rust
impl<C: Curve + PartialEq> PartialEq for ECDSASecretKey<C> {
    fn eq(&self, other: &Self) -> bool {
        self.0 == other.0
    }
}
```