### PR TITLE
Make the rest of gates public

### DIFF
--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -23,7 +23,7 @@ use crate::plonk::vars::{
 
 /// A gate for raising a value to a power.
 #[derive(Clone, Debug)]
-pub(crate) struct ExponentiationGate<F: RichField + Extendable<D>, const D: usize> {
+pub struct ExponentiationGate<F: RichField + Extendable<D>, const D: usize> {
     pub num_power_bits: usize,
     pub _phantom: PhantomData<F>,
 }

--- a/plonky2/src/gates/interpolation.rs
+++ b/plonky2/src/gates/interpolation.rs
@@ -22,7 +22,7 @@ use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 /// Interpolation gate with constraints of degree at most `1<<subgroup_bits`.
 /// `eval_unfiltered_recursively` uses less gates than `LowDegreeInterpolationGate`.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct HighDegreeInterpolationGate<F: RichField + Extendable<D>, const D: usize> {
+pub struct HighDegreeInterpolationGate<F: RichField + Extendable<D>, const D: usize> {
     pub subgroup_bits: usize,
     _phantom: PhantomData<F>,
 }

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -23,7 +23,7 @@ use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 /// Interpolation gate with constraints of degree 2.
 /// `eval_unfiltered_recursively` uses more gates than `HighDegreeInterpolationGate`.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct LowDegreeInterpolationGate<F: RichField + Extendable<D>, const D: usize> {
+pub struct LowDegreeInterpolationGate<F: RichField + Extendable<D>, const D: usize> {
     pub subgroup_bits: usize,
     _phantom: PhantomData<F>,
 }

--- a/plonky2/src/gates/mod.rs
+++ b/plonky2/src/gates/mod.rs
@@ -19,7 +19,7 @@ pub mod public_input;
 pub mod random_access;
 pub mod reducing;
 pub mod reducing_extension;
-pub mod selectors;
+pub(crate) mod selectors;
 pub mod util;
 
 // Can't use #[cfg(test)] here because it needs to be visible to other crates.

--- a/plonky2/src/gates/mod.rs
+++ b/plonky2/src/gates/mod.rs
@@ -14,12 +14,12 @@ pub mod multiplication_extension;
 pub mod noop;
 pub mod packed_util;
 pub mod poseidon;
-pub(crate) mod poseidon_mds;
-pub(crate) mod public_input;
+pub mod poseidon_mds;
+pub mod public_input;
 pub mod random_access;
 pub mod reducing;
 pub mod reducing_extension;
-pub(crate) mod selectors;
+pub mod selectors;
 pub mod util;
 
 // Can't use #[cfg(test)] here because it needs to be visible to other crates.

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -23,7 +23,7 @@ use crate::plonk::vars::{
 
 /// A gate for checking that a particular element of a list matches a given value.
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct RandomAccessGate<F: RichField + Extendable<D>, const D: usize> {
+pub struct RandomAccessGate<F: RichField + Extendable<D>, const D: usize> {
     pub bits: usize,
     pub num_copies: usize,
     pub num_extra_constants: usize,

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -10,7 +10,7 @@ use crate::hash::hash_types::RichField;
 pub(crate) const UNUSED_SELECTOR: usize = u32::MAX as usize;
 
 #[derive(Debug, Clone)]
-pub(crate) struct SelectorsInfo {
+pub struct SelectorsInfo {
     pub(crate) selector_indices: Vec<usize>,
     pub(crate) groups: Vec<Range<usize>>,
 }

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -10,7 +10,7 @@ use crate::hash::hash_types::RichField;
 pub(crate) const UNUSED_SELECTOR: usize = u32::MAX as usize;
 
 #[derive(Debug, Clone)]
-pub struct SelectorsInfo {
+pub(crate) struct SelectorsInfo {
     pub(crate) selector_indices: Vec<usize>,
     pub(crate) groups: Vec<Range<usize>>,
 }


### PR DESCRIPTION
Motivation: Since gates are in a `Vec` of trait objects and we want to allow people to implement their own gates outside the library, they need to be able to construct them in order to deserialize circuit data (see #590).