### PR TITLE
Remove `num_virtual_targets` from `CommonCircuitData`

### DIFF
--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -31,7 +31,6 @@ pub(crate) fn generate_partial_witness<
     let mut witness = PartitionWitness::new(
         config.num_wires,
         common_data.degree(),
-        common_data.num_virtual_targets,
         &prover_data.representative_map,
     );
 

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -278,14 +278,9 @@ pub struct PartitionWitness<'a, F: Field> {
 }
 
 impl<'a, F: Field> PartitionWitness<'a, F> {
-    pub fn new(
-        num_wires: usize,
-        degree: usize,
-        num_virtual_targets: usize,
-        representative_map: &'a [usize],
-    ) -> Self {
+    pub fn new(num_wires: usize, degree: usize, representative_map: &'a [usize]) -> Self {
         Self {
-            values: vec![None; degree * num_wires + num_virtual_targets],
+            values: vec![None; representative_map.len()],
             representative_map,
             num_wires,
             degree,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -814,7 +814,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             quotient_degree_factor,
             num_gate_constraints,
             num_constants,
-            num_virtual_targets: self.virtual_target_index,
             num_public_inputs,
             k_is,
             num_partial_products,

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -265,8 +265,6 @@ pub struct CommonCircuitData<
     /// The number of constant wires.
     pub(crate) num_constants: usize,
 
-    pub(crate) num_virtual_targets: usize,
-
     pub(crate) num_public_inputs: usize,
 
     /// The `{k_i}` valued used in `S_ID_i` in Plonk's permutation argument.


### PR DESCRIPTION
Virtual targets are only a prover specific thing and the prover already has access to this info via `ProverOnlyCircuitData::representative_map`.