### PR TITLE
Allow constants to be passed from Rust into our assembly

### DIFF
--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -1,9 +1,18 @@
 //! Loads each kernel assembly file and concatenates them.
 
+use std::collections::HashMap;
+
+use ethereum_types::U256;
 use itertools::Itertools;
 
 use super::assembler::{assemble, Kernel};
 use crate::cpu::kernel::parser::parse;
+
+pub fn evm_constants() -> HashMap<String, U256> {
+    let mut c = HashMap::new();
+    c.insert("SEGMENT_ID_TXN_DATA".into(), 0.into()); // TODO: Replace with actual segment ID.
+    c
+}
 
 #[allow(dead_code)] // TODO: Should be used once witness generation is done.
 pub(crate) fn combined_kernel() -> Kernel {
@@ -18,7 +27,7 @@ pub(crate) fn combined_kernel() -> Kernel {
     ];
 
     let parsed_files = files.iter().map(|f| parse(f)).collect_vec();
-    assemble(parsed_files)
+    assemble(parsed_files, evm_constants())
 }
 
 #[cfg(test)]

--- a/evm/src/cpu/kernel/ast.rs
+++ b/evm/src/cpu/kernel/ast.rs
@@ -30,6 +30,7 @@ pub(crate) enum PushTarget {
     Literal(Literal),
     Label(String),
     MacroVar(String),
+    Constant(String),
 }
 
 #[derive(Clone, Debug)]

--- a/evm/src/cpu/kernel/evm_asm.pest
+++ b/evm/src/cpu/kernel/evm_asm.pest
@@ -13,6 +13,7 @@ literal_hex = @{ ^"0x" ~ ASCII_HEX_DIGIT+ }
 literal = { literal_hex | literal_decimal }
 
 variable = ${ "$" ~ identifier }
+constant = ${ "@" ~ identifier }
 
 item = { macro_def | macro_call | global_label | local_label | bytes_item | push_instruction | nullary_instruction }
 macro_def = { ^"%macro" ~ identifier ~ macro_paramlist? ~ item* ~ ^"%endmacro" }
@@ -23,7 +24,7 @@ global_label = { ^"GLOBAL " ~ identifier ~ ":" }
 local_label = { identifier ~ ":" }
 bytes_item = { ^"BYTES " ~ literal ~ ("," ~ literal)* }
 push_instruction = { ^"PUSH " ~ push_target }
-push_target = { literal | identifier | variable }
+push_target = { literal | identifier | variable | constant }
 nullary_instruction = { identifier }
 
 file = { SOI ~ item* ~ silent_eoi }

--- a/evm/src/cpu/kernel/mod.rs
+++ b/evm/src/cpu/kernel/mod.rs
@@ -7,10 +7,12 @@ mod parser;
 use assembler::assemble;
 use parser::parse;
 
+use crate::cpu::kernel::aggregator::evm_constants;
+
 /// Assemble files, outputting bytes.
 /// This is for debugging the kernel only.
 pub fn assemble_to_bytes(files: &[String]) -> Vec<u8> {
     let parsed_files: Vec<_> = files.iter().map(|f| parse(f)).collect();
-    let kernel = assemble(parsed_files);
+    let kernel = assemble(parsed_files, evm_constants());
     kernel.code
 }

--- a/evm/src/cpu/kernel/parser.rs
+++ b/evm/src/cpu/kernel/parser.rs
@@ -77,6 +77,7 @@ fn parse_push_target(target: Pair<Rule>) -> PushTarget {
         Rule::literal => PushTarget::Literal(parse_literal(inner)),
         Rule::identifier => PushTarget::Label(inner.as_str().into()),
         Rule::variable => PushTarget::MacroVar(inner.into_inner().next().unwrap().as_str().into()),
+        Rule::constant => PushTarget::Constant(inner.into_inner().next().unwrap().as_str().into()),
         _ => panic!("Unexpected {:?}", inner.as_rule()),
     }
 }


### PR DESCRIPTION
Roughly like environment variables. So we don't have to declare things like segment IDs twice.