### PR TITLE
Util for assembling EVM code to hex

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -10,6 +10,7 @@ plonky2_util = { path = "../util" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"
 ethereum-types = "0.13.1"
+hex = { version = "0.4.3", optional = true }
 itertools = "0.10.3"
 log = "0.4.14"
 pest = "2.1.3"
@@ -18,3 +19,10 @@ rayon = "1.5.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 keccak-rust = { git = "https://github.com/npwardberkeley/keccak-rust" }
+
+[features]
+asmtools = ["hex"]
+
+[[bin]]
+name = "assemble"
+required-features = ["asmtools"]

--- a/evm/src/bin/assemble.rs
+++ b/evm/src/bin/assemble.rs
@@ -1,0 +1,13 @@
+use std::env;
+use std::fs;
+
+use hex::encode;
+use plonky2_evm::cpu::kernel::assemble_to_bytes;
+
+fn main() {
+    let mut args = env::args();
+    args.next();
+    let file_contents: Vec<_> = args.map(|path| fs::read_to_string(path).unwrap()).collect();
+    let assembled = assemble_to_bytes(&file_contents[..]);
+    println!("{}", encode(&assembled));
+}

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -13,7 +13,7 @@ const BYTES_PER_OFFSET: u8 = 3;
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Kernel {
-    code: Vec<u8>,
+    pub code: Vec<u8>,
     global_labels: HashMap<String, usize>,
 }
 

--- a/evm/src/cpu/kernel/mod.rs
+++ b/evm/src/cpu/kernel/mod.rs
@@ -3,3 +3,14 @@ mod assembler;
 mod ast;
 mod opcodes;
 mod parser;
+
+use assembler::assemble;
+use parser::parse;
+
+/// Assemble files, outputting bytes.
+/// This is for debugging the kernel only.
+pub fn assemble_to_bytes(files: &[String]) -> Vec<u8> {
+    let parsed_files: Vec<_> = files.iter().map(|f| parse(f)).collect();
+    let kernel = assemble(parsed_files);
+    kernel.code
+}


### PR DESCRIPTION
This is just for debugging the kernel. It's fully disposable.