### PR TITLE
Small fix for type 0 txns

### DIFF
--- a/evm/src/cpu/kernel/asm/transactions/type_0.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_0.asm
@@ -57,16 +57,7 @@ store_gas_limit:
     %stack (pos, gas_limit) -> (@TXN_FIELD_GAS_LIMIT, gas_limit, pos)
     %mstore_current(@SEGMENT_NORMALIZED_TXN)
 
-    // Peak at the RLP to see if the next byte is zero.
-    // If so, there is no value field, so skip the store_to step.
     // stack: pos
-    DUP1
-    %mload_current(@SEGMENT_RLP_RAW)
-    ISZERO
-    // stack: to_empty, pos
-    %jumpi(parse_value)
-
-    // If we got here, there is a "to" field.
     PUSH store_to
     SWAP1
     // stack: pos, store_to


### PR DESCRIPTION
Always parse "to" as a scalar. No need for a branch; it's left over from when I was trying to enforce canonical RLP (in which case "to" must be 0 or 20 bytes).

The old code would be wrong if we had multiple txns per proof, as if to=0 we wouldn't write that field to memory, so it could have an old value from a previous txn.