### PR TITLE
Rename wire fields

### DIFF
--- a/insertion/src/insert_gadget.rs
+++ b/insertion/src/insert_gadget.rs
@@ -27,25 +27,22 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderInsert<F, D>
         v: Vec<ExtensionTarget<D>>,
     ) -> Vec<ExtensionTarget<D>> {
         let gate = InsertionGate::new(v.len());
-        let gate_index = self.add_gate(gate.clone(), vec![]);
+        let row = self.add_gate(gate.clone(), vec![]);
 
         v.iter().enumerate().for_each(|(i, &val)| {
             self.connect_extension(
                 val,
-                ExtensionTarget::from_range(gate_index, gate.wires_original_list_item(i)),
+                ExtensionTarget::from_range(row, gate.wires_original_list_item(i)),
             );
         });
-        self.connect(
-            index,
-            Target::wire(gate_index, gate.wires_insertion_index()),
-        );
+        self.connect(index, Target::wire(row, gate.wires_insertion_index()));
         self.connect_extension(
             element,
-            ExtensionTarget::from_range(gate_index, gate.wires_element_to_insert()),
+            ExtensionTarget::from_range(row, gate.wires_element_to_insert()),
         );
 
         (0..=v.len())
-            .map(|i| ExtensionTarget::from_range(gate_index, gate.wires_output_list_item(i)))
+            .map(|i| ExtensionTarget::from_range(row, gate.wires_output_list_item(i)))
             .collect::<Vec<_>>()
     }
 }

--- a/insertion/src/insertion_gate.rs
+++ b/insertion/src/insertion_gate.rs
@@ -213,13 +213,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = InsertionGenerator::<F, D> {
-            gate_index,
+            row,
             gate: self.clone(),
         };
         vec![Box::new(gen.adapter())]
