### PR TITLE
Fix EVM dependency list

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -10,7 +10,7 @@ plonky2_util = { path = "../util" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"
 ethereum-types = "0.13.1"
-itertools = "0.10.0"
+itertools = "0.10.3"
 log = "0.4.14"
 pest = "2.1.3"
 pest_derive = "2.1.0"


### PR DESCRIPTION
Upgrades the `itertools` dependency to version `0.10.3`. That’s the first release that includes `multiunzip`. The build fails with older versions.