### PR TITLE
Add `Environment` for reading/writing chain data

### DIFF
--- a/system_zero/Cargo.toml
+++ b/system_zero/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0.40"
 env_logger = "0.9.0"
 itertools = "0.10.0"
 log = "0.4.14"
+primitive-types = "0.11.1"
 rand = "0.8.4"
 rand_chacha = "0.3.1"
 

--- a/system_zero/src/env/environment.rs
+++ b/system_zero/src/env/environment.rs
@@ -1,0 +1,28 @@
+use primitive_types::{H160, H256, U256};
+
+/// An interface to the blockchain environment, for reading and writing various chain data.
+pub trait Environment {
+    /// Get the given account's balance, or 0 if no such account exists.
+    fn get_balance(&self, addr: H160) -> U256;
+
+    /// Add ETH to the given address.
+    fn add_balance(&mut self, addr: H160, value: U256);
+
+    /// Get the given account's code, or an empty result if no such account exists.
+    fn get_code(&self, addr: H160) -> Vec<u64>;
+
+    /// Get the given account's code size, or 0 if no such account exists.
+    fn get_code_size(&self, addr: H160) -> usize;
+
+    /// Get a portion of the given account's code, or an empty result if no such account exists.
+    fn get_code_range(&self, addr: H160, offset: usize, len: usize) -> Vec<u64>;
+
+    /// Read a word from the given account's storage. Panics if no such account exists.
+    fn read_storage(&self, addr: H160, key: H256) -> H256;
+
+    /// Write a word to the given account's storage. Panics if no such account exists.
+    fn write_storage(&mut self, addr: H160, key: H256, value: H256);
+
+    /// Create a new smart contract.
+    fn create(&mut self, addr: H160, endowment: U256, code: Vec<u64>);
+}

--- a/system_zero/src/env/mock.rs
+++ b/system_zero/src/env/mock.rs
@@ -1,0 +1,82 @@
+use std::collections::HashMap;
+
+use primitive_types::{H160, H256, U256};
+
+use crate::env::environment::Environment;
+
+pub struct MockEnvironment {
+    accounts: HashMap<H160, MockAccount>,
+}
+
+impl MockEnvironment {
+    pub fn new() -> Self {
+        Self {
+            accounts: HashMap::new(),
+        }
+    }
+}
+
+impl Environment for MockEnvironment {
+    fn get_balance(&self, addr: H160) -> U256 {
+        self.accounts
+            .get(&addr)
+            .map(|acc| acc.balance)
+            .unwrap_or(U256::zero())
+    }
+
+    fn add_balance(&mut self, addr: H160, value: U256) {
+        let acc = self.accounts.entry(addr).or_default();
+        acc.balance += value;
+    }
+
+    fn get_code(&self, addr: H160) -> Vec<u64> {
+        self.accounts
+            .get(&addr)
+            .map(|acc| acc.code.clone())
+            .unwrap_or_else(Vec::new)
+    }
+
+    fn get_code_size(&self, addr: H160) -> usize {
+        self.get_code(addr).len()
+    }
+
+    fn get_code_range(&self, addr: H160, offset: usize, len: usize) -> Vec<u64> {
+        let code = self.get_code(addr);
+        if code.len() < offset {
+            return vec![];
+        }
+        code[offset..(offset + len).min(code.len())].to_vec()
+    }
+
+    fn read_storage(&self, addr: H160, key: H256) -> H256 {
+        let acc = self.accounts.get(&addr).expect("No such address");
+        acc.storage.get(&key).copied().unwrap_or(H256::zero())
+    }
+
+    fn write_storage(&mut self, addr: H160, key: H256, value: H256) {
+        let acc = self.accounts.get_mut(&addr).expect("No such address");
+        acc.storage.insert(key, value);
+    }
+
+    fn create(&mut self, addr: H160, endowment: U256, code: Vec<u64>) {
+        let acc = self.accounts.entry(addr).or_default();
+        acc.code = code;
+        acc.balance += endowment;
+    }
+}
+
+struct MockAccount {
+    balance: U256,
+    code: Vec<u64>,
+    storage: HashMap<H256, H256>,
+}
+
+impl Default for MockAccount {
+    fn default() -> Self {
+        Self {
+            balance: U256::zero(),
+            code: vec![],
+            storage: HashMap::new(),
+        }
+    }
+}

--- a/system_zero/src/env/mod.rs
+++ b/system_zero/src/env/mod.rs
@@ -1,0 +1,2 @@
+pub mod environment;
+pub(crate) mod mock;

