### PR TITLE
Make `recover_degree_bits` public

### DIFF
--- a/starky/src/proof.rs
+++ b/starky/src/proof.rs
@@ -53,7 +53,7 @@ pub struct StarkProofTarget<const D: usize> {
 
 impl<const D: usize> StarkProofTarget<D> {
     /// Recover the length of the trace from a STARK proof and a STARK config.
-    pub(crate) fn recover_degree_bits(&self, config: &StarkConfig) -> usize {
+    pub fn recover_degree_bits(&self, config: &StarkConfig) -> usize {
         let initial_merkle_proof = &self.opening_proof.query_round_proofs[0]
             .initial_trees_proof
             .evals_proofs[0]

--- a/starky/src/proof.rs
+++ b/starky/src/proof.rs
@@ -33,7 +33,7 @@ pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> StarkProof<F, C, D> {
     /// Recover the length of the trace from a STARK proof and a STARK config.
-    pub(crate) fn recover_degree_bits(&self, config: &StarkConfig) -> usize {
+    pub fn recover_degree_bits(&self, config: &StarkConfig) -> usize {
         let initial_merkle_proof = &self.opening_proof.query_round_proofs[0]
             .initial_trees_proof
             .evals_proofs[0]

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -61,6 +61,8 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
 
     /// Evaluate constraints at a vector of points from the degree `D` extension field. This is like
     /// `eval_ext`, except in the context of a recursive circuit.
+    /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the 
+    /// same order as they are given in `eval_packed_generic`.
     fn eval_ext_recursively(
         &self,
         builder: &mut CircuitBuilder<F, D>,

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -61,7 +61,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
 
     /// Evaluate constraints at a vector of points from the degree `D` extension field. This is like
     /// `eval_ext`, except in the context of a recursive circuit.
-    /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the 
+    /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the
     /// same order as they are given in `eval_packed_generic`.
     fn eval_ext_recursively(
         &self,


### PR DESCRIPTION
`degree_bits` is needed by `add_virtual_stark_proof_with_pis` when building a plonky2 SNARK that verifies a starky STARK proof. Therefore the user needs `recover_degree_bits` to be public.

I also added a doc comment to `eval_ext_recursively` to clear up #538.