### PR TITLE
Impled `Hash` for `AffinePoint`

### DIFF
--- a/plonky2/src/curve/curve_types.rs
+++ b/plonky2/src/curve/curve_types.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::ops::Neg;
 
 use plonky2_field::field_types::{Field, PrimeField};
@@ -119,6 +120,17 @@ impl<C: Curve> PartialEq for AffinePoint<C> {
 }
 
 impl<C: Curve> Eq for AffinePoint<C> {}
+
+impl<C: Curve> Hash for AffinePoint<C> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if self.zero {
+            self.zero.hash(state);
+        } else {
+            self.x.hash(state);
+            self.y.hash(state);
+        }
+    }
+}
 
 /// A point on a short Weierstrass curve, represented in projective coordinates.
 #[derive(Copy, Clone, Debug)]

--- a/plonky2/src/curve/ecdsa.rs
+++ b/plonky2/src/curve/ecdsa.rs
@@ -13,7 +13,7 @@ pub struct ECDSASignature<C: Curve> {
 #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ECDSASecretKey<C: Curve>(pub C::ScalarField);
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct ECDSAPublicKey<C: Curve>(pub AffinePoint<C>);
 
 pub fn sign_message<C: Curve>(msg: C::ScalarField, sk: ECDSASecretKey<C>) -> ECDSASignature<C> {


### PR DESCRIPTION
Oversight on my part. The client ended up needed `Hash` on `AffinePoint` since public keys are hashed in numerous places.