### PR TITLE
Fix macro vars in `%stack` directives

### DIFF
--- a/evm/src/cpu/kernel/ast.rs
+++ b/evm/src/cpu/kernel/ast.rs
@@ -46,12 +46,25 @@ pub(crate) enum StackPlaceholder {
 /// The right hand side of a %stack stack-manipulation macro.
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub(crate) enum StackReplacement {
+    Literal(U256),
     /// Can be either a named item or a label.
     Identifier(String),
-    Literal(U256),
+    Label(String),
     MacroLabel(String),
     MacroVar(String),
     Constant(String),
+}
+
+impl From<PushTarget> for StackReplacement {
+    fn from(target: PushTarget) -> Self {
+        match target {
+            PushTarget::Literal(x) => Self::Literal(x),
+            PushTarget::Label(l) => Self::Label(l),
+            PushTarget::MacroLabel(l) => Self::MacroLabel(l),
+            PushTarget::MacroVar(v) => Self::MacroVar(v),
+            PushTarget::Constant(c) => Self::Constant(c),
+        }
+    }
 }
 
 /// The target of a `PUSH` operation.

--- a/evm/src/cpu/kernel/stack/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack/stack_manipulation.rs
@@ -52,6 +52,7 @@ fn expand(names: Vec<StackPlaceholder>, replacements: Vec<StackReplacement>) -> 
     let mut dst = replacements
         .into_iter()
         .flat_map(|item| match item {
+            StackReplacement::Literal(n) => vec![StackItem::PushTarget(PushTarget::Literal(n))],
             StackReplacement::Identifier(name) => {
                 // May be either a named item or a label. Named items have precedence.
                 if stack_blocks.contains_key(&name) {
@@ -68,7 +69,7 @@ fn expand(names: Vec<StackPlaceholder>, replacements: Vec<StackReplacement>) -> 
                     vec![StackItem::PushTarget(PushTarget::Label(name))]
                 }
             }
-            StackReplacement::Literal(n) => vec![StackItem::PushTarget(PushTarget::Literal(n))],
+            StackReplacement::Label(name) => vec![StackItem::PushTarget(PushTarget::Label(name))],
             StackReplacement::MacroLabel(_)
             | StackReplacement::MacroVar(_)
             | StackReplacement::Constant(_) => {


### PR DESCRIPTION
They weren't being expanded, as @typ3c4t found.