--- a/system_zero/src/generate.rs
+++ b/system_zero/src/generate.rs
@@ -1,0 +1,87 @@
+use plonky2::field::field_types::Field;
+use plonky2::field::goldilocks_field::GoldilocksField;
+use plonky2::field::polynomial::PolynomialValues;
+use plonky2::timed;
+use plonky2::util::timing::TimingTree;
+use plonky2::util::transpose;
+
+use crate::alu::generate_alu;
+use crate::core_registers::{generate_first_row_core_registers, generate_next_row_core_registers};
+use crate::env::environment::Environment;
+use crate::lookup::generate_lookups;
+use crate::memory::TransactionMemory;
+use crate::permutation_unit::generate_permutation_unit;
+use crate::registers::NUM_COLUMNS;
+
+/// Some logic in System Zero only works with the Goldilocks field, so we don't want this code to
+/// be generic w.r.t. field choice.
+type F = GoldilocksField;
+
+/// We require at least 2^16 rows as it helps support efficient 16-bit range checks.
+const MIN_TRACE_ROWS: usize = 1 << 16;
+
+pub fn generate_trace<E: Environment>(env: &mut E) -> Vec<PolynomialValues<F>> {
+    let mut timing = TimingTree::new("generate trace", log::Level::Debug);
+
+    // Generate the witness, except for permuted columns in the lookup argument.
+    let trace_rows = timed!(&mut timing, "generate trace rows", generate_trace_rows(env));
+
+    // Transpose from row-wise to column-wise.
+    let trace_row_vecs: Vec<_> = timed!(
+        &mut timing,
+        "convert to Vecs",
+        trace_rows.into_iter().map(|row| row.to_vec()).collect()
+    );
+    let mut trace_col_vecs: Vec<Vec<F>> =
+        timed!(&mut timing, "transpose", transpose(&trace_row_vecs));
+
+    // Generate permuted columns in the lookup argument.
+    timed!(
+        &mut timing,
+        "generate lookup columns",
+        generate_lookups(&mut trace_col_vecs)
+    );
+
+    let trace_polys = timed!(
+        &mut timing,
+        "convert to PolynomialValues",
+        trace_col_vecs
+            .into_iter()
+            .map(PolynomialValues::new)
+            .collect()
+    );
+
+    timing.print();
+    trace_polys
+}
+
+/// Generate the rows of the trace. Note that this does not generate the permuted columns used
+/// in our lookup arguments, as those are computed after transposing to column-wise form.
+fn generate_trace_rows<E: Environment>(env: &mut E) -> Vec<[F; NUM_COLUMNS]> {
+    let memory = TransactionMemory::default();
+
+    let mut row = [F::ZERO; NUM_COLUMNS];
+    generate_first_row_core_registers(&mut row);
+    generate_alu(&mut row);
+    generate_permutation_unit(&mut row);
+
+    let mut trace = Vec::with_capacity(MIN_TRACE_ROWS);
+
+    loop {
+        let mut next_row = [F::ZERO; NUM_COLUMNS];
+        generate_next_row_core_registers(&row, &mut next_row);
+        generate_alu(&mut next_row);
+        generate_permutation_unit(&mut next_row);
+
+        trace.push(row);
+        row = next_row;
+
+        // TODO: Replace with proper termination condition.
+        if trace.len() == (1 << 16) - 1 {
+            break;
+        }
+    }
+
+    trace.push(row);
+    trace
+}

--- a/system_zero/src/lib.rs
+++ b/system_zero/src/lib.rs
@@ -4,6 +4,8 @@
 
 mod alu;
 mod core_registers;
+pub mod env;
+mod generate;
 pub mod lookup;
 mod memory;
 mod permutation_unit;

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -2,109 +2,24 @@ use std::marker::PhantomData;
 
 use plonky2::field::extension_field::{Extendable, FieldExtension};
 use plonky2::field::packed_field::PackedField;
-use plonky2::field::polynomial::PolynomialValues;
 use plonky2::hash::hash_types::RichField;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::timed;
-use plonky2::util::timing::TimingTree;
-use plonky2::util::transpose;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use starky::permutation::PermutationPair;
 use starky::stark::Stark;
 use starky::vars::StarkEvaluationTargets;
 use starky::vars::StarkEvaluationVars;
 
-use crate::alu::{eval_alu, eval_alu_recursively, generate_alu};
-use crate::core_registers::{
-    eval_core_registers, eval_core_registers_recursively, generate_first_row_core_registers,
-    generate_next_row_core_registers,
-};
-use crate::lookup::{eval_lookups, eval_lookups_recursively, generate_lookups};
-use crate::memory::TransactionMemory;
-use crate::permutation_unit::{
-    eval_permutation_unit, eval_permutation_unit_recursively, generate_permutation_unit,
-};
+use crate::alu::{eval_alu, eval_alu_recursively};
+use crate::core_registers::{eval_core_registers, eval_core_registers_recursively};
+use crate::lookup::{eval_lookups, eval_lookups_recursively};
+use crate::permutation_unit::{eval_permutation_unit, eval_permutation_unit_recursively};
 use crate::public_input_layout::NUM_PUBLIC_INPUTS;
 use crate::registers::{lookup, NUM_COLUMNS};
