### PR TITLE
Fix `num_limbs` in `BaseSumGate`

### DIFF
--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -32,7 +32,8 @@ impl<const B: usize> BaseSumGate<B> {
     }
 
     pub fn new_from_config<F: Field64>(config: &CircuitConfig) -> Self {
-        let num_limbs = F::BITS.min(config.num_routed_wires - Self::START_LIMBS);
+        let num_limbs =
+            logarithm(F::ORDER as usize, B).min(config.num_routed_wires - Self::START_LIMBS);
         Self::new(num_limbs)
     }
 
@@ -188,6 +189,23 @@ impl<F: RichField, const B: usize> SimpleGenerator<F> for BaseSplitGenerator<B> 
 
         for (b, b_value) in limbs.zip(limbs_value) {
             out_buffer.set_target(b, b_value);
+        }
+    }
+}
+
+/// Returns the largest `i` such that `base**i < n`.
+const fn logarithm(n: usize, base: usize) -> usize {
+    assert!(n > 0);
+    assert!(base > 1);
+    let mut i = 0;
+    let mut cur: usize = 1;
+    loop {
+        let (mul, overflow) = cur.overflowing_mul(base);
+        if overflow || mul >= n {
+            return i;
+        } else {
+            i += 1;
+            cur = mul;
         }
     }
 }

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use plonky2_field::extension::Extendable;
 use plonky2_field::packed::PackedField;
 use plonky2_field::types::{Field, Field64};
+use plonky2_util::log_floor;
 
 use crate::gates::gate::Gate;
 use crate::gates::packed_util::PackedEvaluableBase;
@@ -33,7 +34,7 @@ impl<const B: usize> BaseSumGate<B> {
 
     pub fn new_from_config<F: Field64>(config: &CircuitConfig) -> Self {
         let num_limbs =
-            logarithm(F::ORDER as usize, B).min(config.num_routed_wires - Self::START_LIMBS);
+            log_floor(F::ORDER as usize, B).min(config.num_routed_wires - Self::START_LIMBS);
         Self::new(num_limbs)
     }
 
@@ -189,23 +190,6 @@ impl<F: RichField, const B: usize> SimpleGenerator<F> for BaseSplitGenerator<B> 
 
         for (b, b_value) in limbs.zip(limbs_value) {
             out_buffer.set_target(b, b_value);
-        }
-    }
-}
-
-/// Returns the largest `i` such that `base**i < n`.
-const fn logarithm(n: usize, base: usize) -> usize {
-    assert!(n > 0);
-    assert!(base > 1);
-    let mut i = 0;
-    let mut cur: usize = 1;
-    loop {
-        let (mul, overflow) = cur.overflowing_mul(base);
-        if overflow || mul >= n {
-            return i;
-        } else {
-            i += 1;
-            cur = mul;
         }
     }
 }

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -34,7 +34,7 @@ impl<const B: usize> BaseSumGate<B> {
 
     pub fn new_from_config<F: Field64>(config: &CircuitConfig) -> Self {
         let num_limbs =
-            log_floor(F::ORDER as usize - 1, B).min(config.num_routed_wires - Self::START_LIMBS);
+            log_floor(F::ORDER - 1, B as u64).min(config.num_routed_wires - Self::START_LIMBS);
         Self::new(num_limbs)
     }
 

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -34,7 +34,7 @@ impl<const B: usize> BaseSumGate<B> {
 
     pub fn new_from_config<F: Field64>(config: &CircuitConfig) -> Self {
         let num_limbs =
-            log_floor(F::ORDER as usize, B).min(config.num_routed_wires - Self::START_LIMBS);
+            log_floor(F::ORDER as usize - 1, B).min(config.num_routed_wires - Self::START_LIMBS);
         Self::new(num_limbs)
     }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -38,7 +38,7 @@ pub fn log2_strict(n: usize) -> usize {
     res as usize
 }
 
-/// Returns the largest `i` such that `base**i < n`.
+/// Returns the largest integer `i` such that `base**i <= n`.
 pub const fn log_floor(n: usize, base: usize) -> usize {
     assert!(n > 0);
     assert!(base > 1);
@@ -46,7 +46,7 @@ pub const fn log_floor(n: usize, base: usize) -> usize {
     let mut cur: usize = 1;
     loop {
         let (mul, overflow) = cur.overflowing_mul(base);
-        if overflow || mul >= n {
+        if overflow || mul > n {
             return i;
         } else {
             i += 1;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -38,6 +38,23 @@ pub fn log2_strict(n: usize) -> usize {
     res as usize
 }
 
+/// Returns the largest `i` such that `base**i < n`.
+pub const fn log_floor(n: usize, base: usize) -> usize {
+    assert!(n > 0);
+    assert!(base > 1);
+    let mut i = 0;
+    let mut cur: usize = 1;
+    loop {
+        let (mul, overflow) = cur.overflowing_mul(base);
+        if overflow || mul >= n {
+            return i;
+        } else {
+            i += 1;
+            cur = mul;
+        }
+    }
+}
+
 /// Permutes `arr` such that each index is mapped to its reverse in binary.
 pub fn reverse_index_bits<T: Copy>(arr: &[T]) -> Vec<T> {
     let n = arr.len();

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -39,11 +39,11 @@ pub fn log2_strict(n: usize) -> usize {
 }
 
 /// Returns the largest integer `i` such that `base**i <= n`.
-pub const fn log_floor(n: usize, base: usize) -> usize {
+pub const fn log_floor(n: u64, base: u64) -> usize {
     assert!(n > 0);
     assert!(base > 1);
     let mut i = 0;
-    let mut cur: usize = 1;
+    let mut cur: u64 = 1;
     loop {
         let (mul, overflow) = cur.overflowing_mul(base);
         if overflow || mul > n {


### PR DESCRIPTION
As observed by auditors, the current way of computing the number of limbs in `BaseSumGate` allows for overflows.