### PR TITLE
Stop suppressing unused/dead warnings globally

### DIFF
--- a/starky/src/get_challenges.rs
+++ b/starky/src/get_challenges.rs
@@ -75,6 +75,8 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
 {
+    // TODO: Should be used later in compression?
+    #![allow(dead_code)]
     pub(crate) fn fri_query_indices<S: Stark<F, D>>(
         &self,
         stark: &S,

--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -1,6 +1,3 @@
-// TODO: Remove these when crate is closer to being finished.
-#![allow(dead_code)]
-#![allow(unused_variables)]
 #![allow(incomplete_features)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -263,7 +263,6 @@ where
         .map(|i_start| {
             let i_next_start = (i_start + next_step) % size;
             let i_range = i_start..i_start + P::WIDTH;
-            let i_next_range = i_next_start..i_next_start + P::WIDTH;
 
             let x = *P::from_slice(&coset[i_range.clone()]);
             let z_last = x - last;

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -126,9 +126,8 @@ fn recursively_verify_stark_proof_with_challenges<
     let vanishing_polys_zeta = consumer.accumulators();
 
     // Check each polynomial identity, of the form `vanishing(x) = Z_H(x) quotient(x)`, at zeta.
-    let quotient_polys_zeta = &proof.openings.quotient_polys;
     let mut scale = ReducingFactorTarget::new(zeta_pow_deg);
-    for (i, chunk) in quotient_polys_zeta
+    for (i, chunk) in quotient_polys
         .chunks(stark.quotient_degree_factor())
         .enumerate()
     {

--- a/starky/src/verifier.rs
+++ b/starky/src/verifier.rs
@@ -106,7 +106,6 @@ where
     let vanishing_polys_zeta = consumer.accumulators();
 
     // Check each polynomial identity, of the form `vanishing(x) = Z_H(x) quotient(x)`, at zeta.
-    let quotient_polys_zeta = &proof.openings.quotient_polys;
     let zeta_pow_deg = challenges.stark_zeta.exp_power_of_2(degree_bits);
     let z_h_zeta = zeta_pow_deg - F::Extension::ONE;
     // `quotient_polys_zeta` holds `num_challenges * quotient_degree_factor` evaluations.
@@ -114,7 +113,7 @@ where
     // where the "real" quotient polynomial is `t(X) = t_0(X) + t_1(X)*X^n + t_2(X)*X^{2n} + ...`.
     // So to reconstruct `t(zeta)` we can compute `reduce_with_powers(chunk, zeta^n)` for each
     // `quotient_degree_factor`-sized chunk of the original evaluations.
-    for (i, chunk) in quotient_polys_zeta
+    for (i, chunk) in quotient_polys
         .chunks(stark.quotient_degree_factor())
         .enumerate()
     {

--- a/system_zero/src/alu/division.rs
+++ b/system_zero/src/alu/division.rs
@@ -170,7 +170,6 @@ mod tests {
 
     #[test]
     fn generate_eval_consistency_not_div() {
-        const D: usize = 1;
         type F = GoldilocksField;
 
         let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);
@@ -193,7 +192,6 @@ mod tests {
 
     #[test]
     fn generate_eval_consistency_div() {
-        const D: usize = 1;
         type F = GoldilocksField;
 
         let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);

--- a/system_zero/src/alu/mul_add.rs
+++ b/system_zero/src/alu/mul_add.rs
@@ -87,5 +87,5 @@ pub(crate) fn eval_mul_add_recursively<F: RichField + Extendable<D>, const D: us
     );
     let diff = builder.sub_extension(computed_output, output);
     let filtered_diff = builder.mul_extension(is_mul, diff);
-    yield_constr.constraint(builder, diff);
+    yield_constr.constraint(builder, filtered_diff);
 }

--- a/system_zero/src/alu/subtraction.rs
+++ b/system_zero/src/alu/subtraction.rs
@@ -16,12 +16,9 @@ pub(crate) fn generate_subtraction<F: PrimeField64>(values: &mut [F; NUM_COLUMNS
     // in_1 - in_2 == diff - br*2^32
     let (diff, br) = in_1.overflowing_sub(in_2);
 
-    let diff_1 = F::from_canonical_u16(diff as u16);
-    let diff_2 = F::from_canonical_u16((diff >> 16) as u16);
-
     values[COL_SUB_OUTPUT_0] = F::from_canonical_u16(diff as u16);
     values[COL_SUB_OUTPUT_1] = F::from_canonical_u16((diff >> 16) as u16);
-    values[COL_SUB_OUTPUT_BORROW] = F::from_canonical_u16(br as u16);
+    values[COL_SUB_OUTPUT_BORROW] = F::from_bool(br);
 }
 
 pub(crate) fn eval_subtraction<F: Field, P: PackedField<Scalar = F>>(
@@ -61,6 +58,7 @@ pub(crate) fn eval_subtraction_recursively<F: RichField + Extendable<D>, const D
     let out_br = local_values[COL_SUB_OUTPUT_BORROW];
 
     let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << 16));
+    #[allow(unused)] // TODO
     let base_sqr = builder.constant_extension(F::Extension::from_canonical_u64(1 << 32));
 
     // lhs = (out_br + in_1) - in_2

--- a/system_zero/src/lib.rs
+++ b/system_zero/src/lib.rs
@@ -1,7 +1,3 @@
-// TODO: Remove these when crate is closer to being finished.
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
 mod alu;
 mod core_registers;
 pub mod lookup;

--- a/system_zero/src/permutation_unit.rs
+++ b/system_zero/src/permutation_unit.rs
@@ -269,7 +269,6 @@ mod tests {
 
     #[test]
     fn generate_eval_consistency() {
-        const D: usize = 1;
         type F = GoldilocksField;
 
         let mut values = [F::default(); NUM_COLUMNS];
@@ -295,7 +294,6 @@ mod tests {
 
     #[test]
     fn poseidon_result() {
-        const D: usize = 1;
         type F = GoldilocksField;
 
         let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -39,6 +39,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SystemZero<F, D> {
     /// Generate the rows of the trace. Note that this does not generate the permuted columns used
     /// in our lookup arguments, as those are computed after transposing to column-wise form.
     fn generate_trace_rows(&self) -> Vec<[F; NUM_COLUMNS]> {
+        #[allow(unused)] // TODO
         let memory = TransactionMemory::default();
 
         let mut row = [F::ZERO; NUM_COLUMNS];
@@ -67,7 +68,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SystemZero<F, D> {
         trace
     }
 
-    fn generate_trace(&self) -> Vec<PolynomialValues<F>> {
+    pub fn generate_trace(&self) -> Vec<PolynomialValues<F>> {
         let mut timing = TimingTree::new("generate trace", log::Level::Debug);
 
         // Generate the witness, except for permuted columns in the lookup argument.
@@ -209,7 +210,6 @@ mod tests {
     #[test]
     fn degree() -> Result<()> {
         type F = GoldilocksField;
-        type C = PoseidonGoldilocksConfig;
         const D: usize = 2;
 
         type S = SystemZero<F, D>;


### PR DESCRIPTION
Most of them were trivial to address; for the remaining warnings I suppressed just the relevant line and added TODOs.