### PR TITLE
ASM macro support

### DIFF
--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -8,6 +8,7 @@ use crate::cpu::kernel::parser::parse;
 #[allow(dead_code)] // TODO: Should be used once witness generation is done.
 pub(crate) fn combined_kernel() -> Kernel {
     let files = vec![
+        include_str!("asm/basic_macros.asm"),
         include_str!("asm/exp.asm"),
         include_str!("asm/storage_read.asm"),
         include_str!("asm/storage_write.asm"),

--- a/evm/src/cpu/kernel/asm/basic_macros.asm
+++ b/evm/src/cpu/kernel/asm/basic_macros.asm
@@ -1,0 +1,28 @@
+// If pred is zero, yields z; otherwise, yields nz
+%macro select
+    // stack: pred, nz, z
+    iszero
+    // stack: pred == 0, nz, z
+    dup1
+    // stack: pred == 0, pred == 0, nz, z
+    iszero
+    // stack: pred != 0, pred == 0, nz, z
+    swap3
+    // stack: z, pred == 0, nz, pred != 0
+    mul
+    // stack: (pred == 0) * z, nz, pred != 0
+    swap2
+    // stack: pred != 0, nz, (pred == 0) * z
+    mul
+    // stack: (pred != 0) * nz, (pred == 0) * z
+    add
+    // stack: (pred != 0) * nz + (pred == 0) * z
+%endmacro
+
+%macro square
+    // stack: x
+    dup1
+    // stack: x, x
+    mul
+    // stack: x^2
+%endmacro

--- a/evm/src/cpu/kernel/asm/exp.asm
+++ b/evm/src/cpu/kernel/asm/exp.asm
@@ -10,8 +10,6 @@
 /// Note that this correctly handles exp(0, 0) == 1.
 
 global exp:
-// We don't seem to handle global labels yet, so this function has a local label too for now:
-exp:
     // stack: x, e, retdest
     dup2
     // stack: e, x, e, retdest
@@ -41,9 +39,7 @@ step_case:
     // stack: e / 2, recursion_return, x, e, retdest
     dup3
     // stack: x, e / 2, recursion_return, x, e, retdest
-    dup1
-    // stack: x, x, e / 2, recursion_return, x, e, retdest
-    mul
+    %square
     // stack: x * x, e / 2, recursion_return, x, e, retdest
     push exp
     // stack: exp, x * x, e / 2, recursion_return, x, e, retdest

--- a/evm/src/cpu/kernel/ast.rs
+++ b/evm/src/cpu/kernel/ast.rs
@@ -6,8 +6,12 @@ pub(crate) struct File {
     pub(crate) body: Vec<Item>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Item {
+    /// Defines a new macro.
+    MacroDef(String, Vec<Item>),
+    /// Calls a macro.
+    MacroCall(String),
     /// Declares a global label.
     GlobalLabelDeclaration(String),
     /// Declares a label that is local to the current file.
@@ -21,13 +25,13 @@ pub(crate) enum Item {
 }
 
 /// The target of a `PUSH` operation.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum PushTarget {
     Literal(Literal),
     Label(String),
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Literal {
     Decimal(String),
     Hex(String),

--- a/evm/src/cpu/kernel/evm_asm.pest
+++ b/evm/src/cpu/kernel/evm_asm.pest
@@ -12,7 +12,9 @@ literal_decimal = @{ ASCII_DIGIT+ }
 literal_hex = @{ ^"0x" ~ ASCII_HEX_DIGIT+ }
 literal = { literal_hex | literal_decimal }
 
-item = { global_label | local_label | bytes_item | push_instruction | nullary_instruction }
+item = { macro_def | macro_call | global_label | local_label | bytes_item | push_instruction | nullary_instruction }
+macro_def = { ^"%macro" ~ identifier ~ item* ~ ^"%endmacro" }
+macro_call = ${ "%" ~ !(^"macro" | ^"endmacro") ~ identifier }
 global_label = { ^"GLOBAL " ~ identifier ~ ":" }
 local_label = { identifier ~ ":" }
 bytes_item = { ^"BYTES " ~ literal ~ ("," ~ literal)* }

--- a/evm/src/cpu/kernel/parser.rs
+++ b/evm/src/cpu/kernel/parser.rs
@@ -20,6 +20,12 @@ pub(crate) fn parse(s: &str) -> File {
 fn parse_item(item: Pair<Rule>) -> Item {
     let item = item.into_inner().next().unwrap();
     match item.as_rule() {
+        Rule::macro_def => {
+            let mut inner = item.into_inner();
+            let name = inner.next().unwrap().as_str().into();
+            Item::MacroDef(name, inner.map(parse_item).collect())
+        }
+        Rule::macro_call => Item::MacroCall(item.into_inner().next().unwrap().as_str().into()),
         Rule::global_label => {
             Item::GlobalLabelDeclaration(item.into_inner().next().unwrap().as_str().into())
         }


### PR DESCRIPTION
Also recognize global labels as a `PUSH` target; previously it only considered local labels.