### PR TITLE
Recover public key

### DIFF
--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -244,6 +244,12 @@ impl DivAssign for Secp256K1Base {
     }
 }
 
+impl Secp256K1Base {
+    pub fn sqrt(self) -> Self {
+        self.exp_biguint(&((Self::order() + BigUint::one()) / BigUint::from(4u64)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_field_arithmetic;

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -257,7 +257,19 @@ impl Secp256K1Base {
 
 #[cfg(test)]
 mod tests {
+    use crate::field_types::Field;
+    use crate::ops::Square;
+    use crate::secp256k1_base::Secp256K1Base;
     use crate::test_field_arithmetic;
 
     test_field_arithmetic!(crate::secp256k1_base::Secp256K1Base);
+
+    #[test]
+    fn test_sqrt() {
+        type F = Secp256K1Base;
+
+        let x = F::rand();
+        let x_square_sqrt = x.square().sqrt();
+        assert!((x == x_square_sqrt) || (x == -x_square_sqrt));
+    }
 }

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -11,6 +11,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::field_types::{Field, PrimeField};
+use crate::ops::Square;
 
 /// The base field of the secp256k1 elliptic curve.
 ///
@@ -245,9 +246,12 @@ impl DivAssign for Secp256K1Base {
 }
 
 impl Secp256K1Base {
-    /// Computes a square root using the formula `√x = x^(p-1)/4` which holds when `p%4==3`.
+    /// Computes a square root using the formula `√x = x^(p+1)/4` which holds when `p%4==3`.
+    /// Panics if not a square.
     pub fn sqrt(self) -> Self {
-        self.exp_biguint(&((Self::order() + BigUint::one()) / BigUint::from(4u64)))
+        let sqrt = self.exp_biguint(&((Self::order() + BigUint::one()) / BigUint::from(4u64)));
+        assert_eq!(sqrt.square(), self, "Square root does not exist.");
+        sqrt
     }
 }
 

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -245,6 +245,7 @@ impl DivAssign for Secp256K1Base {
 }
 
 impl Secp256K1Base {
+    /// Computes a square root using the formula `√x = x^(p-1)/4` which holds when `p%4==3`.
     pub fn sqrt(self) -> Self {
         self.exp_biguint(&((Self::order() + BigUint::one()) / BigUint::from(4u64)))
     }

--- a/plonky2/src/curve/curve_types.rs
+++ b/plonky2/src/curve/curve_types.rs
@@ -2,14 +2,9 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Neg;
 
-use num::Integer;
 use plonky2_field::field_types::{Field, PrimeField};
 use plonky2_field::ops::Square;
-use plonky2_field::secp256k1_base::Secp256K1Base;
 use serde::{Deserialize, Serialize};
-
-use crate::curve::ecdsa::RecoveryId;
-use crate::curve::secp256k1::Secp256K1;
 
 // To avoid implementation conflicts from associated types,
 // see https://github.com/rust-lang/rust/issues/20400

--- a/plonky2/src/curve/curve_types.rs
+++ b/plonky2/src/curve/curve_types.rs
@@ -2,9 +2,14 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Neg;
 
+use num::Integer;
 use plonky2_field::field_types::{Field, PrimeField};
 use plonky2_field::ops::Square;
+use plonky2_field::secp256k1_base::Secp256K1Base;
 use serde::{Deserialize, Serialize};
+
+use crate::curve::ecdsa::RecoveryId;
+use crate::curve::secp256k1::Secp256K1;
 
 // To avoid implementation conflicts from associated types,
 // see https://github.com/rust-lang/rust/issues/20400

--- a/plonky2/src/curve/ecdsa.rs
+++ b/plonky2/src/curve/ecdsa.rs
@@ -24,6 +24,13 @@ pub fn secret_to_public<C: Curve>(sk: ECDSASecretKey<C>) -> ECDSAPublicKey<C> {
     ECDSAPublicKey((CurveScalar(sk.0) * C::GENERATOR_PROJECTIVE).to_affine())
 }
 
+/// Flag to indicate the y-coordinate parity of the `R=kG` affine curve point computed in ECDSA.
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum RecoveryId {
+    Even,
+    Odd,
+}
+
 pub fn sign_message<C: Curve>(
     msg: C::ScalarField,
     sk: ECDSASecretKey<C>,
@@ -71,12 +78,7 @@ pub fn verify_message<C: Curve>(
     r == x
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum RecoveryId {
-    Even,
-    Odd,
-}
-
+/// Recover the public key associated with the private key used to sign a message.
 // TODO: Check for overflow, see https://crypto.stackexchange.com/a/18138.
 pub fn recover_public_key(
     msg: Secp256K1Scalar,

--- a/plonky2/src/curve/secp256k1.rs
+++ b/plonky2/src/curve/secp256k1.rs
@@ -40,7 +40,7 @@ const SECP256K1_GENERATOR_Y: Secp256K1Base = Secp256K1Base([
 ]);
 
 impl AffinePoint<Secp256K1> {
-    /// Returns an affine point with x-coordinate `x`.
+    /// Returns an affine point with x-coordinate `x` and parity matching `recovery_id`.
     pub fn lift_x(x: Secp256K1Base, recovery_id: RecoveryId) -> Self {
         let y = (x.cube() + Secp256K1::A * x + Secp256K1::B).sqrt();
         let odd = y.to_canonical_biguint().is_odd();

--- a/plonky2/src/curve/secp256k1.rs
+++ b/plonky2/src/curve/secp256k1.rs
@@ -40,6 +40,7 @@ const SECP256K1_GENERATOR_Y: Secp256K1Base = Secp256K1Base([
 ]);
 
 impl AffinePoint<Secp256K1> {
+    /// Returns an affine point with x-coordinate `x`.
     pub fn lift_x(x: Secp256K1Base, recovery_id: RecoveryId) -> Self {
         let y = (x.cube() + Secp256K1::A * x + Secp256K1::B).sqrt();
         let odd = y.to_canonical_biguint().is_odd();

--- a/plonky2/src/gadgets/ecdsa.rs
+++ b/plonky2/src/gadgets/ecdsa.rs
@@ -85,7 +85,7 @@ mod tests {
 
         let pk_target = ECDSAPublicKeyTarget(builder.constant_affine_point(pk.0));
 
-        let sig = sign_message(msg, sk);
+        let (sig, _) = sign_message(msg, sk);
 
         let ECDSASignature { r, s } = sig;
         let r_target = builder.constant_nonnative(r);


### PR DESCRIPTION
Add function `recover_public_key` to recover an ECDSA public key from a message, signature and recovery id.
I've made the recovery id a separate type to keep `ECDSASignature` similar to `ECDSASignatureTarget`, but it could also be a field of the signature if it's more convenient.

cc @dlubarov @npwardberkeley 