@@ -244,13 +240,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
 
 #[derive(Debug)]
 struct InsertionGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: InsertionGate<F, D>,
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F> for InsertionGenerator<F, D> {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         let local_targets = |columns: Range<usize>| columns.map(local_target);
 
@@ -264,7 +260,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F> for Insert
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/insertion/src/insertion_gate.rs
+++ b/insertion/src/insertion_gate.rs
@@ -264,8 +264,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F> for Insert
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/insertion/src/insertion_gate.rs
+++ b/insertion/src/insertion_gate.rs
@@ -250,9 +250,9 @@ struct InsertionGenerator<F: RichField + Extendable<D>, const D: usize> {
 
 impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F> for InsertionGenerator<F, D> {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
-        let local_targets = |inputs: Range<usize>| inputs.map(local_target);
+        let local_targets = |columns: Range<usize>| columns.map(local_target);
 
         let mut deps = vec![local_target(self.gate.wires_insertion_index())];
         deps.extend(local_targets(self.gate.wires_element_to_insert()));
@@ -263,12 +263,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F> for Insert
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let get_local_ext = |wire_range: Range<usize>| {
             debug_assert_eq!(wire_range.len(), D);

--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -243,14 +243,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         while exp_bits_vec.len() < num_power_bits {
             exp_bits_vec.push(_false);
         }
-        let gate_index = self.add_gate(gate.clone(), vec![]);
+        let row = self.add_gate(gate.clone(), vec![]);
 
-        self.connect(base, Target::wire(gate_index, gate.wire_base()));
+        self.connect(base, Target::wire(row, gate.wire_base()));
         exp_bits_vec.iter().enumerate().for_each(|(i, bit)| {
-            self.connect(bit.target, Target::wire(gate_index, gate.wire_power_bit(i)));
+            self.connect(bit.target, Target::wire(row, gate.wire_power_bit(i)));
         });
 
-        Target::wire(gate_index, gate.wire_output())
+        Target::wire(row, gate.wire_output())
     }
 
     // TODO: Test

--- a/plonky2/src/gadgets/interpolation.rs
+++ b/plonky2/src/gadgets/interpolation.rs
@@ -88,20 +88,17 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         evaluation_point: ExtensionTarget<D>,
     ) -> ExtensionTarget<D> {
         let gate = G::new(subgroup_bits);
-        let gate_index = self.add_gate(gate, vec![]);
-        self.connect(coset_shift, Target::wire(gate_index, gate.wire_shift()));
+        let row = self.add_gate(gate, vec![]);
+        self.connect(coset_shift, Target::wire(row, gate.wire_shift()));
         for (i, &v) in values.iter().enumerate() {
-            self.connect_extension(
-                v,
-                ExtensionTarget::from_range(gate_index, gate.wires_value(i)),
-            );
+            self.connect_extension(v, ExtensionTarget::from_range(row, gate.wires_value(i)));
         }
         self.connect_extension(
             evaluation_point,
-            ExtensionTarget::from_range(gate_index, gate.wires_evaluation_point()),
+            ExtensionTarget::from_range(row, gate.wires_evaluation_point()),
         );
 
-        ExtensionTarget::from_range(gate_index, gate.wires_evaluation_value())
+        ExtensionTarget::from_range(row, gate.wires_evaluation_value())
     }
 }
 

--- a/plonky2/src/gadgets/random_access.rs
+++ b/plonky2/src/gadgets/random_access.rs
@@ -20,21 +20,18 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let claimed_element = self.add_virtual_target();
 
         let dummy_gate = RandomAccessGate::<F, D>::new_from_config(&self.config, bits);
-        let (gate_index, copy) = self.find_slot(dummy_gate, &[], &[]);
+        let (row, copy) = self.find_slot(dummy_gate, &[], &[]);
 
         v.iter().enumerate().for_each(|(i, &val)| {
-            self.connect(
-                val,
-                Target::wire(gate_index, dummy_gate.wire_list_item(i, copy)),
-            );
+            self.connect(val, Target::wire(row, dummy_gate.wire_list_item(i, copy)));
         });
         self.connect(
             access_index,
-            Target::wire(gate_index, dummy_gate.wire_access_index(copy)),
+            Target::wire(row, dummy_gate.wire_access_index(copy)),
         );
         self.connect(
             claimed_element,
-            Target::wire(gate_index, dummy_gate.wire_claimed_element(copy)),
+            Target::wire(row, dummy_gate.wire_claimed_element(copy)),
         );
 
         claimed_element

--- a/plonky2/src/gadgets/split_join.rs
+++ b/plonky2/src/gadgets/split_join.rs
@@ -25,9 +25,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         let mut bits = Vec::with_capacity(num_bits);
         for &gate in &gates {
-            for limb_input in gate_type.limbs() {
+            for limb_column in gate_type.limbs() {
                 // `new_unsafe` is safe here because BaseSumGate::<2> forces it to be in `{0, 1}`.
-                bits.push(BoolTarget::new_unsafe(Target::wire(gate, limb_input)));
+                bits.push(BoolTarget::new_unsafe(Target::wire(gate, limb_column)));
             }
         }
         for b in bits.drain(num_bits..) {

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -362,7 +362,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for AssertLessThanGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         vec![
             local_target(self.gate.wire_first_input()),
@@ -371,12 +371,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let first_input = get_local_wire(self.gate.wire_first_input());
         let second_input = get_local_wire(self.gate.wire_second_input());

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -251,13 +251,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThan
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = AssertLessThanGenerator::<F, D> {
-            gate_index,
+            row,
             gate: self.clone(),
         };
         vec![Box::new(gen.adapter())]
@@ -354,7 +350,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
 #[derive(Debug)]
 struct AssertLessThanGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: AssertLessThanGate<F, D>,
 }
 
@@ -362,7 +358,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for AssertLessThanGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         vec![
             local_target(self.gate.wire_first_input()),
@@ -372,7 +368,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -372,8 +372,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -71,11 +71,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
             .collect()
     }
 
-    fn generators(
-        &self,
-        _gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, _row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         vec![]
     }
 

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -239,7 +239,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for ExponentiationGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         let mut deps = Vec::with_capacity(self.gate.num_power_bits + 1);
         deps.push(local_target(self.gate.wire_base()));
@@ -250,12 +250,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let num_power_bits = self.gate.num_power_bits;
         let base = get_local_wire(self.gate.wire_base());

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -251,8 +251,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -161,13 +161,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = ExponentiationGenerator::<F, D> {
-            gate_index,
+            row,
             gate: self.clone(),
         };
         vec![Box::new(gen.adapter())]
@@ -231,7 +227,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
 #[derive(Debug)]
 struct ExponentiationGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: ExponentiationGate<F, D>,
 }
 
@@ -239,7 +235,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for ExponentiationGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         let mut deps = Vec::with_capacity(self.gate.num_power_bits + 1);
         deps.push(local_target(self.gate.wire_base()));
@@ -251,7 +247,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -216,8 +216,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     fn dependencies(&self) -> Vec<Target> {
         let local_target = |input| {
             Target::Wire(Wire {
-                gate: self.gate_index,
-                input,
+                row: self.gate_index,
+                column: input,
             })
         };
 
@@ -236,8 +236,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -169,13 +169,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = InterpolationGenerator::<F, D> {
-            gate_index,
+            row,
             gate: *self,
             _phantom: PhantomData,
         };
@@ -205,7 +201,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
 
 #[derive(Debug)]
 struct InterpolationGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: HighDegreeInterpolationGate<F, D>,
     _phantom: PhantomData<F>,
 }
@@ -216,7 +212,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     fn dependencies(&self) -> Vec<Target> {
         let local_target = |column| {
             Target::Wire(Wire {
-                row: self.gate_index,
+                row: self.row,
                 column,
             })
         };
@@ -236,7 +232,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -214,14 +214,14 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for InterpolationGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| {
+        let local_target = |column| {
             Target::Wire(Wire {
                 row: self.gate_index,
-                column: input,
+                column,
             })
         };
 
-        let local_targets = |inputs: Range<usize>| inputs.map(local_target);
+        let local_targets = |columns: Range<usize>| columns.map(local_target);
 
         let num_points = self.gate.num_points();
         let mut deps = Vec::with_capacity(1 + D + num_points * D);
@@ -235,12 +235,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let get_local_ext = |wire_range: Range<usize>| {
             debug_assert_eq!(wire_range.len(), D);

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -307,8 +307,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     fn dependencies(&self) -> Vec<Target> {
         let local_target = |input| {
             Target::Wire(Wire {
-                gate: self.gate_index,
-                input,
+                row: self.gate_index,
+                column: input,
             })
         };
 
@@ -327,8 +327,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -261,13 +261,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LowDegreeInter
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = InterpolationGenerator::<F, D> {
-            gate_index,
+            row,
             gate: *self,
             _phantom: PhantomData,
         };
@@ -296,7 +292,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LowDegreeInter
 
 #[derive(Debug)]
 struct InterpolationGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: LowDegreeInterpolationGate<F, D>,
     _phantom: PhantomData<F>,
 }
@@ -307,7 +303,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     fn dependencies(&self) -> Vec<Target> {
         let local_target = |column| {
             Target::Wire(Wire {
-                row: self.gate_index,
+                row: self.row,
                 column,
             })
         };
@@ -327,7 +323,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 
@@ -373,7 +369,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
             .skip(2)
         {
             out_buffer.set_extension_target(
-                ExtensionTarget::from_range(self.gate_index, self.gate.powers_evaluation_point(i)),
+                ExtensionTarget::from_range(self.row, self.gate.powers_evaluation_point(i)),
                 power,
             );
         }

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -305,14 +305,14 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for InterpolationGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| {
+        let local_target = |column| {
             Target::Wire(Wire {
                 row: self.gate_index,
-                column: input,
+                column,
             })
         };
 
-        let local_targets = |inputs: Range<usize>| inputs.map(local_target);
+        let local_targets = |columns: Range<usize>| columns.map(local_target);
 
         let num_points = self.gate.num_points();
         let mut deps = Vec::with_capacity(1 + D + num_points * D);
@@ -326,12 +326,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let get_local_ext = |wire_range: Range<usize>| {
             debug_assert_eq!(wire_range.len(), D);

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -31,11 +31,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
         Vec::new()
     }
 
-    fn generators(
-        &self,
-        _gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, _row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         Vec::new()
     }
 

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -420,14 +420,14 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F>
         (0..SPONGE_WIDTH)
             .map(|i| PoseidonGate::<F, D>::wire_input(i))
             .chain(Some(PoseidonGate::<F, D>::WIRE_SWAP))
-            .map(|input| Target::wire(self.gate_index, input))
+            .map(|column| Target::wire(self.gate_index, column))
             .collect()
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
         let mut state = (0..SPONGE_WIDTH)

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -426,8 +426,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let mut state = (0..SPONGE_WIDTH)
@@ -569,16 +569,16 @@ mod tests {
         let mut inputs = PartialWitness::new();
         inputs.set_wire(
             Wire {
-                gate: gate_index,
-                input: Gate::WIRE_SWAP,
+                row: gate_index,
+                column: Gate::WIRE_SWAP,
             },
             F::ZERO,
         );
         for i in 0..SPONGE_WIDTH {
             inputs.set_wire(
                 Wire {
-                    gate: gate_index,
-                    input: Gate::wire_input(i),
+                    row: gate_index,
+                    column: Gate::wire_input(i),
                 },
                 permutation_inputs[i],
             );
@@ -590,8 +590,8 @@ mod tests {
             F::poseidon(permutation_inputs.try_into().unwrap());
         for i in 0..SPONGE_WIDTH {
             let out = witness.get_wire(Wire {
-                gate: 0,
-                input: Gate::wire_output(i),
+                row: 0,
+                column: Gate::wire_output(i),
             });
             assert_eq!(out, expected_outputs[i]);
         }

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -181,12 +181,8 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
             .collect()
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
-        let gen = PoseidonMdsGenerator::<D> { gate_index };
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
+        let gen = PoseidonMdsGenerator::<D> { row };
         vec![Box::new(gen.adapter())]
     }
 
@@ -209,7 +205,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
 
 #[derive(Clone, Debug)]
 struct PoseidonMdsGenerator<const D: usize> {
-    gate_index: usize,
+    row: usize,
 }
 
 impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F>
@@ -218,14 +214,13 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F>
     fn dependencies(&self) -> Vec<Target> {
         (0..SPONGE_WIDTH)
             .flat_map(|i| {
-                Target::wires_from_range(self.gate_index, PoseidonMdsGate::<F, D>::wires_input(i))
+                Target::wires_from_range(self.row, PoseidonMdsGate::<F, D>::wires_input(i))
             })
             .collect()
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let get_local_get_target =
-            |wire_range| ExtensionTarget::from_range(self.gate_index, wire_range);
+        let get_local_get_target = |wire_range| ExtensionTarget::from_range(self.row, wire_range);
         let get_local_ext =
             |wire_range| witness.get_extension_target(get_local_get_target(wire_range));
 

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -62,11 +62,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PublicInputGat
             .collect()
     }
 
-    fn generators(
-        &self,
-        _gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, _row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         Vec::new()
     }
 

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -329,8 +329,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -318,7 +318,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for RandomAccessGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         let mut deps = vec![local_target(self.gate.wire_access_index(self.copy))];
         for i in 0..self.gate.vec_size() {
@@ -328,13 +328,13 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
-        let mut set_local_wire = |input, value| out_buffer.set_wire(local_wire(input), value);
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
+        let mut set_local_wire = |column, value| out_buffer.set_wire(local_wire(column), value);
 
         let copy = self.copy;
         let vec_size = self.gate.vec_size();

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -52,9 +52,9 @@ impl<const D: usize> ExtensionTarget<D> {
         res.try_into().unwrap()
     }
 
-    pub fn from_range(gate: usize, range: Range<usize>) -> Self {
+    pub fn from_range(row: usize, range: Range<usize>) -> Self {
         debug_assert_eq!(range.end - range.start, D);
-        Target::wires_from_range(gate, range).try_into().unwrap()
+        Target::wires_from_range(row, range).try_into().unwrap()
     }
 }
 

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -306,7 +306,7 @@ impl<F: Field> SimpleGenerator<F> for NonzeroTestGenerator {
 /// Generator used to fill an extra constant.
 #[derive(Debug, Clone)]
 pub(crate) struct ConstantGenerator<F: Field> {
-    pub gate_index: usize,
+    pub row: usize,
     pub constant_index: usize,
     pub wire_index: usize,
     pub constant: F,
@@ -324,9 +324,6 @@ impl<F: Field> SimpleGenerator<F> for ConstantGenerator<F> {
     }
 
     fn run_once(&self, _witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        out_buffer.set_target(
-            Target::wire(self.gate_index, self.wire_index),
-            self.constant,
-        );
+        out_buffer.set_target(Target::wire(self.row, self.wire_index), self.constant);
     }
 }

--- a/plonky2/src/iop/target.rs
+++ b/plonky2/src/iop/target.rs
@@ -16,11 +16,8 @@ pub enum Target {
 }
 
 impl Target {
-    pub fn wire(gate: usize, input: usize) -> Self {
-        Self::Wire(Wire {
-            row: gate,
-            column: input,
-        })
+    pub fn wire(row: usize, column: usize) -> Self {
+        Self::Wire(Wire { row, column })
     }
 
     pub fn is_routable(&self, config: &CircuitConfig) -> bool {
@@ -36,10 +33,7 @@ impl Target {
 
     pub fn index(&self, num_wires: usize, degree: usize) -> usize {
         match self {
-            Target::Wire(Wire {
-                row: gate,
-                column: input,
-            }) => gate * num_wires + input,
+            Target::Wire(Wire { row, column }) => row * num_wires + column,
             Target::VirtualTarget { index } => degree * num_wires + index,
         }
     }

--- a/plonky2/src/iop/target.rs
+++ b/plonky2/src/iop/target.rs
@@ -17,7 +17,10 @@ pub enum Target {
 
 impl Target {
     pub fn wire(gate: usize, input: usize) -> Self {
-        Self::Wire(Wire { gate, input })
+        Self::Wire(Wire {
+            row: gate,
+            column: input,
+        })
     }
 
     pub fn is_routable(&self, config: &CircuitConfig) -> bool {
@@ -33,7 +36,10 @@ impl Target {
 
     pub fn index(&self, num_wires: usize, degree: usize) -> usize {
         match self {
-            Target::Wire(Wire { gate, input }) => gate * num_wires + input,
+            Target::Wire(Wire {
+                row: gate,
+                column: input,
+            }) => gate * num_wires + input,
             Target::VirtualTarget { index } => degree * num_wires + index,
         }
     }

--- a/plonky2/src/iop/target.rs
+++ b/plonky2/src/iop/target.rs
@@ -27,8 +27,8 @@ impl Target {
         }
     }
 
-    pub fn wires_from_range(gate: usize, range: Range<usize>) -> Vec<Self> {
-        range.map(|i| Self::wire(gate, i)).collect()
+    pub fn wires_from_range(row: usize, range: Range<usize>) -> Vec<Self> {
+        range.map(|i| Self::wire(row, i)).collect()
     }
 
     pub fn index(&self, num_wires: usize, degree: usize) -> usize {

--- a/plonky2/src/iop/wire.rs
+++ b/plonky2/src/iop/wire.rs
@@ -2,21 +2,26 @@ use std::ops::Range;
 
 use crate::plonk::circuit_data::CircuitConfig;
 
-/// Represents a wire in the circuit.
+/// Represents a wire in the circuit, seen as a `degree x num_wires` table.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Wire {
-    /// The index of the associated gate.
-    pub gate: usize,
-    /// The index of the gate input wherein this wire is inserted.
-    pub input: usize,
+    /// Row index of the wire.
+    pub row: usize,
+    /// Column index of the wire.
+    pub column: usize,
 }
 
 impl Wire {
     pub fn is_routable(&self, config: &CircuitConfig) -> bool {
-        self.input < config.num_routed_wires
+        self.column < config.num_routed_wires
     }
 
     pub fn from_range(gate: usize, range: Range<usize>) -> Vec<Self> {
-        range.map(|i| Wire { gate, input: i }).collect()
+        range
+            .map(|i| Wire {
+                row: gate,
+                column: i,
+            })
+            .collect()
     }
 }

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -315,7 +315,7 @@ impl<'a, F: Field> PartitionWitness<'a, F> {
         let mut wire_values = vec![vec![F::ZERO; self.degree]; self.num_wires];
         for i in 0..self.degree {
             for j in 0..self.num_wires {
-                let t = Target::Wire(Wire { gate: i, input: j });
+                let t = Target::Wire(Wire { row: i, column: j });
                 if let Some(x) = self.try_get_target(t) {
                     wire_values[j][i] = x;
                 }

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -527,7 +527,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             let gate = self.add_gate(NoopGate, vec![]);
             for w in 0..num_wires {
                 self.add_simple_generator(RandomValueGenerator {
-                    target: Target::Wire(Wire { gate, input: w }),
+                    target: Target::Wire(Wire {
+                        row: gate,
+                        column: w,
+                    }),
                 });
             }
         }
@@ -542,18 +545,18 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             for w in 0..num_routed_wires {
                 self.add_simple_generator(RandomValueGenerator {
                     target: Target::Wire(Wire {
-                        gate: gate_1,
-                        input: w,
+                        row: gate_1,
+                        column: w,
                     }),
                 });
                 self.generate_copy(
                     Target::Wire(Wire {
-                        gate: gate_1,
-                        input: w,
+                        row: gate_1,
+                        column: w,
                     }),
                     Target::Wire(Wire {
-                        gate: gate_2,
-                        input: w,
+                        row: gate_2,
+                        column: w,
                     }),
                 );
             }
@@ -596,7 +599,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         for gate in 0..degree {
             for input in 0..config.num_wires {
-                forest.add(Target::Wire(Wire { gate, input }));
+                forest.add(Target::Wire(Wire {
+                    row: gate,
+                    column: input,
+                }));
             }
         }
 

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -218,12 +218,12 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         );
         constants.resize(gate_type.num_constants(), F::ZERO);
 
-        let gate_index = self.gate_instances.len();
+        let row = self.gate_instances.len();
 
         self.constant_generators
             .extend(gate_type.extra_constant_wires().into_iter().map(
                 |(constant_index, wire_index)| ConstantGenerator {
-                    gate_index,
+                    row,
                     constant_index,
                     wire_index,
                     constant: F::ZERO, // Placeholder; will be replaced later.
@@ -243,7 +243,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             constants,
         });
 
-        gate_index
+        row
     }
 
     fn check_gate_compatibility<G: Gate<F, D>>(&self, gate: &G) {
@@ -400,7 +400,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         })
     }
 
-    /// Find an available slot, of the form `(gate_index, op)` for gate `G` using parameters `params`
+    /// Find an available slot, of the form `(row, op)` for gate `G` using parameters `params`
     /// and constants `constants`. Parameters are any data used to differentiate which gate should be
     /// used for the given operation.
     pub fn find_slot<G: Gate<F, D> + Clone>(
@@ -524,13 +524,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         // For each "regular" blinding factor, we simply add a no-op gate, and insert a random value
         // for each wire.
         for _ in 0..regular_poly_openings {
-            let gate = self.add_gate(NoopGate, vec![]);
+            let row = self.add_gate(NoopGate, vec![]);
             for w in 0..num_wires {
                 self.add_simple_generator(RandomValueGenerator {
-                    target: Target::Wire(Wire {
-                        row: gate,
-                        column: w,
-                    }),
+                    target: Target::Wire(Wire { row, column: w }),
                 });
             }
         }
@@ -683,9 +680,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .zip(self.constant_generators.clone())
         {
             // Set the constant in the constant polynomial.
-            self.gate_instances[const_gen.gate_index].constants[const_gen.constant_index] = c;
+            self.gate_instances[const_gen.row].constants[const_gen.constant_index] = c;
             // Generate a copy between the target and the routable wire.
-            self.connect(Target::wire(const_gen.gate_index, const_gen.wire_index), t);
+            self.connect(Target::wire(const_gen.row, const_gen.wire_index), t);
             // Set the constant in the generator (it's initially set with a dummy value).
             const_gen.set_constant(c);
             self.add_simple_generator(const_gen);

--- a/plonky2/src/plonk/permutation_argument.rs
+++ b/plonky2/src/plonk/permutation_argument.rs
@@ -91,7 +91,10 @@ impl Forest {
         // Here we keep just the Wire targets, filtering out everything else.
         for gate in 0..self.degree {
             for input in 0..self.num_routed_wires {
-                let w = Wire { gate, input };
+                let w = Wire {
+                    row: gate,
+                    column: input,
+                };
                 let t = Target::Wire(w);
                 let x_parent = self.parents[self.target_index(t)];
                 partition.entry(x_parent).or_default().push(w);
@@ -146,9 +149,12 @@ impl WirePartition {
         let mut sigma = Vec::new();
         for input in 0..num_routed_wires {
             for gate in 0..degree {
-                let wire = Wire { gate, input };
+                let wire = Wire {
+                    row: gate,
+                    column: input,
+                };
                 let neighbor = neighbors[&wire];
-                sigma.push(neighbor.input * degree + neighbor.gate);
+                sigma.push(neighbor.column * degree + neighbor.row);
             }
         }
         sigma

--- a/plonky2/src/plonk/permutation_argument.rs
+++ b/plonky2/src/plonk/permutation_argument.rs
@@ -89,12 +89,9 @@ impl Forest {
         let mut partition = HashMap::<_, Vec<_>>::new();
 
         // Here we keep just the Wire targets, filtering out everything else.
-        for gate in 0..self.degree {
-            for input in 0..self.num_routed_wires {
-                let w = Wire {
-                    row: gate,
-                    column: input,
-                };
+        for row in 0..self.degree {
+            for column in 0..self.num_routed_wires {
+                let w = Wire { row, column };
                 let t = Target::Wire(w);
                 let x_parent = self.parents[self.target_index(t)];
                 partition.entry(x_parent).or_default().push(w);
@@ -147,12 +144,9 @@ impl WirePartition {
         }
 
         let mut sigma = Vec::new();
-        for input in 0..num_routed_wires {
-            for gate in 0..degree {
-                let wire = Wire {
-                    row: gate,
-                    column: input,
-                };
+        for column in 0..num_routed_wires {
+            for row in 0..degree {
+                let wire = Wire { row, column };
                 let neighbor = neighbors[&wire];
                 sigma.push(neighbor.column * degree + neighbor.row);
             }

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -155,21 +155,21 @@ impl<const D: usize> ReducingFactorTarget<D> {
         reversed_terms.reverse();
         for chunk in reversed_terms.chunks_exact(max_coeffs_len) {
             let gate = ReducingGate::new(max_coeffs_len);
-            let gate_index = builder.add_gate(gate.clone(), vec![]);
+            let row = builder.add_gate(gate.clone(), vec![]);
 
             builder.connect_extension(
                 self.base,
-                ExtensionTarget::from_range(gate_index, ReducingGate::<D>::wires_alpha()),
+                ExtensionTarget::from_range(row, ReducingGate::<D>::wires_alpha()),
             );
             builder.connect_extension(
                 acc,
-                ExtensionTarget::from_range(gate_index, ReducingGate::<D>::wires_old_acc()),
+                ExtensionTarget::from_range(row, ReducingGate::<D>::wires_old_acc()),
             );
             for (&t, c) in chunk.iter().zip(gate.wires_coeffs()) {
-                builder.connect(t, Target::wire(gate_index, c));
+                builder.connect(t, Target::wire(row, c));
             }
 
-            acc = ExtensionTarget::from_range(gate_index, ReducingGate::<D>::wires_output());
+            acc = ExtensionTarget::from_range(row, ReducingGate::<D>::wires_output());
         }
 
         acc
@@ -205,31 +205,24 @@ impl<const D: usize> ReducingFactorTarget<D> {
         reversed_terms.reverse();
         for chunk in reversed_terms.chunks_exact(max_coeffs_len) {
             let gate = ReducingExtensionGate::new(max_coeffs_len);
-            let gate_index = builder.add_gate(gate.clone(), vec![]);
+            let row = builder.add_gate(gate.clone(), vec![]);
 
             builder.connect_extension(
                 self.base,
-                ExtensionTarget::from_range(gate_index, ReducingExtensionGate::<D>::wires_alpha()),
+                ExtensionTarget::from_range(row, ReducingExtensionGate::<D>::wires_alpha()),
             );
             builder.connect_extension(
                 acc,
-                ExtensionTarget::from_range(
-                    gate_index,
-                    ReducingExtensionGate::<D>::wires_old_acc(),
-                ),
+                ExtensionTarget::from_range(row, ReducingExtensionGate::<D>::wires_old_acc()),
             );
             for (i, &t) in chunk.iter().enumerate() {
                 builder.connect_extension(
                     t,
-                    ExtensionTarget::from_range(
-                        gate_index,
-                        ReducingExtensionGate::<D>::wires_coeff(i),
-                    ),
+                    ExtensionTarget::from_range(row, ReducingExtensionGate::<D>::wires_coeff(i)),
                 );
             }
 
-            acc =
-                ExtensionTarget::from_range(gate_index, ReducingExtensionGate::<D>::wires_output());
+            acc = ExtensionTarget::from_range(row, ReducingExtensionGate::<D>::wires_output());
         }
 
         acc

--- a/u32/src/gadgets/arithmetic_u32.rs
+++ b/u32/src/gadgets/arithmetic_u32.rs
@@ -131,26 +131,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderU32<F, D>
         }
 
         let gate = U32ArithmeticGate::<F, D>::new_from_config(&self.config);
-        let (gate_index, copy) = self.find_slot(gate, &[], &[]);
+        let (row, copy) = self.find_slot(gate, &[], &[]);
 
-        self.connect(
-            Target::wire(gate_index, gate.wire_ith_multiplicand_0(copy)),
-            x.0,
-        );
-        self.connect(
-            Target::wire(gate_index, gate.wire_ith_multiplicand_1(copy)),
-            y.0,
-        );
-        self.connect(Target::wire(gate_index, gate.wire_ith_addend(copy)), z.0);
+        self.connect(Target::wire(row, gate.wire_ith_multiplicand_0(copy)), x.0);
+        self.connect(Target::wire(row, gate.wire_ith_multiplicand_1(copy)), y.0);
+        self.connect(Target::wire(row, gate.wire_ith_addend(copy)), z.0);
 
-        let output_low = U32Target(Target::wire(
-            gate_index,
-            gate.wire_ith_output_low_half(copy),
-        ));
-        let output_high = U32Target(Target::wire(
-            gate_index,
-            gate.wire_ith_output_high_half(copy),
-        ));
+        let output_low = U32Target(Target::wire(row, gate.wire_ith_output_low_half(copy)));
+        let output_high = U32Target(Target::wire(row, gate.wire_ith_output_high_half(copy)));
 
         (output_low, output_high)
     }
@@ -168,22 +156,20 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderU32<F, D>
             _ => {
                 let num_addends = to_add.len();
                 let gate = U32AddManyGate::<F, D>::new_from_config(&self.config, num_addends);
-                let (gate_index, copy) =
+                let (row, copy) =
                     self.find_slot(gate, &[F::from_canonical_usize(num_addends)], &[]);
 
                 for j in 0..num_addends {
                     self.connect(
-                        Target::wire(gate_index, gate.wire_ith_op_jth_addend(copy, j)),
+                        Target::wire(row, gate.wire_ith_op_jth_addend(copy, j)),
                         to_add[j].0,
                     );
                 }
                 let zero = self.zero();
-                self.connect(Target::wire(gate_index, gate.wire_ith_carry(copy)), zero);
+                self.connect(Target::wire(row, gate.wire_ith_carry(copy)), zero);
 
-                let output_low =
-                    U32Target(Target::wire(gate_index, gate.wire_ith_output_result(copy)));
-                let output_high =
-                    U32Target(Target::wire(gate_index, gate.wire_ith_output_carry(copy)));
+                let output_low = U32Target(Target::wire(row, gate.wire_ith_output_result(copy)));
+                let output_high = U32Target(Target::wire(row, gate.wire_ith_output_carry(copy)));
 
                 (output_low, output_high)
             }
@@ -202,18 +188,18 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderU32<F, D>
         let num_addends = to_add.len();
 
         let gate = U32AddManyGate::<F, D>::new_from_config(&self.config, num_addends);
-        let (gate_index, copy) = self.find_slot(gate, &[F::from_canonical_usize(num_addends)], &[]);
+        let (row, copy) = self.find_slot(gate, &[F::from_canonical_usize(num_addends)], &[]);
 
         for j in 0..num_addends {
             self.connect(
-                Target::wire(gate_index, gate.wire_ith_op_jth_addend(copy, j)),
+                Target::wire(row, gate.wire_ith_op_jth_addend(copy, j)),
                 to_add[j].0,
             );
         }
-        self.connect(Target::wire(gate_index, gate.wire_ith_carry(copy)), carry.0);
+        self.connect(Target::wire(row, gate.wire_ith_carry(copy)), carry.0);
 
-        let output = U32Target(Target::wire(gate_index, gate.wire_ith_output_result(copy)));
-        let output_carry = U32Target(Target::wire(gate_index, gate.wire_ith_output_carry(copy)));
+        let output = U32Target(Target::wire(row, gate.wire_ith_output_result(copy)));
+        let output_carry = U32Target(Target::wire(row, gate.wire_ith_output_carry(copy)));
 
         (output, output_carry)
     }
@@ -226,17 +212,17 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilderU32<F, D>
     // Returns x - y - borrow, as a pair (result, borrow), where borrow is 0 or 1 depending on whether borrowing from the next digit is required (iff y + borrow > x).
     fn sub_u32(&mut self, x: U32Target, y: U32Target, borrow: U32Target) -> (U32Target, U32Target) {
         let gate = U32SubtractionGate::<F, D>::new_from_config(&self.config);
-        let (gate_index, copy) = self.find_slot(gate, &[], &[]);
+        let (row, copy) = self.find_slot(gate, &[], &[]);
 
-        self.connect(Target::wire(gate_index, gate.wire_ith_input_x(copy)), x.0);
-        self.connect(Target::wire(gate_index, gate.wire_ith_input_y(copy)), y.0);
+        self.connect(Target::wire(row, gate.wire_ith_input_x(copy)), x.0);
+        self.connect(Target::wire(row, gate.wire_ith_input_y(copy)), y.0);
         self.connect(
-            Target::wire(gate_index, gate.wire_ith_input_borrow(copy)),
+            Target::wire(row, gate.wire_ith_input_borrow(copy)),
             borrow.0,
         );
 
-        let output_result = U32Target(Target::wire(gate_index, gate.wire_ith_output_result(copy)));
-        let output_borrow = U32Target(Target::wire(gate_index, gate.wire_ith_output_borrow(copy)));
+        let output_result = U32Target(Target::wire(row, gate.wire_ith_output_result(copy)));
+        let output_borrow = U32Target(Target::wire(row, gate.wire_ith_output_borrow(copy)));
 
         (output_result, output_borrow)
     }

--- a/u32/src/gadgets/multiple_comparison.rs
+++ b/u32/src/gadgets/multiple_comparison.rs
@@ -29,28 +29,28 @@ pub fn list_le_circuit<F: RichField + Extendable<D>, const D: usize>(
     let mut result = one;
     for i in 0..n {
         let a_le_b_gate = ComparisonGate::new(num_bits, num_chunks);
-        let a_le_b_gate_index = builder.add_gate(a_le_b_gate.clone(), vec![]);
+        let a_le_b_row = builder.add_gate(a_le_b_gate.clone(), vec![]);
         builder.connect(
-            Target::wire(a_le_b_gate_index, a_le_b_gate.wire_first_input()),
+            Target::wire(a_le_b_row, a_le_b_gate.wire_first_input()),
             a[i],
         );
         builder.connect(
-            Target::wire(a_le_b_gate_index, a_le_b_gate.wire_second_input()),
+            Target::wire(a_le_b_row, a_le_b_gate.wire_second_input()),
             b[i],
         );
-        let a_le_b_result = Target::wire(a_le_b_gate_index, a_le_b_gate.wire_result_bool());
+        let a_le_b_result = Target::wire(a_le_b_row, a_le_b_gate.wire_result_bool());
 
         let b_le_a_gate = ComparisonGate::new(num_bits, num_chunks);
-        let b_le_a_gate_index = builder.add_gate(b_le_a_gate.clone(), vec![]);
+        let b_le_a_row = builder.add_gate(b_le_a_gate.clone(), vec![]);
         builder.connect(
-            Target::wire(b_le_a_gate_index, b_le_a_gate.wire_first_input()),
+            Target::wire(b_le_a_row, b_le_a_gate.wire_first_input()),
             b[i],
         );
         builder.connect(
-            Target::wire(b_le_a_gate_index, b_le_a_gate.wire_second_input()),
+            Target::wire(b_le_a_row, b_le_a_gate.wire_second_input()),
             a[i],
         );
-        let b_le_a_result = Target::wire(b_le_a_gate_index, b_le_a_gate.wire_result_bool());
+        let b_le_a_result = Target::wire(b_le_a_row, b_le_a_gate.wire_result_bool());
 
         let these_limbs_equal = builder.mul(a_le_b_result, b_le_a_result);
         let these_limbs_less_than = builder.sub(one, b_le_a_result);

--- a/u32/src/gadgets/range_check.rs
+++ b/u32/src/gadgets/range_check.rs
@@ -12,12 +12,9 @@ pub fn range_check_u32_circuit<F: RichField + Extendable<D>, const D: usize>(
 ) {
     let num_input_limbs = vals.len();
     let gate = U32RangeCheckGate::<F, D>::new(num_input_limbs);
-    let gate_index = builder.add_gate(gate, vec![]);
+    let row = builder.add_gate(gate, vec![]);
 
     for i in 0..num_input_limbs {
-        builder.connect(
-            Target::wire(gate_index, gate.wire_ith_input_limb(i)),
-            vals[i].0,
-        );
+        builder.connect(Target::wire(row, gate.wire_ith_input_limb(i)), vals[i].0);
     }
 }

--- a/u32/src/gates/add_many_u32.rs
+++ b/u32/src/gates/add_many_u32.rs
@@ -292,8 +292,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/u32/src/gates/add_many_u32.rs
+++ b/u32/src/gates/add_many_u32.rs
@@ -282,7 +282,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for U32AddManyGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         (0..self.gate.num_addends)
             .map(|j| local_target(self.gate.wire_ith_op_jth_addend(self.i, j)))
@@ -291,12 +291,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let addends: Vec<_> = (0..self.gate.num_addends)
             .map(|j| get_local_wire(self.gate.wire_ith_op_jth_addend(self.i, j)))

--- a/u32/src/gates/arithmetic_u32.rs
+++ b/u32/src/gates/arithmetic_u32.rs
@@ -290,7 +290,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for U32ArithmeticGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         vec![
             local_target(self.gate.wire_ith_multiplicand_0(self.i)),
@@ -300,12 +300,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let multiplicand_0 = get_local_wire(self.gate.wire_ith_multiplicand_0(self.i));
         let multiplicand_1 = get_local_wire(self.gate.wire_ith_multiplicand_1(self.i));

--- a/u32/src/gates/arithmetic_u32.rs
+++ b/u32/src/gates/arithmetic_u32.rs
@@ -193,17 +193,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         (0..self.num_ops)
             .map(|i| {
                 let g: Box<dyn WitnessGenerator<F>> = Box::new(
                     U32ArithmeticGenerator {
                         gate: *self,
-                        gate_index,
+                        row,
                         i,
                         _phantom: PhantomData,
                     }
@@ -281,7 +277,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 #[derive(Clone, Debug)]
 struct U32ArithmeticGenerator<F: RichField + Extendable<D>, const D: usize> {
     gate: U32ArithmeticGate<F, D>,
-    gate_index: usize,
+    row: usize,
     i: usize,
     _phantom: PhantomData<F>,
 }
@@ -290,7 +286,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for U32ArithmeticGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         vec![
             local_target(self.gate.wire_ith_multiplicand_0(self.i)),
@@ -301,7 +297,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/u32/src/gates/arithmetic_u32.rs
+++ b/u32/src/gates/arithmetic_u32.rs
@@ -301,8 +301,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/u32/src/gates/comparison.rs
+++ b/u32/src/gates/comparison.rs
@@ -283,13 +283,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = ComparisonGenerator::<F, D> {
-            gate_index,
+            row,
             gate: self.clone(),
         };
         vec![Box::new(gen.adapter())]
@@ -397,7 +393,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
 #[derive(Debug)]
 struct ComparisonGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: ComparisonGate<F, D>,
 }
 
@@ -405,7 +401,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for ComparisonGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         vec![
             local_target(self.gate.wire_first_input()),
@@ -415,7 +411,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/u32/src/gates/comparison.rs
+++ b/u32/src/gates/comparison.rs
@@ -405,7 +405,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for ComparisonGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         vec![
             local_target(self.gate.wire_first_input()),
@@ -414,12 +414,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let first_input = get_local_wire(self.gate.wire_first_input());
         let second_input = get_local_wire(self.gate.wire_second_input());

--- a/u32/src/gates/comparison.rs
+++ b/u32/src/gates/comparison.rs
@@ -415,8 +415,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/u32/src/gates/subtraction_u32.rs
+++ b/u32/src/gates/subtraction_u32.rs
@@ -274,7 +274,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for U32SubtractionGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         vec![
             local_target(self.gate.wire_ith_input_x(self.i)),
@@ -284,12 +284,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     }
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let input_x = get_local_wire(self.gate.wire_ith_input_x(self.i));
         let input_y = get_local_wire(self.gate.wire_ith_input_y(self.i));

--- a/u32/src/gates/subtraction_u32.rs
+++ b/u32/src/gates/subtraction_u32.rs
@@ -182,17 +182,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32Subtraction
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         (0..self.num_ops)
             .map(|i| {
                 let g: Box<dyn WitnessGenerator<F>> = Box::new(
                     U32SubtractionGenerator {
                         gate: *self,
-                        gate_index,
+                        row,
                         i,
                         _phantom: PhantomData,
                     }
@@ -265,7 +261,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 #[derive(Clone, Debug)]
 struct U32SubtractionGenerator<F: RichField + Extendable<D>, const D: usize> {
     gate: U32SubtractionGate<F, D>,
-    gate_index: usize,
+    row: usize,
     i: usize,
     _phantom: PhantomData<F>,
 }
@@ -274,7 +270,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
     for U32SubtractionGenerator<F, D>
 {
     fn dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         vec![
             local_target(self.gate.wire_ith_input_x(self.i)),
@@ -285,7 +281,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/u32/src/gates/subtraction_u32.rs
+++ b/u32/src/gates/subtraction_u32.rs
@@ -285,8 +285,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
 
     fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/waksman/src/gates/switch.rs
+++ b/waksman/src/gates/switch.rs
@@ -154,15 +154,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, 
         constraints
     }
 
-    fn generators(
-        &self,
-        gate_index: usize,
-        _local_constants: &[F],
-    ) -> Vec<Box<dyn WitnessGenerator<F>>> {
+    fn generators(&self, row: usize, _local_constants: &[F]) -> Vec<Box<dyn WitnessGenerator<F>>> {
         (0..self.num_copies)
             .map(|c| {
                 let g: Box<dyn WitnessGenerator<F>> = Box::new(SwitchGenerator::<F, D> {
-                    gate_index,
+                    row,
                     gate: *self,
                     copy: c,
                 });
@@ -215,14 +211,14 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D> for
 
 #[derive(Debug)]
 struct SwitchGenerator<F: RichField + Extendable<D>, const D: usize> {
-    gate_index: usize,
+    row: usize,
     gate: SwitchGate<F, D>,
     copy: usize,
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     fn in_out_dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         let mut deps = Vec::new();
         for e in 0..self.gate.chunk_size {
@@ -236,7 +232,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     }
 
     fn in_switch_dependencies(&self) -> Vec<Target> {
-        let local_target = |column| Target::wire(self.gate_index, column);
+        let local_target = |column| Target::wire(self.row, column);
 
         let mut deps = Vec::new();
         for e in 0..self.gate.chunk_size {
@@ -250,7 +246,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
 
     fn run_in_out(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 
@@ -280,7 +276,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
 
     fn run_in_switch(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |column| Wire {
-            row: self.gate_index,
+            row: self.row,
             column,
         };
 

--- a/waksman/src/gates/switch.rs
+++ b/waksman/src/gates/switch.rs
@@ -250,8 +250,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
 
     fn run_in_out(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));
@@ -280,8 +280,8 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
 
     fn run_in_switch(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
         let local_wire = |input| Wire {
-            gate: self.gate_index,
-            input,
+            row: self.gate_index,
+            column: input,
         };
 
         let get_local_wire = |input| witness.get_wire(local_wire(input));

--- a/waksman/src/gates/switch.rs
+++ b/waksman/src/gates/switch.rs
@@ -222,7 +222,7 @@ struct SwitchGenerator<F: RichField + Extendable<D>, const D: usize> {
 
 impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     fn in_out_dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         let mut deps = Vec::new();
         for e in 0..self.gate.chunk_size {
@@ -236,7 +236,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     }
 
     fn in_switch_dependencies(&self) -> Vec<Target> {
-        let local_target = |input| Target::wire(self.gate_index, input);
+        let local_target = |column| Target::wire(self.gate_index, column);
 
         let mut deps = Vec::new();
         for e in 0..self.gate.chunk_size {
@@ -249,12 +249,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     }
 
     fn run_in_out(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let switch_bool_wire = local_wire(self.gate.wire_switch_bool(self.copy));
 
@@ -279,12 +279,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGenerator<F, D> {
     }
 
     fn run_in_switch(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        let local_wire = |input| Wire {
+        let local_wire = |column| Wire {
             row: self.gate_index,
-            column: input,
+            column,
         };
 
-        let get_local_wire = |input| witness.get_wire(local_wire(input));
+        let get_local_wire = |column| witness.get_wire(local_wire(column));
 
         let switch_bool = get_local_wire(self.gate.wire_switch_bool(self.copy));
         for e in 0..self.gate.chunk_size {

--- a/waksman/src/permutation.rs
+++ b/waksman/src/permutation.rs
@@ -82,30 +82,24 @@ fn create_switch<F: RichField + Extendable<D>, const D: usize>(
 
     let gate = SwitchGate::new_from_config(&builder.config, chunk_size);
     let params = vec![F::from_canonical_usize(chunk_size)];
-    let (gate_index, next_copy) = builder.find_slot(gate, &params, &[]);
+    let (row, next_copy) = builder.find_slot(gate, &params, &[]);
 
     let mut c = Vec::new();
     let mut d = Vec::new();
     for e in 0..chunk_size {
         builder.connect(
             a1[e],
-            Target::wire(gate_index, gate.wire_first_input(next_copy, e)),
+            Target::wire(row, gate.wire_first_input(next_copy, e)),
         );
         builder.connect(
             a2[e],
-            Target::wire(gate_index, gate.wire_second_input(next_copy, e)),
+            Target::wire(row, gate.wire_second_input(next_copy, e)),
         );
-        c.push(Target::wire(
-            gate_index,
-            gate.wire_first_output(next_copy, e),
-        ));
-        d.push(Target::wire(
-            gate_index,
-            gate.wire_second_output(next_copy, e),
-        ));
+        c.push(Target::wire(row, gate.wire_first_output(next_copy, e)));
+        d.push(Target::wire(row, gate.wire_second_output(next_copy, e)));
     }
 
-    let switch = Target::wire(gate_index, gate.wire_switch_bool(next_copy));
+    let switch = Target::wire(row, gate.wire_switch_bool(next_copy));
 
     (switch, c, d)
 }

--- a/waksman/src/sorting.rs
+++ b/waksman/src/sorting.rs
@@ -54,10 +54,10 @@ pub fn assert_le<F: RichField + Extendable<D>, const D: usize>(
     num_chunks: usize,
 ) {
     let gate = AssertLessThanGate::new(bits, num_chunks);
-    let gate_index = builder.add_gate(gate.clone(), vec![]);
+    let row = builder.add_gate(gate.clone(), vec![]);
 
-    builder.connect(Target::wire(gate_index, gate.wire_first_input()), lhs);
-    builder.connect(Target::wire(gate_index, gate.wire_second_input()), rhs);
+    builder.connect(Target::wire(row, gate.wire_first_input()), lhs);
+    builder.connect(Target::wire(row, gate.wire_second_input()), rhs);
 }
 
 /// Sort memory operations by address value, then by timestamp value.


### PR DESCRIPTION
Rename fields of the `Wire` struct from `Wire { gate, input}` to `Wire {row, column}` to make the Plonk tabular circuit representation more explicit.