### PR TITLE
Check that Merkle proofs have the proper length and leaf size

### DIFF
--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -122,6 +122,7 @@ where
             x_index,
             params.lde_bits(),
             cap,
+            params.config.cap_height,
             merkle_proof,
         )?;
     }
@@ -239,6 +240,7 @@ where
             coset_index,
             codeword_len_bits,
             &proof.commit_phase_merkle_caps[i],
+            params.config.cap_height,
             &round_proof.steps[i].merkle_proof,
         )?;
 

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -54,8 +54,8 @@ where
 {
     // Ensure that the Merkle proof has the proper length. This protects against attacks like the
     // one mentioned in https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
-    let cap_bits = log2_strict(merkle_cap.len());
-    let implied_leaf_depth = proof.siblings.len() + cap_bits;
+    let cap_height = log2_strict(merkle_cap.len());
+    let implied_leaf_depth = proof.siblings.len() + cap_height;
     ensure!(
         implied_leaf_depth == leaf_depth,
         "Merkle proof implies leaf depth of {}, expected {}",

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -1,5 +1,6 @@
 use anyhow::{ensure, Result};
 use plonky2_field::extension::Extendable;
+use plonky2_util::log2_strict;
 use serde::{Deserialize, Serialize};
 
 use crate::hash::hash_types::RichField;
@@ -28,6 +29,7 @@ pub struct MerkleProofTarget {
 pub fn verify_merkle_proof<F: RichField, H: Hasher<F>>(
     leaf_data: Vec<F>,
     leaf_index: usize,
+    leaf_depth: usize,
     merkle_root: H::Hash,
     proof: &MerkleProof<F, H>,
 ) -> Result<()>
@@ -35,7 +37,7 @@ where
     [(); H::HASH_SIZE]:,
 {
     let merkle_cap = MerkleCap(vec![merkle_root]);
-    verify_merkle_proof_to_cap(leaf_data, leaf_index, &merkle_cap, proof)
+    verify_merkle_proof_to_cap(leaf_data, leaf_index, leaf_depth, &merkle_cap, proof)
 }
 
 /// Verifies that the given leaf data is present at the given index in the Merkle tree with the
@@ -43,12 +45,24 @@ where
 pub fn verify_merkle_proof_to_cap<F: RichField, H: Hasher<F>>(
     leaf_data: Vec<F>,
     leaf_index: usize,
+    leaf_depth: usize,
     merkle_cap: &MerkleCap<F, H>,
     proof: &MerkleProof<F, H>,
 ) -> Result<()>
 where
     [(); H::HASH_SIZE]:,
 {
+    // Ensure that the Merkle proof has the proper length. This protects against attacks like the
+    // one mentioned in https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
+    let cap_bits = log2_strict(merkle_cap.len());
+    let implied_leaf_depth = proof.siblings.len() + cap_bits;
+    ensure!(
+        implied_leaf_depth == leaf_depth,
+        "Merkle proof implies leaf depth of {}, expected {}",
+        implied_leaf_depth,
+        leaf_depth
+    );
+
     let mut index = leaf_index;
     let mut current_digest = H::hash_or_noop(&leaf_data);
     for &sibling_digest in proof.siblings.iter() {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -21,6 +21,10 @@ impl<F: RichField, H: Hasher<F>> MerkleCap<F, H> {
         self.0.len()
     }
 
+    pub fn height(&self) -> usize {
+        log2_strict(self.len())
+    }
+
     pub fn flatten(&self) -> Vec<F> {
         self.0.iter().flat_map(|&h| h.to_vec()).collect()
     }
@@ -232,7 +236,7 @@ mod tests {
         let tree = MerkleTree::<F, C::Hasher>::new(leaves.clone(), cap_height);
         for (i, leaf) in leaves.into_iter().enumerate() {
             let proof = tree.prove(i);
-            verify_merkle_proof_to_cap(leaf, i, tree.height(), &tree.cap, &proof)?;
+            verify_merkle_proof_to_cap(leaf, i, tree.height(), &tree.cap, cap_height, &proof)?;
         }
         Ok(())
     }

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -162,6 +162,10 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
         }
     }
 
+    pub fn height(&self) -> usize {
+        log2_strict(self.leaves.len())
+    }
+
     pub fn get(&self, i: usize) -> &[F] {
         &self.leaves[i]
     }
@@ -228,7 +232,7 @@ mod tests {
         let tree = MerkleTree::<F, C::Hasher>::new(leaves.clone(), cap_height);
         for (i, leaf) in leaves.into_iter().enumerate() {
             let proof = tree.prove(i);
-            verify_merkle_proof_to_cap(leaf, i, &tree.cap, &proof)?;
+            verify_merkle_proof_to_cap(leaf, i, tree.height(), &tree.cap, &proof)?;
         }
         Ok(())
     }

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -155,7 +155,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         challenges: &ProofChallenges<F, D>,
         common_data: &CommonCircuitData<F, C, D>,
-    ) -> FriInferredElements<F, D> {
+    ) -> anyhow::Result<FriInferredElements<F, D>> {
         let ProofChallenges {
             plonk_zeta,
             fri_challenges:
@@ -217,12 +217,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     arity_bits,
                     &evals,
                     fri_betas[i],
-                );
+                )?;
                 subgroup_x = subgroup_x.exp_power_of_2(arity_bits);
                 x_index = coset_index;
             }
         }
-        FriInferredElements(fri_inferred_elements)
+        Ok(FriInferredElements(fri_inferred_elements))
     }
 }
 

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -182,7 +182,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         [(); C::Hasher::HASH_SIZE]:,
     {
         let challenges = self.get_challenges(self.get_public_inputs_hash(), common_data)?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);
@@ -206,7 +206,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         );
         let public_inputs_hash = self.get_public_inputs_hash();
         let challenges = self.get_challenges(public_inputs_hash, common_data)?;
-        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
+        let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data)?;
         let decompressed_proof =
             self.proof
                 .decompress(&challenges, fri_inferred_elements, &common_data.fri_params);

--- a/plonky2/src/util/serialization.rs
+++ b/plonky2/src/util/serialization.rs
@@ -282,7 +282,7 @@ impl Buffer {
         arity: usize,
         compressed: bool,
     ) -> Result<FriQueryStep<F, C::Hasher, D>> {
-        let evals = self.read_field_ext_vec::<F, D>(arity - if compressed { 1 } else { 0 })?;
+        let evals = self.read_field_ext_vec::<F, D>(arity - usize::from(compressed))?;
         let merkle_proof = self.read_merkle_proof()?;
         Ok(FriQueryStep {
             evals,


### PR DESCRIPTION
In our Merkle tree, there's no special field to distinguish leaves from branch nodes, so collisions between them may be possible. In particular, a prover could take the digest of a branch node, and prove inclusion a leaf with the same location and digest.[^1] A fixed-depth Merkle tree avoids such attacks, but we forgot to actually validate depth when verifying a Merkle proof.

Relatedly, we weren't checking that a leaf has the proper size. I'm not sure if an attacker can do anything useful with a wrongly sized leaf, particularly if the above issue is fixed, but it seems safest to just enforce that the entire hash tree structure is proper.

These changes are for the native verifier. Our recursive circuit already has the proper hash structure baked into it.

[^1]: This is only possible if a Merkle tree has a leaf size of 4, which I don't think occurs in our standard config.