### PR TITLE
Standardize gadget suffix to `*_circuit`

### DIFF
--- a/insertion/src/insertion_gate.rs
+++ b/insertion/src/insertion_gate.rs
@@ -153,7 +153,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -86,7 +86,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticGate
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -93,7 +93,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticExte
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -15,7 +15,7 @@ use crate::iop::target::Target;
 use crate::iop::wire::Wire;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
-use crate::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_recursive};
+use crate::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit};
 use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
@@ -168,7 +168,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThan
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -188,9 +188,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThan
 
         let chunk_base = builder.constant(F::from_canonical_usize(1 << self.chunk_bits()));
         let first_chunks_combined =
-            reduce_with_powers_ext_recursive(builder, &first_chunks, chunk_base);
+            reduce_with_powers_ext_circuit(builder, &first_chunks, chunk_base);
         let second_chunks_combined =
-            reduce_with_powers_ext_recursive(builder, &second_chunks, chunk_base);
+            reduce_with_powers_ext_circuit(builder, &second_chunks, chunk_base);
 
         constraints.push(builder.sub_extension(first_chunks_combined, first_input));
         constraints.push(builder.sub_extension(second_chunks_combined, second_input));

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -14,7 +14,7 @@ use crate::iop::target::Target;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
-use crate::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_recursive};
+use crate::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit};
 use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
@@ -77,7 +77,7 @@ impl<F: RichField + Extendable<D>, const D: usize, const B: usize> Gate<F, D> fo
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -85,7 +85,7 @@ impl<F: RichField + Extendable<D>, const D: usize, const B: usize> Gate<F, D> fo
         let base = builder.constant(F::from_canonical_usize(B));
         let sum = vars.local_wires[Self::WIRE_SUM];
         let limbs = vars.local_wires[self.limbs()].to_vec();
