### PR TITLE
Add `flat_map_iter` to `maybe_rayon`

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-plonky2 = { path = "../plonky2" }
+plonky2 = { path = "../plonky2", default-features = false, features = ["rand", "rand_chacha", "timing", "gate_testing"] }
 plonky2_util = { path = "../util" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"

--- a/maybe_rayon/src/lib.rs
+++ b/maybe_rayon/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "parallel"))]
 use std::{
-    iter::{IntoIterator, Iterator, FlatMap},
+    iter::{FlatMap, IntoIterator, Iterator},
     slice::{Chunks, ChunksExact, ChunksExactMut, ChunksMut},
 };
 
@@ -235,7 +235,6 @@ pub trait ParallelIteratorMock {
         Self: Sized,
         U: IntoIterator,
         F: Fn(Self::Item) -> U;
-
 }
 
 #[cfg(not(feature = "parallel"))]
@@ -253,7 +252,7 @@ impl<T: Iterator> ParallelIteratorMock for T {
     where
         Self: Sized,
         U: IntoIterator,
-        F: Fn(Self::Item) -> U
+        F: Fn(Self::Item) -> U,
     {
         self.flat_map(map_op)
     }

--- a/maybe_rayon/src/lib.rs
+++ b/maybe_rayon/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "parallel"))]
 use std::{
-    iter::{IntoIterator, Iterator},
+    iter::{IntoIterator, Iterator, FlatMap},
     slice::{Chunks, ChunksExact, ChunksExactMut, ChunksMut},
 };
 
@@ -223,13 +223,22 @@ impl<T: Send> MaybeParChunksMut<T> for [T] {
     }
 }
 
+#[cfg(not(feature = "parallel"))]
 pub trait ParallelIteratorMock {
     type Item;
     fn find_any<P>(self, predicate: P) -> Option<Self::Item>
     where
         P: Fn(&Self::Item) -> bool + Sync + Send;
+
+    fn flat_map_iter<U, F>(self, map_op: F) -> FlatMap<Self, U, F>
+    where
+        Self: Sized,
+        U: IntoIterator,
+        F: Fn(Self::Item) -> U;
+
 }
 
+#[cfg(not(feature = "parallel"))]
 impl<T: Iterator> ParallelIteratorMock for T {
     type Item = T::Item;
 
@@ -238,6 +247,15 @@ impl<T: Iterator> ParallelIteratorMock for T {
         P: Fn(&Self::Item) -> bool + Sync + Send,
     {
         self.find(predicate)
+    }
+
+    fn flat_map_iter<U, F>(self, map_op: F) -> FlatMap<Self, U, F>
+    where
+        Self: Sized,
+        U: IntoIterator,
+        F: Fn(Self::Item) -> U
+    {
+        self.flat_map(map_op)
     }
 }
 

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -115,7 +115,7 @@ pub struct MerkleCapTarget(pub Vec<HashOutTarget>);
 pub struct BytesHash<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> BytesHash<N> {
-    #[cfg(feature = "parallel")]
+    #[cfg(feature = "rand")]
     pub fn rand_from_rng<R: rand::Rng>(rng: &mut R) -> Self {
         let mut buf = [0; N];
         rng.fill_bytes(&mut buf);

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -9,7 +9,7 @@ default = ["parallel"]
 parallel = ["maybe_rayon/parallel"]
 
 [dependencies]
-plonky2 = { path = "../plonky2", default-features = false }
+plonky2 = { path = "../plonky2", default-features = false, features = ["rand", "timing", "rand_chacha"] }
 plonky2_util = { path = "../util" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -9,7 +9,7 @@ default = ["parallel"]
 parallel = ["maybe_rayon/parallel"]
 
 [dependencies]
-plonky2 = { path = "../plonky2" }
+plonky2 = { path = "../plonky2", default-features = false }
 plonky2_util = { path = "../util" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"


### PR DESCRIPTION
In #678 I used `rayon`'s `flat_map_iter` but I forgot to add it to `maybe_rayon`'s `ParallelIteratorMock` trait, which breaks `starky` and `evm` when the `parallel` feature is disabled. This PR fixes that.

This PR also fixes `starky` and `evm` not disabling default features for `plonky2`, which causes `rayon` to be enabled even if it's disabled by `starky` and `evm`, and it also fixes a feature gate for `BytesHash`.