### PR TITLE
Store literals as `U256` (or `u8` for `BYTES`)

### DIFF
--- a/evm/src/cpu/kernel/ast.rs
+++ b/evm/src/cpu/kernel/ast.rs
@@ -1,5 +1,4 @@
 use ethereum_types::U256;
-use plonky2_util::ceil_div_usize;
 
 use crate::cpu::kernel::prover_input::ProverInputFn;
 
@@ -15,7 +14,7 @@ pub(crate) enum Item {
     /// Calls a macro: name, args.
     MacroCall(String, Vec<PushTarget>),
     /// Repetition, like `%rep` in NASM.
-    Repeat(Literal, Vec<Item>),
+    Repeat(U256, Vec<Item>),
     /// A directive to manipulate the stack according to a specified pattern.
     /// The first list gives names to items on the top of the stack.
     /// The second list specifies replacement items.
@@ -32,14 +31,14 @@ pub(crate) enum Item {
     /// Any opcode besides a PUSH opcode.
     StandardOp(String),
     /// Literal hex data; should contain an even number of hex chars.
-    Bytes(Vec<Literal>),
+    Bytes(Vec<u8>),
 }
 
 #[derive(Clone, Debug)]
 pub(crate) enum StackReplacement {
     /// Can be either a named item or a label.
     Identifier(String),
-    Literal(Literal),
+    Literal(U256),
     MacroVar(String),
     Constant(String),
 }
@@ -47,69 +46,8 @@ pub(crate) enum StackReplacement {
 /// The target of a `PUSH` operation.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub(crate) enum PushTarget {
-    Literal(Literal),
+    Literal(U256),
     Label(String),
     MacroVar(String),
     Constant(String),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub(crate) enum Literal {
-    Decimal(String),
-    Hex(String),
-}
-
-impl Literal {
-    pub(crate) fn to_trimmed_be_bytes(&self) -> Vec<u8> {
-        let u256 = self.to_u256();
-        let num_bytes = ceil_div_usize(u256.bits(), 8).max(1);
-        // `byte` is little-endian, so we manually reverse it.
-        (0..num_bytes).rev().map(|i| u256.byte(i)).collect()
-    }
-
-    pub(crate) fn to_u256(&self) -> U256 {
-        let (src, radix) = match self {
-            Literal::Decimal(s) => (s, 10),
-            Literal::Hex(s) => (s, 16),
-        };
-        U256::from_str_radix(src, radix)
-            .unwrap_or_else(|_| panic!("Not a valid u256 literal: {:?}", self))
-    }
-
-    pub(crate) fn to_u8(&self) -> u8 {
-        let (src, radix) = match self {
-            Literal::Decimal(s) => (s, 10),
-            Literal::Hex(s) => (s, 16),
-        };
-        u8::from_str_radix(src, radix)
-            .unwrap_or_else(|_| panic!("Not a valid u8 literal: {:?}", self))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::cpu::kernel::ast::*;
-
-    #[test]
-    fn literal_to_be_bytes() {
-        assert_eq!(
-            Literal::Decimal("0".into()).to_trimmed_be_bytes(),
-            vec![0x00]
-        );
-
-        assert_eq!(
-            Literal::Decimal("768".into()).to_trimmed_be_bytes(),
-            vec![0x03, 0x00]
-        );
-
-        assert_eq!(
-            Literal::Hex("a1b2".into()).to_trimmed_be_bytes(),
-            vec![0xa1, 0xb2]
-        );
-
-        assert_eq!(
-            Literal::Hex("1b2".into()).to_trimmed_be_bytes(),
-            vec![0x1, 0xb2]
-        );
-    }
 }

--- a/evm/src/cpu/kernel/mod.rs
+++ b/evm/src/cpu/kernel/mod.rs
@@ -7,6 +7,7 @@ mod parser;
 pub mod prover_input;
 mod stack_manipulation;
 mod txn_fields;
+mod utils;
 
 #[cfg(test)]
 mod interpreter;

--- a/evm/src/cpu/kernel/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack_manipulation.rs
@@ -8,6 +8,7 @@ use crate::cpu::columns::NUM_CPU_COLUMNS;
 use crate::cpu::kernel::assembler::BYTES_PER_OFFSET;
 use crate::cpu::kernel::ast::{Item, PushTarget, StackReplacement};
 use crate::cpu::kernel::stack_manipulation::StackOp::Pop;
+use crate::cpu::kernel::utils::u256_to_trimmed_be_bytes;
 use crate::memory;
 
 pub(crate) fn expand_stack_manipulation(body: Vec<Item>) -> Vec<Item> {
@@ -227,7 +228,7 @@ impl StackOp {
         let (cpu_rows, memory_rows) = match self {
             StackOp::Push(target) => {
                 let bytes = match target {
-                    PushTarget::Literal(n) => n.to_trimmed_be_bytes().len() as u32,
+                    PushTarget::Literal(n) => u256_to_trimmed_be_bytes(n).len() as u32,
                     PushTarget::Label(_) => BYTES_PER_OFFSET as u32,
                     PushTarget::MacroVar(_) | PushTarget::Constant(_) => {
                         panic!("Target should have been expanded already: {:?}", target)

--- a/evm/src/cpu/kernel/utils.rs
+++ b/evm/src/cpu/kernel/utils.rs
@@ -1,0 +1,24 @@
+use ethereum_types::U256;
+use plonky2_util::ceil_div_usize;
+
+pub(crate) fn u256_to_trimmed_be_bytes(u256: &U256) -> Vec<u8> {
+    let num_bytes = ceil_div_usize(u256.bits(), 8).max(1);
+    // `byte` is little-endian, so we manually reverse it.
+    (0..num_bytes).rev().map(|i| u256.byte(i)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_to_be_bytes() {
+        assert_eq!(u256_to_trimmed_be_bytes(&0.into()), vec![0x00]);
+
+        assert_eq!(u256_to_trimmed_be_bytes(&768.into()), vec![0x03, 0x00]);
+
+        assert_eq!(u256_to_trimmed_be_bytes(&0xa1b2.into()), vec![0xa1, 0xb2]);
+
+        assert_eq!(u256_to_trimmed_be_bytes(&0x1b2.into()), vec![0x1, 0xb2]);
+    }
+}


### PR DESCRIPTION
Instead of the original strings. Will make optimizations simpler.

Depends on #646.