-        let computed_sum = reduce_with_powers_ext_recursive(builder, &limbs, base);
+        let computed_sum = reduce_with_powers_ext_circuit(builder, &limbs, base);
         let mut constraints = vec![builder.sub_extension(computed_sum, sum)];
         for limb in limbs {
             constraints.push({

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -56,7 +56,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -120,7 +120,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/gate.rs
+++ b/plonky2/src/gates/gate.rs
@@ -75,7 +75,7 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
         res
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -132,7 +132,7 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
     }
 
     /// Adds this gate's filtered constraints into the `combined_gate_constraints` buffer.
-    fn eval_filtered_recursively(
+    fn eval_filtered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         mut vars: EvaluationTargets<D>,
@@ -142,7 +142,7 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
         num_selectors: usize,
         combined_gate_constraints: &mut [ExtensionTarget<D>],
     ) {
-        let filter = compute_filter_recursively(
+        let filter = compute_filter_circuit(
             builder,
             gate_index,
             group_range,
@@ -150,7 +150,7 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
             num_selectors > 1,
         );
         vars.remove_prefix(num_selectors);
-        let my_constraints = self.eval_unfiltered_recursively(builder, vars);
+        let my_constraints = self.eval_unfiltered_circuit(builder, vars);
         for (acc, c) in combined_gate_constraints.iter_mut().zip(my_constraints) {
             *acc = builder.mul_add_extension(filter, c, *acc);
         }
@@ -258,7 +258,7 @@ fn compute_filter<K: Field>(
         .product()
 }
 
-fn compute_filter_recursively<F: RichField + Extendable<D>, const D: usize>(
+fn compute_filter_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     gate_index: usize,
     group_range: Range<usize>,

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -156,7 +156,7 @@ where
         local_wires: &wires_t,
         public_inputs_hash: &public_inputs_hash_t,
     };
-    let evals_t = gate.eval_unfiltered_recursively(&mut builder, vars_t);
+    let evals_t = gate.eval_unfiltered_circuit(&mut builder, vars_t);
     pw.set_extension_targets(&evals_t, &evals);
 
     let data = builder.build::<C>();

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -64,7 +64,7 @@ impl<F: RichField + Extendable<D>, const D: usize> HighDegreeInterpolationGate<F
     }
 
     /// The domain of the points we're interpolating.
-    fn coset_ext_recursive(
+    fn coset_ext_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         shift: ExtensionTarget<D>,
@@ -134,7 +134,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
         yield_constr.many((evaluation_value - computed_evaluation_value).to_basefield_array());
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -146,7 +146,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
             .collect();
         let interpolant = PolynomialCoeffsExtAlgebraTarget(coeffs);
 
-        let coset = self.coset_ext_recursive(builder, vars.local_wires[self.wire_shift()]);
+        let coset = self.coset_ext_circuit(builder, vars.local_wires[self.wire_shift()]);
         for (i, point) in coset.into_iter().enumerate() {
             let value = vars.get_local_ext_algebra(self.wires_value(i));
             let computed_value = interpolant.eval_scalar(builder, point);

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -184,7 +184,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LowDegreeInter
         yield_constr.many((evaluation_value - computed_evaluation_value).to_basefield_array());
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -84,7 +84,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGa
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -23,7 +23,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
         Vec::new()
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         _builder: &mut CircuitBuilder<F, D>,
         _vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -63,7 +63,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> PoseidonMdsGate<F,
     }
 
     /// Same as `mds_row_shf_recursive` for an extension algebra of `F`.
-    fn mds_row_shf_algebra_recursive(
+    fn mds_row_shf_algebra_circuit(
         builder: &mut CircuitBuilder<F, D>,
         r: usize,
         v: &[ExtensionAlgebraTarget<D>; SPONGE_WIDTH],
@@ -101,14 +101,14 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> PoseidonMdsGate<F,
     }
 
     /// Same as `mds_layer_recursive` for an extension algebra of `F`.
-    fn mds_layer_algebra_recursive(
+    fn mds_layer_algebra_circuit(
         builder: &mut CircuitBuilder<F, D>,
         state: &[ExtensionAlgebraTarget<D>; SPONGE_WIDTH],
     ) -> [ExtensionAlgebraTarget<D>; SPONGE_WIDTH] {
         let mut result = [builder.zero_ext_algebra(); SPONGE_WIDTH];
 
         for r in 0..SPONGE_WIDTH {
-            result[r] = Self::mds_row_shf_algebra_recursive(builder, r, state);
+            result[r] = Self::mds_row_shf_algebra_circuit(builder, r, state);
         }
 
         result
@@ -157,7 +157,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
         )
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -168,7 +168,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
             .try_into()
             .unwrap();
 
-        let computed_outputs = Self::mds_layer_algebra_recursive(builder, &inputs);
+        let computed_outputs = Self::mds_layer_algebra_circuit(builder, &inputs);
 
         (0..SPONGE_WIDTH)
             .map(|i| vars.get_local_ext_algebra(Self::wires_output(i)))

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -48,7 +48,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PublicInputGat
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -161,7 +161,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGa
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -104,7 +104,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingGate<D
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -105,7 +105,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingExtens
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -207,7 +207,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `mds_row_shf`.
-    fn mds_row_shf_recursive<const D: usize>(
+    fn mds_row_shf_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         r: usize,
         v: &[ExtensionTarget<D>; WIDTH],
@@ -267,7 +267,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `mds_layer`.
-    fn mds_layer_recursive<const D: usize>(
+    fn mds_layer_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &[ExtensionTarget<D>; WIDTH],
     ) -> [ExtensionTarget<D>; WIDTH]
@@ -294,7 +294,7 @@ pub trait Poseidon: PrimeField64 {
             let mut result = [builder.zero_extension(); WIDTH];
 
             for r in 0..WIDTH {
-                result[r] = Self::mds_row_shf_recursive(builder, r, state);
+                result[r] = Self::mds_row_shf_circuit(builder, r, state);
             }
 
             result
@@ -314,7 +314,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `partial_first_constant_layer`.
-    fn partial_first_constant_layer_recursive<const D: usize>(
+    fn partial_first_constant_layer_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &mut [ExtensionTarget<D>; WIDTH],
     ) where
@@ -359,7 +359,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `mds_partial_layer_init`.
-    fn mds_partial_layer_init_recursive<const D: usize>(
+    fn mds_partial_layer_init_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &[ExtensionTarget<D>; WIDTH],
     ) -> [ExtensionTarget<D>; WIDTH]
@@ -443,7 +443,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `mds_partial_layer_fast`.
-    fn mds_partial_layer_fast_recursive<const D: usize>(
+    fn mds_partial_layer_fast_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &[ExtensionTarget<D>; WIDTH],
         r: usize,
@@ -496,7 +496,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `constant_layer`.
-    fn constant_layer_recursive<const D: usize>(
+    fn constant_layer_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &mut [ExtensionTarget<D>; WIDTH],
         round_ctr: usize,
@@ -521,7 +521,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `sbox_monomial`.
-    fn sbox_monomial_recursive<const D: usize>(
+    fn sbox_monomial_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         x: ExtensionTarget<D>,
     ) -> ExtensionTarget<D>
@@ -552,14 +552,14 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Recursive version of `sbox_layer`.
-    fn sbox_layer_recursive<const D: usize>(
+    fn sbox_layer_circuit<const D: usize>(
         builder: &mut CircuitBuilder<Self, D>,
         state: &mut [ExtensionTarget<D>; WIDTH],
     ) where
         Self: RichField + Extendable<D>,
     {
         for i in 0..WIDTH {
-            state[i] = <Self as Poseidon>::sbox_monomial_recursive(builder, state[i]);
+            state[i] = <Self as Poseidon>::sbox_monomial_circuit(builder, state[i]);
         }
     }
 

--- a/plonky2/src/plonk/plonk_common.rs
+++ b/plonky2/src/plonk/plonk_common.rs
@@ -81,7 +81,7 @@ pub(crate) fn eval_l_1<F: Field>(n: usize, x: F) -> F {
 /// the order-`n` subgroup.
 ///
 /// Assumes `x != 1`; if `x` could be 1 then this is unsound.
-pub(crate) fn eval_l_1_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_l_1_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     n: usize,
     x: ExtensionTarget<D>,
@@ -138,7 +138,7 @@ where
     sum
 }
 
-pub fn reduce_with_powers_ext_recursive<F: RichField + Extendable<D>, const D: usize>(
+pub fn reduce_with_powers_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     terms: &[ExtensionTarget<D>],
     alpha: Target,

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -8,7 +8,7 @@ use crate::plonk::plonk_common::salt_size;
 use crate::plonk::proof::{
     OpeningSetTarget, ProofChallengesTarget, ProofTarget, ProofWithPublicInputsTarget,
 };
-use crate::plonk::vanishing_poly::eval_vanishing_poly_recursively;
+use crate::plonk::vanishing_poly::eval_vanishing_poly_circuit;
 use crate::plonk::vars::EvaluationTargets;
 use crate::util::reducing::ReducingFactorTarget;
 use crate::with_context;
@@ -70,7 +70,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let vanishing_polys_zeta = with_context!(
             self,
             "evaluate the vanishing polynomial at our challenge point, zeta.",
-            eval_vanishing_poly_recursively(
+            eval_vanishing_poly_circuit(
                 self,
                 inner_common_data,
                 challenges.plonk_zeta,

--- a/plonky2/src/util/partial_products.rs
+++ b/plonky2/src/util/partial_products.rs
@@ -77,7 +77,7 @@ pub(crate) fn check_partial_products<F: Field>(
 /// Checks the relationship between each pair of partial product accumulators. In particular, this
 /// sequence of accumulators starts with `Z(x)`, then contains each partial product polynomials
 /// `p_i(x)`, and finally `Z(g x)`. See the partial products section of the Plonky2 paper.
-pub(crate) fn check_partial_products_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn check_partial_products_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     numerators: &[ExtensionTarget<D>],
     denominators: &[ExtensionTarget<D>],

--- a/starky/src/fibonacci_stark.rs
+++ b/starky/src/fibonacci_stark.rs
@@ -83,7 +83,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for FibonacciStar
         );
     }
 
-    fn eval_ext_recursively(
+    fn eval_ext_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: StarkEvaluationTargets<D, { Self::COLUMNS }, { Self::PUBLIC_INPUTS }>,
@@ -138,8 +138,8 @@ mod tests {
     use crate::proof::StarkProofWithPublicInputs;
     use crate::prover::prove;
     use crate::recursive_verifier::{
-        add_virtual_stark_proof_with_pis, recursively_verify_stark_proof,
-        set_stark_proof_with_pis_target,
+        add_virtual_stark_proof_with_pis, set_stark_proof_with_pis_target,
+        verify_stark_proof_circuit,
     };
     use crate::stark::Stark;
     use crate::stark_testing::test_stark_low_degree;
@@ -234,7 +234,7 @@ mod tests {
         let pt = add_virtual_stark_proof_with_pis(&mut builder, stark, inner_config, degree_bits);
         set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof);
 
-        recursively_verify_stark_proof::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
+        verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
 
         if print_gate_counts {
             builder.print_gate_counts(0);

--- a/starky/src/permutation.rs
+++ b/starky/src/permutation.rs
@@ -325,7 +325,7 @@ pub struct PermutationCheckDataTarget<const D: usize> {
     pub(crate) permutation_challenge_sets: Vec<PermutationChallengeSet<Target>>,
 }
 
-pub(crate) fn eval_permutation_checks_recursively<F, S, const D: usize>(
+pub(crate) fn eval_permutation_checks_circuit<F, S, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     stark: &S,
     config: &StarkConfig,

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -233,12 +233,12 @@ pub fn add_virtual_stark_proof<F: RichField + Extendable<D>, S: Stark<F, D>, con
         trace_cap: builder.add_virtual_cap(cap_height),
         permutation_zs_cap,
         quotient_polys_cap: builder.add_virtual_cap(cap_height),
-        openings: add_stark_opening_set::<F, S, D>(builder, stark, config),
+        openings: add_stark_opening_set_target::<F, S, D>(builder, stark, config),
         opening_proof: builder.add_virtual_fri_proof(&num_leaves_per_oracle, &fri_params),
     }
 }
 
-fn add_stark_opening_set<F: RichField + Extendable<D>, S: Stark<F, D>, const D: usize>(
+fn add_stark_opening_set_target<F: RichField + Extendable<D>, S: Stark<F, D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     stark: S,
     config: &StarkConfig,

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -21,10 +21,10 @@ use crate::proof::{
     StarkProofWithPublicInputs, StarkProofWithPublicInputsTarget,
 };
 use crate::stark::Stark;
-use crate::vanishing_poly::eval_vanishing_poly_recursively;
+use crate::vanishing_poly::eval_vanishing_poly_circuit;
 use crate::vars::StarkEvaluationTargets;
 
-pub fn recursively_verify_stark_proof<
+pub fn verify_stark_proof_circuit<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     S: Stark<F, D>,
@@ -47,7 +47,7 @@ pub fn recursively_verify_stark_proof<
         proof_with_pis.get_challenges::<F, C, S>(builder, &stark, inner_config)
     );
 
-    recursively_verify_stark_proof_with_challenges::<F, C, S, D>(
+    verify_stark_proof_with_challenges_circuit::<F, C, S, D>(
         builder,
         stark,
         proof_with_pis,
@@ -58,7 +58,7 @@ pub fn recursively_verify_stark_proof<
 }
 
 /// Recursively verifies an inner proof.
-fn recursively_verify_stark_proof_with_challenges<
+fn verify_stark_proof_with_challenges_circuit<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     S: Stark<F, D>,
@@ -103,7 +103,7 @@ fn recursively_verify_stark_proof_with_challenges<
     let zeta_pow_deg = builder.exp_power_of_2_extension(challenges.stark_zeta, degree_bits);
     let z_h_zeta = builder.sub_extension(zeta_pow_deg, one);
     let (l_1, l_last) =
-        eval_l_1_and_l_last_recursively(builder, degree_bits, challenges.stark_zeta, z_h_zeta);
+        eval_l_1_and_l_last_circuit(builder, degree_bits, challenges.stark_zeta, z_h_zeta);
     let last =
         builder.constant_extension(F::Extension::primitive_root_of_unity(degree_bits).inverse());
     let z_last = builder.sub_extension(challenges.stark_zeta, last);
@@ -127,7 +127,7 @@ fn recursively_verify_stark_proof_with_challenges<
     with_context!(
         builder,
         "evaluate vanishing polynomial",
-        eval_vanishing_poly_recursively::<F, C, S, D>(
+        eval_vanishing_poly_circuit::<F, C, S, D>(
             builder,
             &stark,
             inner_config,
@@ -170,7 +170,7 @@ fn recursively_verify_stark_proof_with_challenges<
     );
 }
 
-fn eval_l_1_and_l_last_recursively<F: RichField + Extendable<D>, const D: usize>(
+fn eval_l_1_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     log_n: usize,
     x: ExtensionTarget<D>,

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -63,7 +63,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
     /// `eval_ext`, except in the context of a recursive circuit.
     /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the
     /// same order as they are given in `eval_packed_generic`.
-    fn eval_ext_recursively(
+    fn eval_ext_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: StarkEvaluationTargets<D, { Self::COLUMNS }, { Self::PUBLIC_INPUTS }>,

--- a/starky/src/vanishing_poly.rs
+++ b/starky/src/vanishing_poly.rs
@@ -7,7 +7,7 @@ use plonky2::plonk::config::GenericConfig;
 use crate::config::StarkConfig;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use crate::permutation::{
-    eval_permutation_checks, eval_permutation_checks_recursively, PermutationCheckDataTarget,
+    eval_permutation_checks, eval_permutation_checks_circuit, PermutationCheckDataTarget,
     PermutationCheckVars,
 };
 use crate::stark::Stark;
@@ -40,7 +40,7 @@ pub(crate) fn eval_vanishing_poly<F, FE, P, C, S, const D: usize, const D2: usiz
     }
 }
 
-pub(crate) fn eval_vanishing_poly_recursively<F, C, S, const D: usize>(
+pub(crate) fn eval_vanishing_poly_circuit<F, C, S, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     stark: &S,
     config: &StarkConfig,
@@ -54,9 +54,9 @@ pub(crate) fn eval_vanishing_poly_recursively<F, C, S, const D: usize>(
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
 {
-    stark.eval_ext_recursively(builder, vars, consumer);
+    stark.eval_ext_circuit(builder, vars, consumer);
     if let Some(permutation_data) = permutation_data {
-        eval_permutation_checks_recursively::<F, S, D>(
+        eval_permutation_checks_circuit::<F, S, D>(
             builder,
             stark,
             config,

--- a/system_zero/src/alu/addition.rs
+++ b/system_zero/src/alu/addition.rs
@@ -44,7 +44,7 @@ pub(crate) fn eval_addition<F: Field, P: PackedField<Scalar = F>>(
     yield_constr.constraint(is_add * (out - computed_out));
 }
 
-pub(crate) fn eval_addition_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_addition_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     local_values: &[ExtensionTarget<D>; NUM_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/alu/addition.rs
+++ b/system_zero/src/alu/addition.rs
@@ -4,7 +4,7 @@ use plonky2::field::packed_field::PackedField;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::plonk_common::reduce_with_powers_ext_recursive;
+use plonky2::plonk::plonk_common::reduce_with_powers_ext_circuit;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 
 use crate::registers::alu::*;
@@ -60,7 +60,7 @@ pub(crate) fn eval_addition_recursively<F: RichField + Extendable<D>, const D: u
     let limb_base = builder.constant(F::from_canonical_u64(1 << 16));
     // Note that this can't overflow. Since each output limb has been range checked as 16-bits,
     // this sum can be around 48 bits at most.
-    let out = reduce_with_powers_ext_recursive(builder, &[out_1, out_2, out_3], limb_base);
+    let out = reduce_with_powers_ext_circuit(builder, &[out_1, out_2, out_3], limb_base);
 
     let computed_out = builder.add_many_extension(&[in_1, in_2, in_3]);
 

--- a/system_zero/src/alu/bitops.rs
+++ b/system_zero/src/alu/bitops.rs
@@ -4,7 +4,7 @@ use plonky2::field::packed_field::PackedField;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::plonk_common::reduce_with_powers_ext_recursive;
+use plonky2::plonk::plonk_common::reduce_with_powers_ext_circuit;
 use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 
 use crate::registers::alu::*;
@@ -171,12 +171,12 @@ fn eval_bitop_32_recursively<F: RichField + Extendable<D>, const D: usize>(
     let output = lv[output_reg];
 
     let limb_base = builder.constant(F::TWO);
-    let a = reduce_with_powers_ext_recursive(builder, &a_bits, limb_base);
-    let b = reduce_with_powers_ext_recursive(builder, &b_bits, limb_base);
+    let a = reduce_with_powers_ext_circuit(builder, &a_bits, limb_base);
+    let b = reduce_with_powers_ext_circuit(builder, &b_bits, limb_base);
     let a_and_b_bits = a_bits
         .zip(b_bits)
         .map(|(b0, b1)| builder.mul_extension(b0, b1));
-    let a_and_b = reduce_with_powers_ext_recursive(builder, &a_and_b_bits, limb_base);
+    let a_and_b = reduce_with_powers_ext_circuit(builder, &a_and_b_bits, limb_base);
 
     let and_constr = {
         let t = builder.sub_extension(a_and_b, output);

--- a/system_zero/src/alu/bitops.rs
+++ b/system_zero/src/alu/bitops.rs
@@ -130,7 +130,7 @@ pub(crate) fn eval_bitop<F: Field, P: PackedField<Scalar = F>>(
     );
 }
 
-pub(crate) fn constrain_all_to_bits<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn constrain_all_to_bits_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
     filter: ExtensionTarget<D>,
@@ -144,7 +144,7 @@ pub(crate) fn constrain_all_to_bits<F: RichField + Extendable<D>, const D: usize
 }
 
 /// As for `eval_bitop`, but build with `builder`.
-fn eval_bitop_32_recursively<F: RichField + Extendable<D>, const D: usize>(
+fn eval_bitop_32_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_COLUMNS],
     input_a_regs: [usize; 32],
@@ -164,8 +164,8 @@ fn eval_bitop_32_recursively<F: RichField + Extendable<D>, const D: usize>(
 
     // Ensure that the inputs are bits
     let inst_constr = builder.add_many_extension(&[is_and, is_ior, is_xor, is_andnot]);
-    constrain_all_to_bits(builder, yield_constr, inst_constr, &a_bits);
-    constrain_all_to_bits(builder, yield_constr, inst_constr, &b_bits);
+    constrain_all_to_bits_circuit(builder, yield_constr, inst_constr, &a_bits);
+    constrain_all_to_bits_circuit(builder, yield_constr, inst_constr, &b_bits);
 
     // Output
     let output = lv[output_reg];
@@ -209,13 +209,13 @@ fn eval_bitop_32_recursively<F: RichField + Extendable<D>, const D: usize>(
 }
 
 /// As for `eval_bitop` but with a builder.
-pub(crate) fn eval_bitop_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_bitop_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
 ) {
     // Recursive constraint for lo half
-    eval_bitop_32_recursively(
+    eval_bitop_32_circuit(
         builder,
         lv,
         COL_BIT_DECOMP_INPUT_A_LO_BIN_REGS,
@@ -224,7 +224,7 @@ pub(crate) fn eval_bitop_recursively<F: RichField + Extendable<D>, const D: usiz
         yield_constr,
     );
     // Recursive constraint for hi half
-    eval_bitop_32_recursively(
+    eval_bitop_32_circuit(
         builder,
         lv,
         COL_BIT_DECOMP_INPUT_A_HI_BIN_REGS,

--- a/system_zero/src/alu/division.rs
+++ b/system_zero/src/alu/division.rs
@@ -90,7 +90,7 @@ pub(crate) fn eval_division<F: Field, P: PackedField<Scalar = F>>(
     yield_constr.constraint(is_div * divisor * (divisor - remainder - F::ONE - div_rem_diff_m1));
 }
 
-pub(crate) fn eval_division_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_division_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/alu/mod.rs
+++ b/system_zero/src/alu/mod.rs
@@ -7,14 +7,14 @@ use starky::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsume
 use starky::vars::StarkEvaluationTargets;
 use starky::vars::StarkEvaluationVars;
 
-use crate::alu::addition::{eval_addition, eval_addition_recursively, generate_addition};
-use crate::alu::bitops::{eval_bitop, eval_bitop_recursively, generate_bitop};
+use crate::alu::addition::{eval_addition, eval_addition_circuit, generate_addition};
+use crate::alu::bitops::{eval_bitop, eval_bitop_circuit, generate_bitop};
 use crate::alu::division::{eval_division, eval_division_circuit, generate_division};
 use crate::alu::mul_add::{eval_mul_add, eval_mul_add_circuit, generate_mul_add};
 use crate::alu::rotate_shift::{
-    eval_rotate_left, eval_rotate_left_recursively, eval_rotate_right,
-    eval_rotate_right_recursively, eval_shift_left, eval_shift_left_recursively, eval_shift_right,
-    eval_shift_right_recursively, generate_rotate_shift,
+    eval_rotate_left, eval_rotate_left_circuit, eval_rotate_right, eval_rotate_right_circuit,
+    eval_shift_left, eval_shift_left_circuit, eval_shift_right, eval_shift_right_circuit,
+    generate_rotate_shift,
 };
 use crate::alu::subtraction::{eval_subtraction, eval_subtraction_circuit, generate_subtraction};
 use crate::public_input_layout::NUM_PUBLIC_INPUTS;
@@ -96,13 +96,13 @@ pub(crate) fn eval_alu_circuit<F: RichField + Extendable<D>, const D: usize>(
         yield_constr.constraint(builder, constraint);
     }
 
-    eval_addition_recursively(builder, local_values, yield_constr);
+    eval_addition_circuit(builder, local_values, yield_constr);
     eval_subtraction_circuit(builder, local_values, yield_constr);
     eval_mul_add_circuit(builder, local_values, yield_constr);
     eval_division_circuit(builder, local_values, yield_constr);
-    eval_bitop_recursively(builder, local_values, yield_constr);
-    eval_rotate_left_recursively(builder, local_values, yield_constr);
-    eval_rotate_right_recursively(builder, local_values, yield_constr);
-    eval_shift_left_recursively(builder, local_values, yield_constr);
-    eval_shift_right_recursively(builder, local_values, yield_constr);
+    eval_bitop_circuit(builder, local_values, yield_constr);
+    eval_rotate_left_circuit(builder, local_values, yield_constr);
+    eval_rotate_right_circuit(builder, local_values, yield_constr);
+    eval_shift_left_circuit(builder, local_values, yield_constr);
+    eval_shift_right_circuit(builder, local_values, yield_constr);
 }

--- a/system_zero/src/alu/mod.rs
+++ b/system_zero/src/alu/mod.rs
@@ -9,16 +9,14 @@ use starky::vars::StarkEvaluationVars;
 
 use crate::alu::addition::{eval_addition, eval_addition_recursively, generate_addition};
 use crate::alu::bitops::{eval_bitop, eval_bitop_recursively, generate_bitop};
-use crate::alu::division::{eval_division, eval_division_recursively, generate_division};
-use crate::alu::mul_add::{eval_mul_add, eval_mul_add_recursively, generate_mul_add};
+use crate::alu::division::{eval_division, eval_division_circuit, generate_division};
+use crate::alu::mul_add::{eval_mul_add, eval_mul_add_circuit, generate_mul_add};
 use crate::alu::rotate_shift::{
     eval_rotate_left, eval_rotate_left_recursively, eval_rotate_right,
     eval_rotate_right_recursively, eval_shift_left, eval_shift_left_recursively, eval_shift_right,
     eval_shift_right_recursively, generate_rotate_shift,
 };
-use crate::alu::subtraction::{
-    eval_subtraction, eval_subtraction_recursively, generate_subtraction,
-};
+use crate::alu::subtraction::{eval_subtraction, eval_subtraction_circuit, generate_subtraction};
 use crate::public_input_layout::NUM_PUBLIC_INPUTS;
 use crate::registers::alu::*;
 use crate::registers::NUM_COLUMNS;
@@ -84,7 +82,7 @@ pub(crate) fn eval_alu<F: Field, P: PackedField<Scalar = F>>(
     eval_shift_right(local_values, yield_constr);
 }
 
-pub(crate) fn eval_alu_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_alu_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     vars: StarkEvaluationTargets<D, NUM_COLUMNS, NUM_PUBLIC_INPUTS>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
@@ -99,9 +97,9 @@ pub(crate) fn eval_alu_recursively<F: RichField + Extendable<D>, const D: usize>
     }
 
     eval_addition_recursively(builder, local_values, yield_constr);
-    eval_subtraction_recursively(builder, local_values, yield_constr);
-    eval_mul_add_recursively(builder, local_values, yield_constr);
-    eval_division_recursively(builder, local_values, yield_constr);
+    eval_subtraction_circuit(builder, local_values, yield_constr);
+    eval_mul_add_circuit(builder, local_values, yield_constr);
+    eval_division_circuit(builder, local_values, yield_constr);
     eval_bitop_recursively(builder, local_values, yield_constr);
     eval_rotate_left_recursively(builder, local_values, yield_constr);
     eval_rotate_right_recursively(builder, local_values, yield_constr);

--- a/system_zero/src/alu/mul_add.rs
+++ b/system_zero/src/alu/mul_add.rs
@@ -59,7 +59,7 @@ pub(crate) fn eval_mul_add<F: Field, P: PackedField<Scalar = F>>(
     yield_constr.constraint(is_mul * (computed_output - output));
 }
 
-pub(crate) fn eval_mul_add_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_mul_add_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     local_values: &[ExtensionTarget<D>; NUM_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/alu/subtraction.rs
+++ b/system_zero/src/alu/subtraction.rs
@@ -45,7 +45,7 @@ pub(crate) fn eval_subtraction<F: Field, P: PackedField<Scalar = F>>(
     // checked by boolean::col_bit(0) in the ALU.
 }
 
-pub(crate) fn eval_subtraction_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_subtraction_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     local_values: &[ExtensionTarget<D>; NUM_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/core_registers.rs
+++ b/system_zero/src/core_registers.rs
@@ -62,7 +62,7 @@ pub(crate) fn eval_core_registers<F: Field, P: PackedField<Scalar = F>>(
     // TODO constraints for stack etc.
 }
 
-pub(crate) fn eval_core_registers_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_core_registers_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     vars: StarkEvaluationTargets<D, NUM_COLUMNS, NUM_PUBLIC_INPUTS>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/lookup.rs
+++ b/system_zero/src/lookup.rs
@@ -121,7 +121,7 @@ pub(crate) fn eval_lookups<F: Field, P: PackedField<Scalar = F>>(
     }
 }
 
-pub(crate) fn eval_lookups_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_lookups_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     vars: StarkEvaluationTargets<D, NUM_COLUMNS, NUM_PUBLIC_INPUTS>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/permutation_unit.rs
+++ b/system_zero/src/permutation_unit.rs
@@ -187,7 +187,7 @@ pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, co
     }
 
     for r in 0..HALF_N_FULL_ROUNDS {
-        F::constant_layer_recursive(builder, &mut state, r);
+        F::constant_layer_circuit(builder, &mut state, r);
 
         for i in 0..SPONGE_WIDTH {
             let state_cubed = builder.cube_extension(state[i]);
@@ -199,7 +199,7 @@ pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, co
             // Form state ** 7.
         }
 
-        state = F::mds_layer_recursive(builder, &state);
+        state = F::mds_layer_circuit(builder, &state);
 
         for i in 0..SPONGE_WIDTH {
             let diff =
@@ -210,7 +210,7 @@ pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, co
     }
 
     for r in 0..N_PARTIAL_ROUNDS {
-        F::constant_layer_recursive(builder, &mut state, HALF_N_FULL_ROUNDS + r);
+        F::constant_layer_circuit(builder, &mut state, HALF_N_FULL_ROUNDS + r);
 
         let state0_cubed = builder.cube_extension(state[0]);
         let diff = builder.sub_extension(state0_cubed, local_values[col_partial_mid_sbox(r)]);
@@ -221,11 +221,11 @@ pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, co
         yield_constr.constraint(builder, diff);
         state[0] = local_values[col_partial_after_sbox(r)];
 
-        state = F::mds_layer_recursive(builder, &state);
+        state = F::mds_layer_circuit(builder, &state);
     }
 
     for r in 0..HALF_N_FULL_ROUNDS {
-        F::constant_layer_recursive(
+        F::constant_layer_circuit(
             builder,
             &mut state,
             HALF_N_FULL_ROUNDS + N_PARTIAL_ROUNDS + r,
@@ -241,7 +241,7 @@ pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, co
             // Form state ** 7.
         }
 
-        state = F::mds_layer_recursive(builder, &state);
+        state = F::mds_layer_circuit(builder, &state);
 
         for i in 0..SPONGE_WIDTH {
             let diff =

--- a/system_zero/src/permutation_unit.rs
+++ b/system_zero/src/permutation_unit.rs
@@ -172,7 +172,7 @@ pub(crate) fn eval_permutation_unit<F, FE, P, const D: usize>(
     }
 }
 
-pub(crate) fn eval_permutation_unit_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_permutation_unit_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     vars: StarkEvaluationTargets<D, NUM_COLUMNS, NUM_PUBLIC_INPUTS>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -14,12 +14,12 @@ use starky::stark::Stark;
 use starky::vars::StarkEvaluationTargets;
 use starky::vars::StarkEvaluationVars;
 
-use crate::alu::{eval_alu, eval_alu_recursively, generate_alu};
+use crate::alu::{eval_alu, eval_alu_circuit, generate_alu};
 use crate::core_registers::{
-    eval_core_registers, eval_core_registers_recursively, generate_first_row_core_registers,
+    eval_core_registers, eval_core_registers_circuit, generate_first_row_core_registers,
     generate_next_row_core_registers,
 };
-use crate::lookup::{eval_lookups, eval_lookups_recursively, generate_lookups};
+use crate::lookup::{eval_lookups, eval_lookups_circuit, generate_lookups};
 use crate::memory::TransactionMemory;
 use crate::permutation_unit::{
     eval_permutation_unit, eval_permutation_unit_recursively, generate_permutation_unit,
@@ -135,16 +135,16 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for SystemZero<F,
         // TODO: Other units
     }
 
-    fn eval_ext_recursively(
+    fn eval_ext_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: StarkEvaluationTargets<D, NUM_COLUMNS, NUM_PUBLIC_INPUTS>,
         yield_constr: &mut RecursiveConstraintConsumer<F, D>,
     ) {
-        eval_core_registers_recursively(builder, vars, yield_constr);
-        eval_alu_recursively(builder, vars, yield_constr);
+        eval_core_registers_circuit(builder, vars, yield_constr);
+        eval_alu_circuit(builder, vars, yield_constr);
         eval_permutation_unit_recursively(builder, vars, yield_constr);
-        eval_lookups_recursively(builder, vars, yield_constr);
+        eval_lookups_circuit(builder, vars, yield_constr);
         // TODO: Other units
     }
 

--- a/system_zero/src/system_zero.rs
+++ b/system_zero/src/system_zero.rs
@@ -22,7 +22,7 @@ use crate::core_registers::{
 use crate::lookup::{eval_lookups, eval_lookups_circuit, generate_lookups};
 use crate::memory::TransactionMemory;
 use crate::permutation_unit::{
-    eval_permutation_unit, eval_permutation_unit_recursively, generate_permutation_unit,
+    eval_permutation_unit, eval_permutation_unit_circuit, generate_permutation_unit,
 };
 use crate::public_input_layout::NUM_PUBLIC_INPUTS;
 use crate::registers::{lookup, NUM_COLUMNS};
@@ -143,7 +143,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for SystemZero<F,
     ) {
         eval_core_registers_circuit(builder, vars, yield_constr);
         eval_alu_circuit(builder, vars, yield_constr);
-        eval_permutation_unit_recursively(builder, vars, yield_constr);
+        eval_permutation_unit_circuit(builder, vars, yield_constr);
         eval_lookups_circuit(builder, vars, yield_constr);
         // TODO: Other units
     }

--- a/u32/src/gates/add_many_u32.rs
+++ b/u32/src/gates/add_many_u32.rs
@@ -172,7 +172,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32AddManyGate
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/u32/src/gates/arithmetic_u32.rs
+++ b/u32/src/gates/arithmetic_u32.rs
@@ -136,7 +136,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/u32/src/gates/comparison.rs
+++ b/u32/src/gates/comparison.rs
@@ -10,7 +10,7 @@ use plonky2::iop::target::Target;
 use plonky2::iop::wire::Wire;
 use plonky2::iop::witness::{PartitionWitness, Witness};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_recursive};
+use plonky2::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit};
 use plonky2::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
@@ -185,7 +185,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -205,9 +205,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
 
         let chunk_base = builder.constant(F::from_canonical_usize(1 << self.chunk_bits()));
         let first_chunks_combined =
-            reduce_with_powers_ext_recursive(builder, &first_chunks, chunk_base);
+            reduce_with_powers_ext_circuit(builder, &first_chunks, chunk_base);
         let second_chunks_combined =
-            reduce_with_powers_ext_recursive(builder, &second_chunks, chunk_base);
+            reduce_with_powers_ext_circuit(builder, &second_chunks, chunk_base);
 
         constraints.push(builder.sub_extension(first_chunks_combined, first_input));
         constraints.push(builder.sub_extension(second_chunks_combined, second_input));
@@ -268,7 +268,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
 
         let two = builder.two();
         let bits_combined =
-            reduce_with_powers_ext_recursive(builder, &most_significant_diff_bits, two);
+            reduce_with_powers_ext_circuit(builder, &most_significant_diff_bits, two);
         let two_n =
             builder.constant_extension(F::Extension::from_canonical_u64(1 << self.chunk_bits()));
         let sum = builder.add_extension(two_n, most_significant_diff);

--- a/u32/src/gates/range_check_u32.rs
+++ b/u32/src/gates/range_check_u32.rs
@@ -8,7 +8,7 @@ use plonky2::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartitionWitness, Witness};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_recursive};
+use plonky2::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit};
 use plonky2::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use plonky2_field::extension_field::Extendable;
 use plonky2_field::field_types::Field;
@@ -99,7 +99,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32RangeCheckG
         }
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,
@@ -112,7 +112,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32RangeCheckG
             let aux_limbs: Vec<_> = (0..self.aux_limbs_per_input_limb())
                 .map(|j| vars.local_wires[self.wire_ith_input_limb_jth_aux_limb(i, j)])
                 .collect();
-            let computed_sum = reduce_with_powers_ext_recursive(builder, &aux_limbs, base);
+            let computed_sum = reduce_with_powers_ext_circuit(builder, &aux_limbs, base);
 
             constraints.push(builder.sub_extension(computed_sum, input_limb));
             for aux_limb in aux_limbs {

--- a/u32/src/gates/subtraction_u32.rs
+++ b/u32/src/gates/subtraction_u32.rs
@@ -132,7 +132,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32Subtraction
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,

--- a/waksman/src/gates/switch.rs
+++ b/waksman/src/gates/switch.rs
@@ -112,7 +112,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, 
         self.eval_unfiltered_base_batch_packed(vars_base)
     }
 
-    fn eval_unfiltered_recursively(
+    fn eval_unfiltered_circuit(
         &self,
         builder: &mut CircuitBuilder<F, D>,
         vars: EvaluationTargets<D>,


### PR DESCRIPTION
Standardize the naming of gadgets (outside of `impl` blocks) to use the `*_circuit` suffix.
See https://github.com/mir-protocol/plonky2/pull/486 for a discussion of this change.