### PR TITLE
set cap for challenger's input buffer size

### DIFF
--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -91,8 +91,7 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
             // Evaluate the permutation to produce `r` new outputs.
             self.sponge_state = H::Permutation::permute(self.sponge_state);
             self.output_buffer.clear();
-            self.output_buffer
-                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -152,8 +151,7 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
         }
 
         self.output_buffer.clear();
-        self.output_buffer
-            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }
@@ -223,9 +221,9 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
 
         if self.output_buffer.is_empty() {
             // Evaluate the permutation to produce `r` new outputs.
+            self.sponge_state = builder.permute::<H>(self.sponge_state);
             self.output_buffer.clear();
-            self.output_buffer
-                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -278,8 +276,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         }
 
         self.output_buffer.clear();
-        self.output_buffer
-            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -91,7 +91,8 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
             // Evaluate the permutation to produce `r` new outputs.
             self.sponge_state = H::Permutation::permute(self.sponge_state);
             self.output_buffer.clear();
-            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer
+                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -151,7 +152,8 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
         }
 
         self.output_buffer.clear();
-        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer
+            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }
@@ -222,7 +224,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         if self.output_buffer.is_empty() {
             // Evaluate the permutation to produce `r` new outputs.
             self.output_buffer.clear();
-            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer
+                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -275,7 +278,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         }
 
         self.output_buffer.clear();
-        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer
+            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -91,7 +91,7 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
             // Evaluate the permutation to produce `r` new outputs.
             self.sponge_state = H::Permutation::permute(self.sponge_state);
             self.output_buffer.clear();
-            (&mut self.output_buffer[0..SPONGE_RATE]).copy_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -151,7 +151,7 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
         }
 
         self.output_buffer.clear();
-        (&mut self.output_buffer[0..SPONGE_RATE]).copy_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }
@@ -221,8 +221,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
 
         if self.output_buffer.is_empty() {
             // Evaluate the permutation to produce `r` new outputs.
-            self.sponge_state = builder.permute::<H>(self.sponge_state);
-            self.output_buffer = self.sponge_state[0..SPONGE_RATE].to_vec();
+            self.output_buffer.clear();
+            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -274,7 +274,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
             self.sponge_state = builder.permute::<H>(self.sponge_state);
         }
 
-        self.output_buffer = self.sponge_state[0..SPONGE_RATE].to_vec();
+        self.output_buffer.clear();
+        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -91,7 +91,8 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
             // Evaluate the permutation to produce `r` new outputs.
             self.sponge_state = H::Permutation::permute(self.sponge_state);
             self.output_buffer.clear();
-            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer
+                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -151,7 +152,8 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
         }
 
         self.output_buffer.clear();
-        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer
+            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }
@@ -223,7 +225,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
             // Evaluate the permutation to produce `r` new outputs.
             self.sponge_state = builder.permute::<H>(self.sponge_state);
             self.output_buffer.clear();
-            self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+            self.output_buffer
+                .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
         }
 
         self.output_buffer
@@ -276,7 +279,8 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         }
 
         self.output_buffer.clear();
-        self.output_buffer.extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
+        self.output_buffer
+            .extend_from_slice(&self.sponge_state[0..SPONGE_RATE]);
 
         self.input_buffer.clear();
     }


### PR DESCRIPTION
Challenger's input buffer can get pretty large and overflow small heaps. I've set it so that it automatically absorbs all of the buffered elements when it reaches a length of `MAX_INPUT_BUFFER`, which is currently set to `128`.

I've also removed some unnecessary `Vec` allocations when setting the output buffer.