### PR TITLE
Simplify memory table

### DIFF
--- a/evm/src/memory/columns.rs
+++ b/evm/src/memory/columns.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
 
-// Columns for the same memory operations, ordered by (addr, timestamp).
+// Columns for memory operations, ordered by (addr, timestamp).
 pub(crate) const TIMESTAMP: usize = 0;
 pub(crate) const IS_READ: usize = TIMESTAMP + 1;
 pub(crate) const ADDR_CONTEXT: usize = IS_READ + 1;

--- a/evm/src/memory/columns.rs
+++ b/evm/src/memory/columns.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 
 use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
 
+// Columns for the same memory operations, ordered by (addr, timestamp).
 pub(crate) const TIMESTAMP: usize = 0;
 pub(crate) const IS_READ: usize = TIMESTAMP + 1;
 pub(crate) const ADDR_CONTEXT: usize = IS_READ + 1;
@@ -17,24 +18,11 @@ pub(crate) const fn value_limb(i: usize) -> usize {
     VALUE_START + i
 }
 
-// Separate columns for the same memory operations, sorted by (addr, timestamp).
-pub(crate) const SORTED_TIMESTAMP: usize = VALUE_START + VALUE_LIMBS;
-pub(crate) const SORTED_IS_READ: usize = SORTED_TIMESTAMP + 1;
-pub(crate) const SORTED_ADDR_CONTEXT: usize = SORTED_IS_READ + 1;
-pub(crate) const SORTED_ADDR_SEGMENT: usize = SORTED_ADDR_CONTEXT + 1;
-pub(crate) const SORTED_ADDR_VIRTUAL: usize = SORTED_ADDR_SEGMENT + 1;
-
-const SORTED_VALUE_START: usize = SORTED_ADDR_VIRTUAL + 1;
-pub(crate) const fn sorted_value_limb(i: usize) -> usize {
-    debug_assert!(i < VALUE_LIMBS);
-    SORTED_VALUE_START + i
-}
-
-// Flags to indicate whether this part of the address differs from the next row (in the sorted
-// columns), and the previous parts do not differ.
-// That is, e.g., `SEGMENT_FIRST_CHANGE` is `F::ONE` iff `SORTED_ADDR_CONTEXT` is the same in this
-// row and the next, but `SORTED_ADDR_SEGMENT` is not.
-pub(crate) const CONTEXT_FIRST_CHANGE: usize = SORTED_VALUE_START + VALUE_LIMBS;
+// Flags to indicate whether this part of the address differs from the next row,
+// and the previous parts do not differ.
+// That is, e.g., `SEGMENT_FIRST_CHANGE` is `F::ONE` iff `ADDR_CONTEXT` is the same in this
+// row and the next, but `ADDR_SEGMENT` is not.
+pub(crate) const CONTEXT_FIRST_CHANGE: usize = VALUE_START + VALUE_LIMBS;
 pub(crate) const SEGMENT_FIRST_CHANGE: usize = CONTEXT_FIRST_CHANGE + 1;
 pub(crate) const VIRTUAL_FIRST_CHANGE: usize = SEGMENT_FIRST_CHANGE + 1;
 
@@ -45,7 +33,7 @@ pub(crate) const fn is_channel(channel: usize) -> usize {
     IS_CHANNEL_START + channel
 }
 
-// We use a range check to ensure sorting.
+// We use a range check to enforce the ordering.
 pub(crate) const RANGE_CHECK: usize = IS_CHANNEL_START + NUM_CHANNELS;
 // The counter column (used for the range check) starts from 0 and increments.
 pub(crate) const COUNTER: usize = RANGE_CHECK + 1;

--- a/evm/src/memory/memory_stark.rs
+++ b/evm/src/memory/memory_stark.rs
@@ -197,14 +197,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
         &self,
         mut memory_ops: Vec<MemoryOp<F>>,
     ) -> Vec<[F; NUM_COLUMNS]> {
-        memory_ops.sort_by_key(|op| {
-            (
-                op.context.to_canonical_u64(),
-                op.segment.to_canonical_u64(),
-                op.virt.to_canonical_u64(),
-                op.timestamp.to_canonical_u64(),
-            )
-        });
+        memory_ops.sort_by_key(|op| (op.context, op.segment, op.virt, op.timestamp));
 
         let num_ops = memory_ops.len();
 


### PR DESCRIPTION
By no longer storing unsorted operations; they are effectively stored in the CPU table already.

I ran into some issues with sorting, since the existing sort method didn't include `is_channel` columns. Rather than update the existing method, I removed it and added a sort on the `MemoryOp`s, which I think seems cleaner.