### PR TITLE
Make use of `mstore_txn_field` in type 0 parsing

### DIFF
--- a/evm/src/cpu/kernel/asm/transactions/type_0.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_0.asm
@@ -23,8 +23,8 @@ global process_type_0_txn:
     // Decode the nonce and store it.
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, nonce) -> (@TXN_FIELD_NONCE, nonce, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, nonce) -> (nonce, pos)
+    %mstore_txn_field(@TXN_FIELD_NONCE)
 
     // Decode the gas price and store it.
     // For legacy transactions, we set both the
@@ -32,34 +32,33 @@ global process_type_0_txn:
     // fields to gas_price.
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, gas_price) -> (@TXN_FIELD_MAX_PRIORITY_FEE_PER_GAS, gas_price,
-                                @TXN_FIELD_MAX_FEE_PER_GAS, gas_price, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, gas_price) -> (gas_price, gas_price, pos)
+    %mstore_txn_field(@TXN_FIELD_MAX_PRIORITY_FEE_PER_GAS)
+    %mstore_txn_field(@TXN_FIELD_MAX_FEE_PER_GAS)
 
     // Decode the gas limit and store it.
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, gas_limit) -> (@TXN_FIELD_GAS_LIMIT, gas_limit, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, gas_limit) -> (gas_limit, pos)
+    %mstore_txn_field(@TXN_FIELD_GAS_LIMIT)
 
     // Decode the "to" field and store it.
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, to) -> (@TXN_FIELD_TO, to, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, to) -> (to, pos)
+    %mstore_txn_field(@TXN_FIELD_TO)
 
     // Decode the value field and store it.
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, value) -> (@TXN_FIELD_VALUE, value, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, value) -> (value, pos)
+    %mstore_txn_field(@TXN_FIELD_VALUE)
 
     // Decode the data length, store it, and compute new_pos after any data.
     // stack: pos
     %decode_rlp_string_len
-    %stack (pos, data_len) -> (@TXN_FIELD_DATA_LEN, data_len, pos, data_len, pos, data_len)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, data_len) -> (data_len, pos, data_len, pos, data_len)
+    %mstore_txn_field(@TXN_FIELD_DATA_LEN)
     // stack: pos, data_len, pos, data_len
     ADD
     // stack: new_pos, pos, data_len
@@ -91,8 +90,8 @@ parse_v:
     // TXN_FIELD_CHAIN_ID with their default values of zero.
     // stack: v, pos
     %sub_const(27)
-    %stack (y_parity, pos) -> (@TXN_FIELD_Y_PARITY, y_parity, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (y_parity, pos) -> (y_parity, pos)
+    %mstore_txn_field(@TXN_FIELD_Y_PARITY)
 
     // stack: pos
     %jump(parse_r)
@@ -101,8 +100,8 @@ process_v_new_style:
     // stack: v, pos
     // We have a new style v, so chain_id_present = 1,
     // chain_id = (v - 35) / 2, and y_parity = (v - 35) % 2.
-    %stack (v, pos) -> (@TXN_FIELD_CHAIN_ID_PRESENT, 1, v, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (v, pos) -> (1, v, pos)
+    %mstore_txn_field(@TXN_FIELD_CHAIN_ID_PRESENT)
 
     // stack: v, pos
     %sub_const(35)
@@ -110,25 +109,23 @@ process_v_new_style:
     // stack: v - 35, v - 35, pos
     %div_const(2)
     // stack: chain_id, v - 35, pos
-    PUSH @TXN_FIELD_CHAIN_ID
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %mstore_txn_field(@TXN_FIELD_CHAIN_ID)
 
     // stack: v - 35, pos
     %mod_const(2)
     // stack: y_parity, pos
-    PUSH @TXN_FIELD_Y_PARITY
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %mstore_txn_field(@TXN_FIELD_Y_PARITY)
 
 parse_r:
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, r) -> (@TXN_FIELD_R, r, pos)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, r) -> (r, pos)
+    %mstore_txn_field(@TXN_FIELD_R)
 
     // stack: pos
     %decode_rlp_scalar
-    %stack (pos, s) -> (@TXN_FIELD_S, s)
-    %mstore_current(@SEGMENT_NORMALIZED_TXN)
+    %stack (pos, s) -> (s)
+    %mstore_txn_field(@TXN_FIELD_S)
     // stack: (empty)
 
     // TODO: Write the signed txn data to memory, where it can be hashed and


### PR DESCRIPTION
Some of the `%stack` operations are now trivial, but I kind of like keeping `%stack` since it serves as documentation as well, making comments about the stack unnecessary.