### PR TITLE
CTL: limbs (CPU) <-> bits (logic)

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -116,11 +116,11 @@ mod tests {
             let mut row = [F::ZERO; logic::columns::NUM_COLUMNS];
 
             assert_eq!(logic::PACKED_LIMB_BITS, 16);
-            for col in logic::columns::INPUT0_PACKED {
-                row[col] = F::from_canonical_u16(rng.gen());
+            for col in logic::columns::INPUT0 {
+                row[col] = F::from_bool(rng.gen());
             }
-            for col in logic::columns::INPUT1_PACKED {
-                row[col] = F::from_canonical_u16(rng.gen());
+            for col in logic::columns::INPUT1 {
+                row[col] = F::from_bool(rng.gen());
             }
             let op: usize = rng.gen_range(0..3);
             let op_col = [
@@ -148,6 +148,7 @@ mod tests {
         memory_stark.generate_trace(memory_ops)
     }
 
+    // JNTODO
     fn make_cpu_trace(
         num_keccak_perms: usize,
         num_logic_rows: usize,
@@ -207,13 +208,22 @@ mod tests {
             .map(|(col, opcode)| logic_trace[col].values[i] * F::from_canonical_u64(opcode))
             .sum();
             for (cols_cpu, cols_logic) in [
-                (cpu::columns::LOGIC_INPUT0, logic::columns::INPUT0_PACKED),
-                (cpu::columns::LOGIC_INPUT1, logic::columns::INPUT1_PACKED),
-                (cpu::columns::LOGIC_OUTPUT, logic::columns::RESULT),
+                (cpu::columns::LOGIC_INPUT0, logic::columns::INPUT0),
+                (cpu::columns::LOGIC_INPUT1, logic::columns::INPUT1),
             ] {
-                for (col_cpu, col_logic) in cols_cpu.zip(cols_logic) {
-                    row[col_cpu] = logic_trace[col_logic].values[i];
+                for (col_cpu, limb_cols_logic) in
+                    cols_cpu.zip(logic::columns::limb_bit_cols_for_input(cols_logic))
+                {
+                    row[col_cpu] = limb_cols_logic
+                        .enumerate()
+                        .map(|(j, col_logic)| {
+                            logic_trace[col_logic].values[i] * F::from_canonical_u64(1 << j)
+                        })
+                        .sum();
                 }
+            }
+            for (col_cpu, col_logic) in cpu::columns::LOGIC_OUTPUT.zip(logic::columns::RESULT) {
+                row[col_cpu] = logic_trace[col_logic].values[i];
             }
             cpu_stark.generate(&mut row);
             cpu_trace_rows.push(row);

--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -87,7 +87,7 @@ mod tests {
         add_virtual_all_proof, set_all_proof_target, verify_proof_circuit,
     };
     use crate::stark::Stark;
-    use crate::util::trace_rows_to_poly_values;
+    use crate::util::{limb_from_bits_le, trace_rows_to_poly_values};
     use crate::verifier::verify_proof;
     use crate::{cpu, keccak, memory};
 
@@ -213,12 +213,8 @@ mod tests {
                 for (col_cpu, limb_cols_logic) in
                     cols_cpu.zip(logic::columns::limb_bit_cols_for_input(cols_logic))
                 {
-                    row[col_cpu] = limb_cols_logic
-                        .enumerate()
-                        .map(|(j, col_logic)| {
-                            logic_trace[col_logic].values[i] * F::from_canonical_u64(1 << j)
-                        })
-                        .sum();
+                    row[col_cpu] =
+                        limb_from_bits_le(limb_cols_logic.map(|col| logic_trace[col].values[i]));
                 }
             }
             for (col_cpu, col_logic) in cpu::columns::LOGIC_OUTPUT.zip(logic::columns::RESULT) {

--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -148,7 +148,6 @@ mod tests {
         memory_stark.generate_trace(memory_ops)
     }
 
-    // JNTODO
     fn make_cpu_trace(
         num_keccak_perms: usize,
         num_logic_rows: usize,

--- a/evm/src/logic.rs
+++ b/evm/src/logic.rs
@@ -66,6 +66,8 @@ pub struct LogicStark<F, const D: usize> {
 }
 
 enum Op {
+    // The `Zero` op is just for convenience. The all-zero row already satisfies the constraints;
+    // `Zero` lets us  call `generate` on it without crashing.
     Zero,
     And,
     Or,

--- a/evm/src/util.rs
+++ b/evm/src/util.rs
@@ -1,7 +1,33 @@
 use itertools::Itertools;
+use plonky2::field::extension_field::Extendable;
 use plonky2::field::field_types::Field;
+use plonky2::field::packed_field::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::util::transpose;
+
+/// Construct an integer from its constituent bits (in little-endian order)
+pub fn limb_from_bits_le<P: PackedField>(iter: impl IntoIterator<Item = P>) -> P {
+    // TODO: This is technically wrong, as 1 << i won't be canonical for all fields...
+    iter.into_iter()
+        .enumerate()
+        .map(|(i, bit)| bit * P::Scalar::from_canonical_u64(1 << i))
+        .sum()
+}
+
+/// Construct an integer from its constituent bits (in little-endian order): recursive edition
+pub fn limb_from_bits_le_recursive<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    iter: impl IntoIterator<Item = ExtensionTarget<D>>,
+) -> ExtensionTarget<D> {
+    iter.into_iter()
+        .enumerate()
+        .fold(builder.zero_extension(), |acc, (i, bit)| {
+            // TODO: This is technically wrong, as 1 << i won't be canonical for all fields...
+            builder.mul_const_add_extension(F::from_canonical_u64(1 << i), bit, acc)
+        })
+}
 
 /// A helper function to transpose a row-wise trace and put it in the format that `prove` expects.
 pub fn trace_rows_to_poly_values<F: Field, const COLUMNS: usize>(


### PR DESCRIPTION
Uses the linear combination `Column` API to do CTL directly between limbs in the CPU table and bits in the logic table. Removes 32 columns from the logic table.