### PR TITLE
Added caching for GitHub Workflows

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -23,6 +23,9 @@ jobs:
           toolchain: nightly
           override: true
 
+      - name: rust-cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -47,6 +50,9 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt, clippy
+
+      - name: rust-cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install nightly toolchain
+        id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -24,7 +25,15 @@ jobs:
           override: true
 
       - name: rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rustc-test-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -33,7 +42,7 @@ jobs:
           args: --all
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Cprefer-dynamic=y
-          CARGO_INCREMENTAL: 0
+          CARGO_INCREMENTAL: 1
 
   lints:
     name: Formatting and Clippy
@@ -44,6 +53,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install nightly toolchain
+        id: rustc-toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -52,17 +62,29 @@ jobs:
           components: rustfmt, clippy
 
       - name: rust-cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rustc-lints-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+        env:
+          CARGO_INCREMENTAL: 1
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --all-features --all-targets -- -D warnings -A incomplete-features
+        env:
+          CARGO_INCREMENTAL: 1
 


### PR DESCRIPTION
Added caching to the CI workflows.

Under the hood, [rust-cache](https://github.com/Swatinem/rust-cache) calls GitHub's more generic [cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) action with a configuration that makes sense for a Cargo project. The high level idea is this:

- Generate a cache key based on variables that would normally require a full/partial recompile (eg. compiler version, `Cargo.lock`, etc.).
- Check if there is a cache entry for this key.
- If the key is missing, then after the job completes, create a new cache entry for this key containing build artifacts (`~/.cargo` & `target/`).
- If the key exists, then copy the cached directories directly into the workflow container.

So for a cache hit, this should significantly speed up build times since we can skip the large majority of downloading/compiling dependencies. For hopefully the majority of cases, we should only need to recompile whatever project crates were changed by the PR.

A few other notes:
- Since we're using nightly, this means every day our cache entries are going to become invalidated whenever a new nightly version is released.
- By default, caching also includes the workflow job in the key that it's a part of, which in our case is good since `test` and `lints` both use different `RUSTFLAGS`.
- The underlying GitHub cache action ejects cache entries after 10GB total is used or are stale for 7 days. 