### PR TITLE
Store memory values as `U256`s

### DIFF
--- a/evm/src/cpu/bootstrap_kernel.rs
+++ b/evm/src/cpu/bootstrap_kernel.rs
@@ -17,7 +17,6 @@ use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::keccak_util::keccakf_u32s;
 use crate::cpu::public_inputs::NUM_PUBLIC_INPUTS;
 use crate::generation::state::GenerationState;
-use crate::memory;
 use crate::memory::segments::Segment;
 use crate::memory::NUM_CHANNELS;
 use crate::vars::{StarkEvaluationTargets, StarkEvaluationVars};
@@ -50,11 +49,8 @@ pub(crate) fn generate_bootstrap_kernel<F: Field>(state: &mut GenerationState<F>
         // Write this chunk to memory, while simultaneously packing its bytes into a u32 word.
         let mut packed_bytes: u32 = 0;
         for (addr, byte) in chunk {
-            let mut value = [F::ZERO; memory::VALUE_LIMBS];
-            value[0] = F::from_canonical_u8(byte);
-
             let channel = addr % NUM_CHANNELS;
-            state.set_mem_current(channel, Segment::Code, addr, value);
+            state.set_mem_current(channel, Segment::Code, addr, byte.into());
 
             packed_bytes = (packed_bytes << 8) | byte as u32;
         }

--- a/evm/src/generation/memory.rs
+++ b/evm/src/generation/memory.rs
@@ -1,19 +1,18 @@
-use plonky2::field::types::Field;
+use ethereum_types::U256;
 
 use crate::memory::memory_stark::MemoryOp;
 use crate::memory::segments::Segment;
-use crate::memory::VALUE_LIMBS;
 
 #[allow(unused)] // TODO: Should be used soon.
 #[derive(Debug)]
-pub(crate) struct MemoryState<F: Field> {
+pub(crate) struct MemoryState {
     /// A log of each memory operation, in the order that it occurred.
-    pub log: Vec<MemoryOp<F>>,
+    pub log: Vec<MemoryOp>,
 
-    pub contexts: Vec<MemoryContextState<F>>,
+    pub contexts: Vec<MemoryContextState>,
 }
 
-impl<F: Field> Default for MemoryState<F> {
+impl Default for MemoryState {
     fn default() -> Self {
         Self {
             log: vec![],
@@ -24,28 +23,27 @@ impl<F: Field> Default for MemoryState<F> {
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct MemoryContextState<F: Field> {
+pub(crate) struct MemoryContextState {
     /// The content of each memory segment.
-    pub segments: [MemorySegmentState<F>; Segment::COUNT],
+    pub segments: [MemorySegmentState; Segment::COUNT],
 }
 
 #[derive(Default, Debug)]
-pub(crate) struct MemorySegmentState<F: Field> {
-    pub content: Vec<[F; VALUE_LIMBS]>,
+pub(crate) struct MemorySegmentState {
+    pub content: Vec<U256>,
 }
 
-impl<F: Field> MemorySegmentState<F> {
-    pub(super) fn get(&self, virtual_addr: usize) -> [F; VALUE_LIMBS] {
+impl MemorySegmentState {
+    pub(super) fn get(&self, virtual_addr: usize) -> U256 {
         self.content
             .get(virtual_addr)
             .copied()
-            .unwrap_or([F::ZERO; VALUE_LIMBS])
+            .unwrap_or(U256::zero())
     }
 
-    pub(super) fn set(&mut self, virtual_addr: usize, value: [F; VALUE_LIMBS]) {
+    pub(super) fn set(&mut self, virtual_addr: usize, value: U256) {
         if virtual_addr + 1 > self.content.len() {
-            self.content
-                .resize(virtual_addr + 1, [F::ZERO; VALUE_LIMBS]);
+            self.content.resize(virtual_addr + 1, U256::zero());
         }
         self.content[virtual_addr] = value;
     }

--- a/evm/src/generation/state.rs
+++ b/evm/src/generation/state.rs
@@ -15,7 +15,7 @@ pub(crate) struct GenerationState<F: Field> {
     pub(crate) current_cpu_row: CpuColumnsView<F>,
 
     pub(crate) current_context: usize,
-    pub(crate) memory: MemoryState<F>,
+    pub(crate) memory: MemoryState,
 
     pub(crate) keccak_inputs: Vec<[u64; keccak::keccak_stark::NUM_INPUTS]>,
     pub(crate) logic_ops: Vec<logic::Operation>,
@@ -55,7 +55,7 @@ impl<F: Field> GenerationState<F> {
         channel_index: usize,
         segment: Segment,
         virt: usize,
-    ) -> [F; crate::memory::VALUE_LIMBS] {
+    ) -> U256 {
         let timestamp = self.cpu_rows.len();
         let context = self.current_context;
         let value = self.memory.contexts[context].segments[segment as usize].get(virt);
@@ -77,7 +77,7 @@ impl<F: Field> GenerationState<F> {
         channel_index: usize,
         segment: Segment,
         virt: usize,
-        value: [F; crate::memory::VALUE_LIMBS],
+        value: U256,
     ) {
         let timestamp = self.cpu_rows.len();
         let context = self.current_context;

--- a/evm/src/memory/columns.rs
+++ b/evm/src/memory/columns.rs
@@ -9,7 +9,8 @@ pub(crate) const ADDR_CONTEXT: usize = IS_READ + 1;
 pub(crate) const ADDR_SEGMENT: usize = ADDR_CONTEXT + 1;
 pub(crate) const ADDR_VIRTUAL: usize = ADDR_SEGMENT + 1;
 
-// Eight limbs to hold up to a 256-bit value.
+// Eight 32-bit limbs hold a total of 256 bits.
+// If a value represents an integer, it is little-endian encoded.
 const VALUE_START: usize = ADDR_VIRTUAL + 1;
 pub(crate) const fn value_limb(i: usize) -> usize {
     debug_assert!(i < VALUE_LIMBS);


### PR DESCRIPTION
Ultimately they're encoded as `[F; 8]`s in the table, but I don't anticipate that we'll have any use cases where we want to store more than 256 bits. Might as well store `U256` until we actually build the table since they're more compact.