### PR TITLE
Remove keccak_rust in favor of tiny-keccak

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -22,6 +22,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 rlp = "0.5.1"
 keccak-hash = "0.9.0"
+tiny-keccak = "2.0.2"
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -21,7 +21,6 @@ maybe_rayon = { path = "../maybe_rayon" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rlp = "0.5.1"
-keccak-rust = { git = "https://github.com/npwardberkeley/keccak-rust" }
 keccak-hash = "0.9.0"
 
 [dev-dependencies]

--- a/evm/src/keccak/columns.rs
+++ b/evm/src/keccak/columns.rs
@@ -15,8 +15,11 @@ pub const fn reg_step(i: usize) -> usize {
 pub fn reg_input_limb<F: Field>(i: usize) -> Column<F> {
     debug_assert!(i < 2 * NUM_INPUTS);
     let i_u64 = i / 2; // The index of the 64-bit chunk.
-    let x = i_u64 / 5;
-    let y = i_u64 % 5;
+
+    // The 5x5 state is treated as y-major, as per the Keccak spec.
+    let y = i_u64 / 5;
+    let x = i_u64 % 5;
+
     let reg_low_limb = reg_a(x, y);
     let is_high_limb = i % 2;
     Column::single(reg_low_limb + is_high_limb)
@@ -28,8 +31,11 @@ pub fn reg_input_limb<F: Field>(i: usize) -> Column<F> {
 pub const fn reg_output_limb(i: usize) -> usize {
     debug_assert!(i < 2 * NUM_INPUTS);
     let i_u64 = i / 2; // The index of the 64-bit chunk.
-    let x = i_u64 / 5;
-    let y = i_u64 % 5;
+
+    // The 5x5 state is treated as y-major, as per the Keccak spec.
+    let y = i_u64 / 5;
+    let x = i_u64 % 5;
+
     let is_high_limb = i % 2;
     reg_a_prime_prime_prime(x, y) + is_high_limb
 }


### PR DESCRIPTION
`keccak_rust` doesn't seem to have much usage, and it treats `x` as the major axis of its 5x5 input.  This is not exactly wrong, since Keccak itself doesn't have a notion of axis order. However, there is a convention for mapping bits of the cube to a flat list of bits, which is

> The mapping between the bits of `s` and those of `a` is `s[w(5y + x) + z] = a[x][y][z]`.

Obeying this convention would be awkward with `keccak_rust` - the words in memory would need to be transposed.