-
-/// We require at least 2^16 rows as it helps support efficient 16-bit range checks.
-const MIN_TRACE_ROWS: usize = 1 << 16;
 
 #[derive(Copy, Clone)]
 pub struct SystemZero<F: RichField + Extendable<D>, const D: usize> {
     _phantom: PhantomData<F>,
-}
-
-impl<F: RichField + Extendable<D>, const D: usize> SystemZero<F, D> {
-    /// Generate the rows of the trace. Note that this does not generate the permuted columns used
-    /// in our lookup arguments, as those are computed after transposing to column-wise form.
-    fn generate_trace_rows(&self) -> Vec<[F; NUM_COLUMNS]> {
-        let memory = TransactionMemory::default();
-
-        let mut row = [F::ZERO; NUM_COLUMNS];
-        generate_first_row_core_registers(&mut row);
-        generate_alu(&mut row);
-        generate_permutation_unit(&mut row);
-
-        let mut trace = Vec::with_capacity(MIN_TRACE_ROWS);
-
-        loop {
-            let mut next_row = [F::ZERO; NUM_COLUMNS];
-            generate_next_row_core_registers(&row, &mut next_row);
-            generate_alu(&mut next_row);
-            generate_permutation_unit(&mut next_row);
-
-            trace.push(row);
-            row = next_row;
-
-            // TODO: Replace with proper termination condition.
-            if trace.len() == (1 << 16) - 1 {
-                break;
-            }
-        }
-
-        trace.push(row);
-        trace
-    }
-
-    fn generate_trace(&self) -> Vec<PolynomialValues<F>> {
-        let mut timing = TimingTree::new("generate trace", log::Level::Debug);
-
-        // Generate the witness, except for permuted columns in the lookup argument.
-        let trace_rows = timed!(
-            &mut timing,
-            "generate trace rows",
-            self.generate_trace_rows()
-        );
-
-        // Transpose from row-wise to column-wise.
-        let trace_row_vecs: Vec<_> = timed!(
-            &mut timing,
-            "convert to Vecs",
-            trace_rows.into_iter().map(|row| row.to_vec()).collect()
-        );
-        let mut trace_col_vecs: Vec<Vec<F>> =
-            timed!(&mut timing, "transpose", transpose(&trace_row_vecs));
-
-        // Generate permuted columns in the lookup argument.
-        timed!(
-            &mut timing,
-            "generate lookup columns",
-            generate_lookups(&mut trace_col_vecs)
-        );
-
-        let trace_polys = timed!(
-            &mut timing,
-            "convert to PolynomialValues",
-            trace_col_vecs
-                .into_iter()
-                .map(|column| PolynomialValues::new(column))
-                .collect()
-        );
-
-        timing.print();
-        trace_polys
-    }
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> Default for SystemZero<F, D> {
@@ -185,6 +100,8 @@ mod tests {
     use starky::stark_testing::test_stark_low_degree;
     use starky::verifier::verify_stark_proof;
 
+    use crate::env::mock::MockEnvironment;
+    use crate::generate::generate_trace;
     use crate::system_zero::SystemZero;
 
     #[test]
@@ -200,7 +117,8 @@ mod tests {
         let public_inputs = [F::ZERO; S::PUBLIC_INPUTS];
         let config = StarkConfig::standard_fast_config();
         let mut timing = TimingTree::new("prove", Level::Debug);
-        let trace = system.generate_trace();
+        let mut env = MockEnvironment::new();
+        let trace = generate_trace(&mut env);
         let proof = prove::<F, C, S, D>(system, &config, trace, public_inputs, &mut timing)?;
 
         verify_stark_proof(system, proof, &config)


### PR DESCRIPTION
While generating a witness for System Zero, we need a way to access various chain data. For example, to execute the `BALANCE` instruction we need to access an arbitrary account's balance.

In our MVP, we plan to reuse witness generation code for normal transaction execution, even when we're not generating a proof. This is very suboptimal, but in the short term it will help keep our codebase small and nimble.

With this in mind, we anticipate that this `Environment` could have several implementations:
- A mock environment which stores everything in memory, just for testing.
- An environment backed by a real node's database, for when validators execute (not prove) transactions.
- An "light" environment which has only the data required to prove a particular transaction. This may be useful if we have prover nodes which don't run nodes, but just receive the bits of chain data they need from a "leader" who does run a node.

I also just moved the witness generation methods, as they're going to become much longer and more complex when integrated with `Environment` to actually read code from it etc.