### PR TITLE
Tweak Merkle proof API and make it public

### DIFF
--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -208,7 +208,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             with_context!(
                 self,
                 &format!("verify {}'th initial Merkle proof", i),
-                self.verify_merkle_proof_with_cap_index::<H>(
+                self.verify_merkle_proof_to_cap_with_cap_index::<H>(
                     evals.clone(),
                     x_index_bits,
                     cap_index,
@@ -351,7 +351,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             with_context!(
                 self,
                 "verify FRI round Merkle proof.",
-                self.verify_merkle_proof_with_cap_index::<C::Hasher>(
+                self.verify_merkle_proof_to_cap_with_cap_index::<C::Hasher>(
                     flatten_target(evals),
                     &coset_index_bits,
                     cap_index,

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -8,7 +8,7 @@ use crate::fri::proof::{FriChallenges, FriInitialTreeProof, FriProof, FriQueryRo
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
 use crate::fri::{FriConfig, FriParams};
 use crate::hash::hash_types::RichField;
-use crate::hash::merkle_proofs::verify_merkle_proof;
+use crate::hash::merkle_proofs::verify_merkle_proof_to_cap;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::util::reducing::ReducingFactor;
@@ -116,7 +116,7 @@ where
     [(); H::HASH_SIZE]:,
 {
     for ((evals, merkle_proof), cap) in proof.evals_proofs.iter().zip(initial_merkle_caps) {
-        verify_merkle_proof::<F, H>(evals.clone(), x_index, cap, merkle_proof)?;
+        verify_merkle_proof_to_cap::<F, H>(evals.clone(), x_index, cap, merkle_proof)?;
     }
 
     Ok(())
@@ -224,7 +224,7 @@ where
             challenges.fri_betas[i],
         );
 
-        verify_merkle_proof::<F, C::Hasher>(
+        verify_merkle_proof_to_cap::<F, C::Hasher>(
             flatten(evals),
             coset_index,
             &proof.commit_phase_merkle_caps[i],

--- a/plonky2/src/gadgets/split_join.rs
+++ b/plonky2/src/gadgets/split_join.rs
@@ -13,7 +13,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// bit of the integer, with little-endian ordering.
     /// Verifies that the decomposition is correct by using `k` `BaseSum<2>` gates
     /// with `k` such that `k * num_routed_wires >= num_bits`.
-    pub(crate) fn split_le(&mut self, integer: Target, num_bits: usize) -> Vec<BoolTarget> {
+    pub fn split_le(&mut self, integer: Target, num_bits: usize) -> Vec<BoolTarget> {
         if num_bits == 0 {
             return Vec::new();
         }

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -209,7 +209,7 @@ mod tests {
     use plonky2_field::extension::Extendable;
 
     use super::*;
-    use crate::hash::merkle_proofs::verify_merkle_proof;
+    use crate::hash::merkle_proofs::verify_merkle_proof_to_cap;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
     fn random_data<F: RichField>(n: usize, k: usize) -> Vec<Vec<F>> {
@@ -226,7 +226,7 @@ mod tests {
         let tree = MerkleTree::<F, C::Hasher>::new(leaves.clone(), cap_height);
         for (i, leaf) in leaves.into_iter().enumerate() {
             let proof = tree.prove(i);
-            verify_merkle_proof(leaf, i, &tree.cap, &proof)?;
+            verify_merkle_proof_to_cap(leaf, i, &tree.cap, &proof)?;
         }
         Ok(())
     }


### PR DESCRIPTION
- Add `_to_cap` to existing methods for clarity
- Add variants which deal with Merkle roots instead of caps
- Simplify `verify_merkle_proof_to_cap` - it can call `verify_merkle_proof_to_cap_with_cap_index`
- Make them all public except `verify_merkle_proof_to_cap_with_cap_index`, which is pretty niche

Resolves #582.