### PR TITLE
Have `make_kernel` log the size of each (assembled) file

### DIFF
--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -36,6 +36,7 @@ mod tests {
 
     use anyhow::Result;
     use ethereum_types::U256;
+    use log::debug;
     use rand::{thread_rng, Rng};
 
     use crate::cpu::kernel::aggregator::combined_kernel;
@@ -43,9 +44,13 @@ mod tests {
 
     #[test]
     fn make_kernel() {
+        let _ = env_logger::Builder::from_default_env()
+            .format_timestamp(None)
+            .try_init();
+
         // Make sure we can parse and assemble the entire kernel.
         let kernel = combined_kernel();
-        println!("Kernel size: {} bytes", kernel.code.len());
+        debug!("Total kernel size: {} bytes", kernel.code.len());
     }
 
     fn u256ify<'a>(hexes: impl IntoIterator<Item = &'a str>) -> Result<Vec<U256>> {

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use ethereum_types::U256;
 use itertools::izip;
+use log::debug;
 
 use super::ast::PushTarget;
 use crate::cpu::kernel::ast::Literal;
@@ -49,7 +50,10 @@ pub(crate) fn assemble(files: Vec<File>, constants: HashMap<String, U256>) -> Ke
     }
     let mut code = vec![];
     for (file, locals) in izip!(expanded_files, local_labels) {
+        let prev_len = code.len();
         assemble_file(file, &mut code, locals, &global_labels);
+        let file_len = code.len() - prev_len;
+        debug!("Assembled file size: {} bytes", file_len);
     }
     assert_eq!(code.len(), offset, "Code length doesn't match offset.");
     Kernel {


### PR DESCRIPTION
For now it doesn't log filenames, but we can compare against the list of filenames in `combined_kernel`.

Current output:
```
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 0 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 49 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 387 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 27365 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 0 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 11 bytes
[DEBUG plonky2_evm::cpu::kernel::assembler] Assembled file size: 7 bytes
[DEBUG plonky2_evm::cpu::kernel::aggregator::tests] Total kernel size: 27819 bytes
```

This shows that most of our kernel code is from `curve_add.asm`, which makes sense since it invovles a couple uses of the large `inverse` macro.  Thankfully that will be replaced at some point.