### PR TITLE
More realistic padding rows in memory table

### DIFF
--- a/evm/src/generation/state.rs
+++ b/evm/src/generation/state.rs
@@ -62,7 +62,7 @@ impl<F: Field> GenerationState<F> {
         let context = self.current_context;
         let value = self.memory.contexts[context].segments[segment].get(virt);
         self.memory.log.push(MemoryOp {
-            channel_index,
+            channel_index: Some(channel_index),
             timestamp,
             is_read: true,
             context,
@@ -84,7 +84,7 @@ impl<F: Field> GenerationState<F> {
         let timestamp = self.cpu_rows.len();
         let context = self.current_context;
         self.memory.log.push(MemoryOp {
-            channel_index,
+            channel_index: Some(channel_index),
             timestamp,
             is_read: false,
             context,

--- a/evm/src/memory/columns.rs
+++ b/evm/src/memory/columns.rs
@@ -1,7 +1,5 @@
 //! Memory registers.
 
-use std::ops::Range;
-
 use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
 
 // Columns for memory operations, ordered by (addr, timestamp).
@@ -40,8 +38,5 @@ pub(crate) const COUNTER: usize = RANGE_CHECK + 1;
 // Helper columns for the permutation argument used to enforce the range check.
 pub(crate) const RANGE_CHECK_PERMUTED: usize = COUNTER + 1;
 pub(crate) const COUNTER_PERMUTED: usize = RANGE_CHECK_PERMUTED + 1;
-
-// Columns to be padded at the top with zeroes, before the permutation argument takes place.
-pub(crate) const COLUMNS_TO_PAD: Range<usize> = TIMESTAMP..RANGE_CHECK + 1;
 
 pub(crate) const NUM_COLUMNS: usize = COUNTER_PERMUTED + 1;

--- a/evm/src/memory/memory_stark.rs
+++ b/evm/src/memory/memory_stark.rs
@@ -256,7 +256,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
 
     fn pad_memory_ops(memory_ops: &mut Vec<MemoryOp<F>>) {
         let num_ops = memory_ops.len();
-        let max_range_check = get_max_range_check(&memory_ops);
+        let max_range_check = get_max_range_check(memory_ops);
         let num_ops_padded = num_ops.max(max_range_check + 1).next_power_of_two();
         let to_pad = num_ops_padded - num_ops;
 


### PR DESCRIPTION
This adds padding rows which satisfy the ordering checks. To ensure that they also satisfy the value consistency checks, I just copied the address and value from the last operation.

I think this method of padding feels more natural, though it is a big more code since we need to calculate the max range check in a different way. But on the plus side, the constraints are a bit smaller and simpler.

Also added a few constraints that I think we need for soundness:
- Each `is_channel` flag is bool.
- Sum of `is_channel` flags is bool.
- Dummy operations must be reads (otherwise the prover could put writes in the memory table which aren't in the CPU table).