### PR TITLE
Increment program counter on native instructions

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -260,6 +260,7 @@ mod tests {
             let mut row: cpu::columns::CpuColumnsView<F> =
                 [F::ZERO; CpuStark::<F, D>::COLUMNS].into();
             row.is_cpu_cycle = F::ONE;
+            row.program_counter = F::from_canonical_usize(i);
             row.opcode = [
                 (logic::columns::IS_AND, 0x16),
                 (logic::columns::IS_OR, 0x17),
@@ -319,10 +320,11 @@ mod tests {
         }
 
         // Pad to a power of two.
-        for _ in cpu_trace_rows.len()..cpu_trace_rows.len().next_power_of_two() {
+        for i in 0..cpu_trace_rows.len().next_power_of_two() - cpu_trace_rows.len() {
             let mut row: cpu::columns::CpuColumnsView<F> =
                 [F::ZERO; CpuStark::<F, D>::COLUMNS].into();
             row.is_cpu_cycle = F::ONE;
+            row.program_counter = F::from_canonical_usize(i + num_logic_rows);
             cpu_stark.generate(row.borrow_mut());
             cpu_trace_rows.push(row.into());
         }
@@ -335,10 +337,6 @@ mod tests {
             let last_row: &mut cpu::columns::CpuColumnsView<F> =
                 cpu_trace_rows[num_rows - 1].borrow_mut();
             last_row.program_counter = halt_label;
-
-            let second_last_row: &mut cpu::columns::CpuColumnsView<F> =
-                cpu_trace_rows[num_rows - 2].borrow_mut();
-            second_last_row.next_program_counter = halt_label;
         }
 
         trace_rows_to_poly_values(cpu_trace_rows)

--- a/evm/src/cpu/columns/mod.rs
+++ b/evm/src/cpu/columns/mod.rs
@@ -146,9 +146,6 @@ pub struct CpuColumnsView<T: Copy> {
     /// If CPU cycle: the opcode, broken up into bits in **big-endian** order.
     pub opcode_bits: [T; 8],
 
-    /// If CPU cycle: The program counter for the next instruction.
-    pub next_program_counter: T,
-
     /// Filter. 1 iff a Keccak permutation is computed on this row.
     pub is_keccak: T,
 


### PR DESCRIPTION
When we execute an instruction that takes up one row (is not microcoded), then we increment the program counter by 1.