### PR TITLE
Organize segments in an enum

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -146,7 +146,8 @@ mod tests {
     use crate::cross_table_lookup::testutils::check_ctls;
     use crate::keccak::keccak_stark::{KeccakStark, NUM_INPUTS, NUM_ROUNDS};
     use crate::logic::{self, LogicStark, Operation};
-    use crate::memory::memory_stark::{generate_random_memory_ops, MemoryStark};
+    use crate::memory::memory_stark::tests::generate_random_memory_ops;
+    use crate::memory::memory_stark::MemoryStark;
     use crate::memory::NUM_CHANNELS;
     use crate::proof::AllProof;
     use crate::prover::prove;

--- a/evm/src/cpu/bootstrap_kernel.rs
+++ b/evm/src/cpu/bootstrap_kernel.rs
@@ -18,7 +18,8 @@ use crate::cpu::kernel::keccak_util::keccakf_u32s;
 use crate::cpu::public_inputs::NUM_PUBLIC_INPUTS;
 use crate::generation::state::GenerationState;
 use crate::memory;
-use crate::memory::{segments, NUM_CHANNELS};
+use crate::memory::segments::Segment;
+use crate::memory::NUM_CHANNELS;
 use crate::vars::{StarkEvaluationTargets, StarkEvaluationVars};
 
 /// The Keccak rate (1088 bits), measured in bytes.
@@ -53,7 +54,7 @@ pub(crate) fn generate_bootstrap_kernel<F: Field>(state: &mut GenerationState<F>
             value[0] = F::from_canonical_u8(byte);
 
             let channel = addr % NUM_CHANNELS;
-            state.set_mem_current(channel, segments::CODE, addr, value);
+            state.set_mem_current(channel, Segment::Code, addr, value);
 
             packed_bytes = (packed_bytes << 8) | byte as u32;
         }

--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -8,12 +8,15 @@ use once_cell::sync::Lazy;
 
 use super::assembler::{assemble, Kernel};
 use crate::cpu::kernel::parser::parse;
+use crate::memory::segments::Segment;
 
 pub static KERNEL: Lazy<Kernel> = Lazy::new(combined_kernel);
 
 pub fn evm_constants() -> HashMap<String, U256> {
     let mut c = HashMap::new();
-    c.insert("SEGMENT_ID_TXN_DATA".into(), 0.into()); // TODO: Replace with actual segment ID.
+    for segment in Segment::all() {
+        c.insert(segment.var_name().into(), (segment as u32).into());
+    }
     c
 }
 

--- a/evm/src/generation/memory.rs
+++ b/evm/src/generation/memory.rs
@@ -1,7 +1,7 @@
 use plonky2::field::types::Field;
 
 use crate::memory::memory_stark::MemoryOp;
-use crate::memory::segments::NUM_SEGMENTS;
+use crate::memory::segments::Segment;
 use crate::memory::VALUE_LIMBS;
 
 #[allow(unused)] // TODO: Should be used soon.
@@ -26,7 +26,7 @@ impl<F: Field> Default for MemoryState<F> {
 #[derive(Default, Debug)]
 pub(crate) struct MemoryContextState<F: Field> {
     /// The content of each memory segment.
-    pub segments: [MemorySegmentState<F>; NUM_SEGMENTS],
+    pub segments: [MemorySegmentState<F>; Segment::COUNT],
 }
 
 #[derive(Default, Debug)]

--- a/evm/src/generation/state.rs
+++ b/evm/src/generation/state.rs
@@ -6,6 +6,7 @@ use plonky2::field::types::Field;
 use crate::cpu::columns::{CpuColumnsView, NUM_CPU_COLUMNS};
 use crate::generation::memory::MemoryState;
 use crate::memory::memory_stark::MemoryOp;
+use crate::memory::segments::Segment;
 use crate::{keccak, logic};
 
 #[derive(Debug)]
@@ -52,12 +53,12 @@ impl<F: Field> GenerationState<F> {
     pub(crate) fn get_mem_current(
         &mut self,
         channel_index: usize,
-        segment: usize,
+        segment: Segment,
         virt: usize,
     ) -> [F; crate::memory::VALUE_LIMBS] {
         let timestamp = self.cpu_rows.len();
         let context = self.current_context;
-        let value = self.memory.contexts[context].segments[segment].get(virt);
+        let value = self.memory.contexts[context].segments[segment as usize].get(virt);
         self.memory.log.push(MemoryOp {
             channel_index: Some(channel_index),
             timestamp,
@@ -74,7 +75,7 @@ impl<F: Field> GenerationState<F> {
     pub(crate) fn set_mem_current(
         &mut self,
         channel_index: usize,
-        segment: usize,
+        segment: Segment,
         virt: usize,
         value: [F; crate::memory::VALUE_LIMBS],
     ) {
@@ -89,7 +90,7 @@ impl<F: Field> GenerationState<F> {
             virt,
             value,
         });
-        self.memory.contexts[context].segments[segment].set(virt, value)
+        self.memory.contexts[context].segments[segment as usize].set(virt, value)
     }
 
     pub(crate) fn commit_cpu_row(&mut self) {

--- a/evm/src/memory/segments.rs
+++ b/evm/src/memory/segments.rs
@@ -1,22 +1,61 @@
-/// Contains EVM bytecode.
-pub const CODE: usize = 0;
+#[allow(dead_code)] // TODO: Not all segments are used yet.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Debug)]
+pub(crate) enum Segment {
+    /// Contains EVM bytecode.
+    Code = 0,
+    /// The program stack.
+    Stack = 1,
+    /// Main memory, owned by the contract code.
+    MainMemory = 2,
+    /// Data passed to the current context by its caller.
+    Calldata = 3,
+    /// Data returned to the current context by its latest callee.
+    Returndata = 4,
+    /// A segment which contains a few fixed-size metadata fields, such as the caller's context, or the
+    /// size of `CALLDATA` and `RETURNDATA`.
+    Metadata = 5,
+    /// General purpose kernel memory, used by various kernel functions.
+    /// In general, calling a helper function can result in this memory being clobbered.
+    KernelGeneral = 6,
+    /// Contains transaction data (after it's parsed and converted to a standard format).
+    TxnData = 7,
+    /// Raw RLP data.
+    RlpRaw = 8,
+    /// RLP data that has been parsed and converted to a more "friendly" format.
+    RlpParsed = 9,
+}
 
-pub const STACK: usize = 1;
+impl Segment {
+    pub(crate) const COUNT: usize = 10;
 
-/// Main memory, owned by the contract code.
-pub const MAIN_MEM: usize = 2;
+    pub(crate) fn all() -> [Self; Self::COUNT] {
+        [
+            Self::Code,
+            Self::Stack,
+            Self::MainMemory,
+            Self::Calldata,
+            Self::Returndata,
+            Self::Metadata,
+            Self::KernelGeneral,
+            Self::TxnData,
+            Self::RlpRaw,
+            Self::RlpParsed,
+        ]
+    }
 
-/// Memory owned by the kernel.
-pub const KERNEL_MEM: usize = 3;
-
-/// Data passed to the current context by its caller.
-pub const CALLDATA: usize = 4;
-
-/// Data returned to the current context by its latest callee.
-pub const RETURNDATA: usize = 5;
-
-/// A segment which contains a few fixed-size metadata fields, such as the caller's context, or the
-/// size of `CALLDATA` and `RETURNDATA`.
-pub const METADATA: usize = 6;
-
-pub const NUM_SEGMENTS: usize = 7;
+    /// The variable name that gets passed into kernel assembly code.
+    pub(crate) fn var_name(&self) -> &'static str {
+        match self {
+            Segment::Code => "SEGMENT_CODE",
+            Segment::Stack => "SEGMENT_STACK",
+            Segment::MainMemory => "SEGMENT_MAIN_MEMORY",
+            Segment::Calldata => "SEGMENT_CALLDATA",
+            Segment::Returndata => "SEGMENT_RETURNDATA",
+            Segment::Metadata => "SEGMENT_METADATA",
+            Segment::KernelGeneral => "SEGMENT_KERNEL_GENERAL",
+            Segment::TxnData => "SEGMENT_TXN_DATA",
+            Segment::RlpRaw => "SEGMENT_RLP_RAW",
+            Segment::RlpParsed => "SEGMENT_RLP_PARSED",
+        }
+    }
+}


### PR DESCRIPTION
It's a bit more type-safe (can't mix up segment with context or virtual addr), and this way uniqueness of ordinals is enforced, partially addressing a concern raised in #591.

To avoid making `Segment` public (which I don't think would be appropriate), I had to make some other visibility changes, and had to move `generate_random_memory_ops` into the test module.