### PR TITLE
Change visibility of `ECDSASecretKeyTarget` and `ECDSAPublicKeyTarget`'s fields

### DIFF
--- a/ecdsa/src/gadgets/ecdsa.rs
+++ b/ecdsa/src/gadgets/ecdsa.rs
@@ -13,10 +13,10 @@ use crate::gadgets::glv::CircuitBuilderGlv;
 use crate::gadgets::nonnative::{CircuitBuilderNonNative, NonNativeTarget};
 
 #[derive(Clone, Debug)]
-pub struct ECDSASecretKeyTarget<C: Curve>(NonNativeTarget<C::ScalarField>);
+pub struct ECDSASecretKeyTarget<C: Curve>(pub NonNativeTarget<C::ScalarField>);
 
 #[derive(Clone, Debug)]
-pub struct ECDSAPublicKeyTarget<C: Curve>(AffinePointTarget<C>);
+pub struct ECDSAPublicKeyTarget<C: Curve>(pub AffinePointTarget<C>);
 
 #[derive(Clone, Debug)]
 pub struct ECDSASignatureTarget<C: Curve> {


### PR DESCRIPTION
`ECDSASecretKeyTarget` and `ECDSAPublicKeyTarget`'s fields are private, so you cannot initialize them outside this crate. `ECDSASecretKeyTarget` and `ECDSAPublicKeyTarget` are  parameters of `verify_message_circuit`, so they should be able to be initialized outside this crate. 
