### PR TITLE
`CommonCircuitData` serialization

### DIFF
--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -177,6 +177,8 @@ where
         CompressedProofWithPublicInputs::from_bytes(compressed_proof_bytes, cd)?;
     assert_eq!(compressed_proof, compressed_proof_from_bytes);
 
+    let circuit_data_bytes = cd.to_bytes()?;
+
     Ok(())
 }
 

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -50,6 +50,7 @@ impl FriConfig {
 /// FRI parameters, including generated parameters which are specific to an instance size, in
 /// contrast to `FriConfig` which is user-specified and independent of instance size.
 #[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct FriParams {
     /// User-specified FRI configuration.
     pub config: FriConfig,

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -1,7 +1,9 @@
-use plonky2_field::extension::Extendable;
-use plonky2_field::packed::PackedField;
 use std::io::Result as IoResult;
 
+use plonky2_field::extension::Extendable;
+use plonky2_field::packed::PackedField;
+
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -17,8 +19,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0 x y + c1 z`. If the config
 /// supports enough routed wires, it can support several such operations in one gate.

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
@@ -15,8 +16,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate which can perform a weighted multiply-add, i.e. `result = c0 x y + c1 z`. If the config
 /// supports enough routed wires, it can support several such operations in one gate.

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -1,11 +1,12 @@
-use std::marker::PhantomData;
 use std::io::Result as IoResult;
+use std::marker::PhantomData;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 use plonky2_field::types::{Field, Field64};
 use plonky2_util::{bits_u64, ceil_div_usize};
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -22,8 +23,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 // TODO: replace/merge this gate with `ComparisonGate`.
 

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -1,5 +1,5 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -1,3 +1,4 @@
+use std::io::Result as IoResult;
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 
@@ -12,6 +13,9 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// A gate which takes a single constant parameter and outputs that value.
 #[derive(Copy, Clone, Debug)]
@@ -34,6 +38,19 @@ impl ConstantGate {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
     fn id(&self) -> String {
         format!("{:?}", self)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::Constant
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        dst.write_usize(self.num_consts)
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        let num_consts = src.read_usize()?;
+        Ok(Self { num_consts })
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -1,7 +1,9 @@
 use std::io::Result as IoResult;
+
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -14,8 +16,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate which takes a single constant parameter and outputs that value.
 #[derive(Copy, Clone, Debug)]

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -1,11 +1,12 @@
-use std::marker::PhantomData;
 use std::io::Result as IoResult;
+use std::marker::PhantomData;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::ops::Square;
 use plonky2_field::packed::PackedField;
 use plonky2_field::types::Field;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -22,8 +23,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate for raising a value to a power.
 #[derive(Clone, Debug)]

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::ops::Square;
@@ -20,6 +21,9 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// A gate for raising a value to a power.
 #[derive(Clone, Debug)]
@@ -71,6 +75,19 @@ impl<F: RichField + Extendable<D>, const D: usize> ExponentiationGate<F, D> {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ExponentiationGate<F, D> {
     fn id(&self) -> String {
         format!("{:?}<D={}>", self, D)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::Exponentiation
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        dst.write_usize(self.num_power_bits)
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        let num_power_bits = src.read_usize()?;
+        Ok(Self::new(num_power_bits))
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/gate.rs
+++ b/plonky2/src/gates/gate.rs
@@ -39,7 +39,6 @@ pub enum GateKind {
     Reducing,
 }
 
-
 /// A custom gate.
 pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + Sync {
     fn id(&self) -> String;
@@ -47,7 +46,9 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
     fn kind(&self) -> GateKind;
 
     fn serialize(&self, dst: &mut Buffer) -> IoResult<()>;
-    fn deserialize(src: &mut Buffer) -> IoResult<Self> where Self: Sized;
+    fn deserialize(src: &mut Buffer) -> IoResult<Self>
+    where
+        Self: Sized;
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension>;
 

--- a/plonky2/src/gates/gate.rs
+++ b/plonky2/src/gates/gate.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
 use std::hash::{Hash, Hasher};
+use std::io::Result as IoResult;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -17,10 +18,36 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
 };
+use crate::util::serialization::Buffer;
+
+pub enum GateKind {
+    ArithmeticBase,
+    ArithmeticExt,
+    AssertLe,
+    BaseSum,
+    Constant,
+    Exponentiation,
+    Interpolation,
+    LowDegreeInterpolation,
+    MulExt,
+    Noop,
+    PoseidonMds,
+    Poseidon,
+    PublicInput,
+    RandomAccess,
+    ReducingExt,
+    Reducing,
+}
+
 
 /// A custom gate.
 pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + Sync {
     fn id(&self) -> String;
+
+    fn kind(&self) -> GateKind;
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()>;
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> where Self: Sized;
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension>;
 

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::ops::Range;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::algebra::PolynomialCoeffsAlgebra;
 use plonky2_field::extension::{Extendable, FieldExtension};
@@ -18,6 +19,9 @@ use crate::iop::wire::Wire;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// Interpolation gate with constraints of degree at most `1<<subgroup_bits`.
 /// `eval_unfiltered_recursively` uses less gates than `LowDegreeInterpolationGate`.
@@ -86,6 +90,19 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
 {
     fn id(&self) -> String {
         format!("{:?}<D={}>", self, D)
+    }
+    
+    fn kind(&self) -> GateKind {
+        GateKind::Interpolation
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        dst.write_usize(self.subgroup_bits)
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        let subgroup_bits = src.read_usize()?;
+        Ok(Self::new(subgroup_bits))
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -1,12 +1,13 @@
+use std::io::Result as IoResult;
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::io::Result as IoResult;
 
 use plonky2_field::extension::algebra::PolynomialCoeffsAlgebra;
 use plonky2_field::extension::{Extendable, FieldExtension};
 use plonky2_field::interpolation::interpolant;
 use plonky2_field::polynomial::PolynomialCoeffs;
 
+use super::gate::GateKind;
 use crate::gadgets::interpolation::InterpolationGate;
 use crate::gadgets::polynomial::PolynomialCoeffsExtAlgebraTarget;
 use crate::gates::gate::Gate;
@@ -20,8 +21,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// Interpolation gate with constraints of degree at most `1<<subgroup_bits`.
 /// `eval_unfiltered_recursively` uses less gates than `LowDegreeInterpolationGate`.
@@ -91,7 +90,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
     fn id(&self) -> String {
         format!("{:?}<D={}>", self, D)
     }
-    
+
     fn kind(&self) -> GateKind {
         GateKind::Interpolation
     }

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -1,6 +1,6 @@
+use std::io::Result as IoResult;
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::io::Result as IoResult;
 
 use plonky2_field::extension::algebra::PolynomialCoeffsAlgebra;
 use plonky2_field::extension::{Extendable, FieldExtension};
@@ -8,6 +8,7 @@ use plonky2_field::interpolation::interpolant;
 use plonky2_field::polynomial::PolynomialCoeffs;
 use plonky2_field::types::Field;
 
+use super::gate::GateKind;
 use crate::gadgets::interpolation::InterpolationGate;
 use crate::gadgets::polynomial::PolynomialCoeffsExtAlgebraTarget;
 use crate::gates::gate::Gate;
@@ -21,8 +22,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// Interpolation gate with constraints of degree 2.
 /// `eval_unfiltered_recursively` uses more gates than `HighDegreeInterpolationGate`.
@@ -91,7 +90,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LowDegreeInter
     }
 
     fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
-       dst.write_usize(self.subgroup_bits)
+        dst.write_usize(self.subgroup_bits)
     }
 
     fn deserialize(src: &mut Buffer) -> IoResult<Self> {

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
@@ -13,6 +14,9 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// A gate which can perform a weighted multiplication, i.e. `result = c0 x y`. If the config
 /// supports enough routed wires, it can support several such operations in one gate.
@@ -49,6 +53,19 @@ impl<const D: usize> MulExtensionGate<D> {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGate<D> {
     fn id(&self) -> String {
         format!("{:?}", self)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::MulExt
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        dst.write_usize(self.num_ops)
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        let num_ops = src.read_usize()?;
+        Ok(Self { num_ops })
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
@@ -15,8 +16,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate which can perform a weighted multiplication, i.e. `result = c0 x y`. If the config
 /// supports enough routed wires, it can support several such operations in one gate.

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -1,6 +1,8 @@
-use plonky2_field::extension::Extendable;
 use std::io::Result as IoResult;
 
+use plonky2_field::extension::Extendable;
+
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::hash::hash_types::RichField;
 use crate::iop::ext_target::ExtensionTarget;
@@ -8,8 +10,6 @@ use crate::iop::generator::WitnessGenerator;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate which does nothing.
 pub struct NoopGate;

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -1,4 +1,5 @@
 use plonky2_field::extension::Extendable;
+use std::io::Result as IoResult;
 
 use crate::gates::gate::Gate;
 use crate::hash::hash_types::RichField;
@@ -6,6 +7,9 @@ use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::generator::WitnessGenerator;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// A gate which does nothing.
 pub struct NoopGate;
@@ -13,6 +17,18 @@ pub struct NoopGate;
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
     fn id(&self) -> String {
         "NoopGate".into()
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::Noop
+    }
+
+    fn serialize(&self, _dst: &mut Buffer) -> IoResult<()> {
+        Ok(())
+    }
+
+    fn deserialize(_src: &mut Buffer) -> IoResult<Self> {
+        Ok(Self)
     }
 
     fn eval_unfiltered(&self, _vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::types::Field;
@@ -17,6 +18,9 @@ use crate::iop::wire::Wire;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// Evaluates a full Poseidon permutation with 12 state elements.
 ///
@@ -99,6 +103,18 @@ impl<F: RichField + Extendable<D>, const D: usize> PoseidonGate<F, D> {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PoseidonGate<F, D> {
     fn id(&self) -> String {
         format!("{:?}<WIDTH={}>", self, SPONGE_WIDTH)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::Poseidon
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        Ok(())
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        Ok(PoseidonGate::new())
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -1,9 +1,10 @@
-use std::marker::PhantomData;
 use std::io::Result as IoResult;
+use std::marker::PhantomData;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::types::Field;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::poseidon_mds::PoseidonMdsGate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -19,8 +20,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// Evaluates a full Poseidon permutation with 12 state elements.
 ///
@@ -109,11 +108,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PoseidonGate<F
         GateKind::Poseidon
     }
 
-    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+    fn serialize(&self, _dst: &mut Buffer) -> IoResult<()> {
         Ok(())
     }
 
-    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+    fn deserialize(_src: &mut Buffer) -> IoResult<Self> {
         Ok(PoseidonGate::new())
     }
 

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::ops::Range;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::algebra::ExtensionAlgebra;
 use plonky2_field::extension::Extendable;
@@ -17,6 +18,9 @@ use crate::iop::target::Target;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 #[derive(Debug)]
 pub struct PoseidonMdsGate<F: RichField + Extendable<D> + Poseidon, const D: usize> {
@@ -118,6 +122,18 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> PoseidonMdsGate<F,
 impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for PoseidonMdsGate<F, D> {
     fn id(&self) -> String {
         format!("{:?}<WIDTH={}>", self, SPONGE_WIDTH)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::PoseidonMds
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        Ok(())
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        Ok(PoseidonMdsGate::new())
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -1,12 +1,13 @@
+use std::io::Result as IoResult;
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::io::Result as IoResult;
 
 use plonky2_field::extension::algebra::ExtensionAlgebra;
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
 use plonky2_field::types::Field;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
@@ -19,8 +20,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 #[derive(Debug)]
 pub struct PoseidonMdsGate<F: RichField + Extendable<D> + Poseidon, const D: usize> {
@@ -128,11 +127,11 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for Pos
         GateKind::PoseidonMds
     }
 
-    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+    fn serialize(&self, _dst: &mut Buffer) -> IoResult<()> {
         Ok(())
     }
 
-    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+    fn deserialize(_src: &mut Buffer) -> IoResult<Self> {
         Ok(PoseidonMdsGate::new())
     }
 

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
@@ -14,6 +15,9 @@ use crate::plonk::vars::{
     EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
     EvaluationVarsBasePacked,
 };
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// A gate whose first four wires will be equal to a hash of public inputs.
 pub struct PublicInputGate;
@@ -27,6 +31,18 @@ impl PublicInputGate {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PublicInputGate {
     fn id(&self) -> String {
         "PublicInputGate".into()
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::PublicInput
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        Ok(())
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        Ok(Self)
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -16,8 +17,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate whose first four wires will be equal to a hash of public inputs.
 pub struct PublicInputGate;
@@ -37,11 +36,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PublicInputGat
         GateKind::PublicInput
     }
 
-    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+    fn serialize(&self, _dst: &mut Buffer) -> IoResult<()> {
         Ok(())
     }
 
-    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+    fn deserialize(_src: &mut Buffer) -> IoResult<Self> {
         Ok(Self)
     }
 

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -1,11 +1,12 @@
-use std::marker::PhantomData;
 use std::io::Result as IoResult;
+use std::marker::PhantomData;
 
 use itertools::Itertools;
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 use plonky2_field::types::Field;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
 use crate::gates::util::StridedConstraintConsumer;
@@ -22,8 +23,6 @@ use crate::plonk::vars::{
     EvaluationVarsBasePacked,
 };
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// A gate for checking that a particular element of a list matches a given value.
 #[derive(Copy, Clone, Debug)]

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
@@ -14,8 +15,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the base field.
 #[derive(Debug, Clone)]
@@ -71,7 +70,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingGate<D
         Ok(())
     }
 
-    fn deserialize(src: &mut Buffer) -> IoResult<Self> where Self: Sized {
+    fn deserialize(src: &mut Buffer) -> IoResult<Self>
+    where
+        Self: Sized,
+    {
         let num_coeffs = src.read_usize()?;
         Ok(Self::new(num_coeffs))
     }

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -1,4 +1,5 @@
 use std::ops::Range;
+use std::io::Result as IoResult;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
@@ -12,6 +13,9 @@ use crate::iop::target::Target;
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::util::serialization::Buffer;
+
+use super::gate::GateKind;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone)]
@@ -59,6 +63,19 @@ impl<const D: usize> ReducingExtensionGate<D> {
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingExtensionGate<D> {
     fn id(&self) -> String {
         format!("{:?}", self)
+    }
+
+    fn kind(&self) -> GateKind {
+        GateKind::ReducingExt
+    }
+
+    fn serialize(&self, dst: &mut Buffer) -> IoResult<()> {
+        dst.write_usize(self.num_coeffs)
+    }
+
+    fn deserialize(src: &mut Buffer) -> IoResult<Self> {
+        let num_coeffs = src.read_usize()?;
+        Ok(Self::new(num_coeffs)) 
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -1,9 +1,10 @@
-use std::ops::Range;
 use std::io::Result as IoResult;
+use std::ops::Range;
 
 use plonky2_field::extension::Extendable;
 use plonky2_field::extension::FieldExtension;
 
+use super::gate::GateKind;
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
 use crate::hash::hash_types::RichField;
@@ -14,8 +15,6 @@ use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::util::serialization::Buffer;
-
-use super::gate::GateKind;
 
 /// Computes `sum alpha^i c_i` for a vector `c_i` of `num_coeffs` elements of the extension field.
 #[derive(Debug, Clone)]
@@ -75,7 +74,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingExtens
 
     fn deserialize(src: &mut Buffer) -> IoResult<Self> {
         let num_coeffs = src.read_usize()?;
-        Ok(Self::new(num_coeffs)) 
+        Ok(Self::new(num_coeffs))
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -10,7 +10,7 @@ use crate::hash::hash_types::RichField;
 pub(crate) const UNUSED_SELECTOR: usize = u32::MAX as usize;
 
 #[derive(Debug, Clone)]
-pub(crate) struct SelectorsInfo {
+pub struct SelectorsInfo {
     pub(crate) selector_indices: Vec<usize>,
     pub(crate) groups: Vec<Range<usize>>,
 }

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -10,6 +10,7 @@ use crate::hash::hash_types::RichField;
 pub(crate) const UNUSED_SELECTOR: usize = u32::MAX as usize;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct SelectorsInfo {
     pub(crate) selector_indices: Vec<usize>,
     pub(crate) groups: Vec<Range<usize>>,

--- a/plonky2/src/gates/util.rs
+++ b/plonky2/src/gates/util.rs
@@ -2,8 +2,6 @@ use std::marker::PhantomData;
 
 use plonky2_field::packed::PackedField;
 
-use super::gate::GateKind;
-
 /// Writes constraints yielded by a gate to a buffer, with a given stride.
 /// Permits us to abstract the underlying memory layout. In particular, we can make a matrix of
 /// constraints where every column is an evaluation point and every row is a constraint index, with

--- a/plonky2/src/gates/util.rs
+++ b/plonky2/src/gates/util.rs
@@ -2,6 +2,8 @@ use std::marker::PhantomData;
 
 use plonky2_field::packed::PackedField;
 
+use super::gate::GateKind;
+
 /// Writes constraints yielded by a gate to a buffer, with a given stride.
 /// Permits us to abstract the underlying memory layout. In particular, we can make a matrix of
 /// constraints where every column is an evaluation point and every row is a constraint index, with

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -439,6 +439,13 @@ mod tests {
             CompressedProofWithPublicInputs::from_bytes(compressed_proof_bytes, cd)?;
         assert_eq!(compressed_proof, compressed_proof_from_bytes);
 
+        let cd_bytes = cd.to_bytes()?;
+        info!("Common circuit data len: {} bytes", cd_bytes.len());
+        let cd_from_bytes = CommonCircuitData::from_bytes(cd_bytes)?;
+
+        #[cfg(test)]
+        assert_eq!(cd, &cd_from_bytes);
+
         Ok(())
     }
 

--- a/plonky2/src/util/serialization.rs
+++ b/plonky2/src/util/serialization.rs
@@ -41,24 +41,24 @@ use crate::plonk::proof::{
     CompressedProof, CompressedProofWithPublicInputs, OpeningSet, Proof, ProofWithPublicInputs,
 };
 
- const ARITHMETIC_BASE_TAG: u8 = 0;
- const ARITHMETIC_EXT_TAG: u8 = 1;
- const ASSERT_LE_TAG: u8 = 2;
- const BASE_SUM_TAG: u8 = 3;
- const CONSTANT_TAG: u8 = 4;
- const EXPONENTIATION_TAG: u8 = 5;
- const INTERPOLATION_TAG: u8 = 6;
- const LOW_DEGREE_INTERPOLATION_TAG: u8 = 7;
- const MUL_EXT_TAG: u8 = 8;
- const NOOP_TAG: u8 = 9;
- const POSEIDON_MDS_TAG: u8 = 10;
- const POSEIDON_TAG: u8 = 11;
- const PUBLIC_INPUT_TAG: u8 = 12;
- const RANDOM_ACCESS_TAG: u8 = 13;
- const REDUCING_EXT_TAG: u8 = 14;
- const REDUCING_TAG: u8 = 15;
+const ARITHMETIC_BASE_TAG: u8 = 0;
+const ARITHMETIC_EXT_TAG: u8 = 1;
+const ASSERT_LE_TAG: u8 = 2;
+const BASE_SUM_TAG: u8 = 3;
+const CONSTANT_TAG: u8 = 4;
+const EXPONENTIATION_TAG: u8 = 5;
+const INTERPOLATION_TAG: u8 = 6;
+const LOW_DEGREE_INTERPOLATION_TAG: u8 = 7;
+const MUL_EXT_TAG: u8 = 8;
+const NOOP_TAG: u8 = 9;
+const POSEIDON_MDS_TAG: u8 = 10;
+const POSEIDON_TAG: u8 = 11;
+const PUBLIC_INPUT_TAG: u8 = 12;
+const RANDOM_ACCESS_TAG: u8 = 13;
+const REDUCING_EXT_TAG: u8 = 14;
+const REDUCING_TAG: u8 = 15;
 
- fn gate_kind_tag(gate_kind: GateKind) -> u8 {
+fn gate_kind_tag(gate_kind: GateKind) -> u8 {
     match gate_kind {
         GateKind::ArithmeticBase => ARITHMETIC_BASE_TAG,
         GateKind::ArithmeticExt => ARITHMETIC_EXT_TAG,

--- a/plonky2/src/util/serialization.rs
+++ b/plonky2/src/util/serialization.rs
@@ -41,24 +41,24 @@ use crate::plonk::proof::{
     CompressedProof, CompressedProofWithPublicInputs, OpeningSet, Proof, ProofWithPublicInputs,
 };
 
-pub(crate) const ARITHMETIC_BASE_TAG: u8 = 0;
-pub(crate) const ARITHMETIC_EXT_TAG: u8 = 1;
-pub(crate) const ASSERT_LE_TAG: u8 = 2;
-pub(crate) const BASE_SUM_TAG: u8 = 3;
-pub(crate) const CONSTANT_TAG: u8 = 4;
-pub(crate) const EXPONENTIATION_TAG: u8 = 5;
-pub(crate) const INTERPOLATION_TAG: u8 = 6;
-pub(crate) const LOW_DEGREE_INTERPOLATION_TAG: u8 = 7;
-pub(crate) const MUL_EXT_TAG: u8 = 8;
-pub(crate) const NOOP_TAG: u8 = 9;
-pub(crate) const POSEIDON_MDS_TAG: u8 = 10;
-pub(crate) const POSEIDON_TAG: u8 = 11;
-pub(crate) const PUBLIC_INPUT_TAG: u8 = 12;
-pub(crate) const RANDOM_ACCESS_TAG: u8 = 13;
-pub(crate) const REDUCING_EXT_TAG: u8 = 14;
-pub(crate) const REDUCING_TAG: u8 = 15;
+ const ARITHMETIC_BASE_TAG: u8 = 0;
+ const ARITHMETIC_EXT_TAG: u8 = 1;
+ const ASSERT_LE_TAG: u8 = 2;
+ const BASE_SUM_TAG: u8 = 3;
+ const CONSTANT_TAG: u8 = 4;
+ const EXPONENTIATION_TAG: u8 = 5;
+ const INTERPOLATION_TAG: u8 = 6;
+ const LOW_DEGREE_INTERPOLATION_TAG: u8 = 7;
+ const MUL_EXT_TAG: u8 = 8;
+ const NOOP_TAG: u8 = 9;
+ const POSEIDON_MDS_TAG: u8 = 10;
+ const POSEIDON_TAG: u8 = 11;
+ const PUBLIC_INPUT_TAG: u8 = 12;
+ const RANDOM_ACCESS_TAG: u8 = 13;
+ const REDUCING_EXT_TAG: u8 = 14;
+ const REDUCING_TAG: u8 = 15;
 
-pub(crate) fn gate_kind_tag(gate_kind: GateKind) -> u8 {
+ fn gate_kind_tag(gate_kind: GateKind) -> u8 {
     match gate_kind {
         GateKind::ArithmeticBase => ARITHMETIC_BASE_TAG,
         GateKind::ArithmeticExt => ARITHMETIC_EXT_TAG,


### PR DESCRIPTION
Add support for serializing / deserializing `CommonCircuitData` to the serialization [`Buffer`](https://github.com/mir-protocol/plonky2/blob/dec0765fb554f76e80b8e314b5991318be20609b/plonky2/src/util/serialization.rs#L26).