### PR TITLE
Support accessing local row in CTLs

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -145,6 +145,7 @@ mod tests {
     use crate::cpu::cpu_stark::CpuStark;
     use crate::cpu::kernel::aggregator::KERNEL;
     use crate::cross_table_lookup::testutils::check_ctls;
+    use crate::cross_table_lookup::Column;
     use crate::keccak::keccak_stark::{KeccakStark, NUM_INPUTS, NUM_ROUNDS};
     use crate::logic::{self, LogicStark, Operation};
     use crate::memory::memory_stark::tests::generate_random_memory_ops;
@@ -216,8 +217,10 @@ mod tests {
             .map(|i| {
                 (0..2 * NUM_INPUTS)
                     .map(|j| {
-                        keccak::columns::reg_input_limb(j)
-                            .eval_table(keccak_trace, (i + 1) * NUM_ROUNDS - 1)
+                        // There's an extra -1 because the argument to eval_table is the local row,
+                        // but the inputs/outputs live in the next row.
+                        let local_row = (i + 1) * NUM_ROUNDS - 1 - 1;
+                        keccak::columns::reg_input_limb(j).eval_table(keccak_trace, local_row)
                     })
                     .collect::<Vec<_>>()
                     .try_into()
@@ -228,8 +231,11 @@ mod tests {
             .map(|i| {
                 (0..2 * NUM_INPUTS)
                     .map(|j| {
-                        keccak_trace[keccak::columns::reg_output_limb(j)].values
-                            [(i + 1) * NUM_ROUNDS - 1]
+                        let out_limb = Column::single(keccak::columns::reg_output_limb(j));
+                        // There's an extra -1 because the argument to eval_table is the local row,
+                        // but the inputs/outputs live in the next row.
+                        let local_row = (i + 1) * NUM_ROUNDS - 1 - 1;
+                        out_limb.eval_table(keccak_trace, local_row)
                     })
                     .collect::<Vec<_>>()
                     .try_into()

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -10,7 +10,7 @@ use plonky2::hash::hash_types::RichField;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use crate::cpu::columns::{CpuColumnsView, COL_MAP, NUM_CPU_COLUMNS};
 use crate::cpu::{bootstrap_kernel, control_flow, decode, jumps, simple_logic, syscalls};
-use crate::cross_table_lookup::Column;
+use crate::cross_table_lookup::{Column, WeightedColumn};
 use crate::memory::NUM_CHANNELS;
 use crate::stark::Stark;
 use crate::vars::{StarkEvaluationTargets, StarkEvaluationVars};
@@ -50,10 +50,14 @@ pub fn ctl_data_memory<F: Field>(channel: usize) -> Vec<Column<F>> {
     .collect_vec();
     cols.extend(Column::singles(COL_MAP.mem_value[channel]));
 
-    let scalar = F::from_canonical_usize(NUM_CHANNELS);
+    let weight = F::from_canonical_usize(NUM_CHANNELS);
     let addend = F::from_canonical_usize(channel);
     cols.push(Column::linear_combination_with_constant(
-        vec![(COL_MAP.clock, scalar)],
+        vec![WeightedColumn {
+            column: COL_MAP.clock,
+            next: true,
+            weight,
+        }],
         addend,
     ));
 

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -117,10 +117,9 @@ impl<F: Field> Column<F> {
 
     /// Evaluate on an row of a table given in column-major form.
     pub fn eval_table(&self, table: &[PolynomialValues<F>], local_row: usize) -> F {
-        let mut next_row = local_row + 1;
-        if next_row == table[0].len() {
-            next_row = 0;
-        }
+        let degree = table[0].len();
+        debug_assert!(degree.is_power_of_two());
+        let next_row = (local_row + 1) & (degree - 1); // Equivalent to % degree.
 
         self.linear_combination
             .iter()
@@ -331,11 +330,8 @@ fn partial_products<F: Field>(
     let degree = trace[0].len();
     let mut res = Vec::with_capacity(degree);
     for next_row in 0..degree {
-        let local_row = if next_row == 0 {
-            degree - 1
-        } else {
-            next_row - 1
-        };
+        debug_assert!(degree.is_power_of_two());
+        let local_row = (next_row + degree - 1) & (degree - 1); // Equivalent to % degree.
 
         let filter = if let Some(column) = filter_column {
             column.eval_table(trace, local_row)
@@ -792,11 +788,8 @@ pub(crate) mod testutils {
         let degree = trace[0].len();
 
         for next_row in 0..trace[0].len() {
-            let local_row = if next_row == 0 {
-                degree - 1
-            } else {
-                next_row - 1
-            };
+            debug_assert!(degree.is_power_of_two());
+            let local_row = (next_row + degree - 1) & (degree - 1); // Equivalent to % degree.
 
             let filter = if let Some(column) = &table.filter_column {
                 column.eval_table(trace, local_row)


### PR DESCRIPTION
Previously CTLs could only access the "next" row; this lets them access the "local" row as well.