### PR TITLE
Add a `mload_kernel_code_u32` macro

### DIFF
--- a/evm/src/cpu/kernel/asm/basic_macros.asm
+++ b/evm/src/cpu/kernel/asm/basic_macros.asm
@@ -82,6 +82,13 @@
     // stack: input / c, ...
 %endmacro
 
+%macro shl_const(c)
+    // stack: input, ...
+    PUSH $c
+    SHL
+    // stack: input << c, ...
+%endmacro
+
 %macro eq_const(c)
     // stack: input, ...
     PUSH $c

--- a/evm/src/cpu/kernel/asm/memory.asm
+++ b/evm/src/cpu/kernel/asm/memory.asm
@@ -26,6 +26,47 @@
     // stack: (empty)
 %endmacro
 
+// Load a single byte from kernel code.
+%macro mload_kernel_code
+    // stack: offset
+    PUSH @SEGMENT_CODE
+    // stack: segment, offset
+    PUSH 0 // kernel has context 0
+    // stack: context, segment, offset
+    MLOAD_GENERAL
+    // stack: value
+%endmacro
+
+// Load a big-endian u32, consisting of 4 bytes (c_3, c_2, c_1, c_0),
+// from kernel code.
+%macro mload_kernel_code_u32
+    // stack: offset
+    DUP1
+    %mload_kernel_code
+    // stack: c_3, offset
+    %shl_const(8)
+    // stack: c_3 << 8, offset
+    DUP2
+    %add_const(1)
+    %mload_kernel_code
+    OR
+    // stack: (c_3 << 8) | c_2, offset
+    %shl_const(8)
+    // stack: ((c_3 << 8) | c_2) << 8, offset
+    DUP2
+    %add_const(2)
+    %mload_kernel_code
+    OR
+    // stack: (((c_3 << 8) | c_2) << 8) | c_1, offset
+    %shl_const(8)
+    // stack: ((((c_3 << 8) | c_2) << 8) | c_1) << 8, offset
+    SWAP1
+    %add_const(3)
+    %mload_kernel_code
+    OR
+    // stack: (((((c_3 << 8) | c_2) << 8) | c_1) << 8) | c_0
+%endmacro
+
 // Copies `count` values from
 //     SRC = (src_ctx, src_segment, src_addr)
 // to


### PR DESCRIPTION
Intended for loading constants in SHA2, and maybe RIPEMD (cc @typ3c4t).

Sample usage
```
// Loads the i'th K256 constant.
%macro k256
  // stack: i
  %mul_const(4)
  // stack: 4*i
  PUSH k256_data
  // stack: k256_data, 4*i
  ADD
  // stack: k256_data + 4*i
  %mload_kernel_code_u32
  // stack: K256[4*i]
%endmacro

k256_data:
    BYTES 0x42, 0x8a, 0x2f, 0x98
    BYTES 0x71, 0x37, 0x44, 0x91
    ...
```

Untested for now since our interpreter doesn't have the needed memory support quite yet.