### PR TITLE
Fix Clippy on `main`

### DIFF
--- a/ecdsa/src/lib.rs
+++ b/ecdsa/src/lib.rs
@@ -1,4 +1,7 @@
 #![allow(clippy::needless_range_loop)]
+// Below lint is currently broken and produces false positives.
+// TODO: Remove this override when Clippy is patched.
+#![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod curve;
 pub mod gadgets;


### PR DESCRIPTION
The Clippy complaint:
```
error: you are deriving `PartialEq` and can implement `Eq`
 --> ecdsa/src/curve/ecdsa.rs:7:53
  |
7 | #[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
  |                                                     ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
  |
  = note: `-D clippy::derive-partial-eq-without-eq` implied by `-D warnings`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq
```
(and two analogous ones)

This is clearly a false positive since `Eq` _is_ being derived.

This PR disables the broken lint until it is fixed.