### PR TITLE
Added a mapping between code hashes and contract byte code

### DIFF
--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use eth_trie_utils::partial_trie::PartialTrie;
-use ethereum_types::Address;
+use ethereum_types::{Address, H256};
 use plonky2::field::extension::Extendable;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
@@ -40,6 +42,10 @@ pub struct GenerationInputs {
     /// A partial version of each storage trie prior to these transactions. It should include all
     /// storage tries, and nodes therein, that will be accessed by these transactions.
     pub storage_tries: Vec<(Address, PartialTrie)>,
+
+    /// Mapping between smart contract code hashes and the contract byte code.
+    /// All account smart contracts that are invoked will have an entry present.
+    pub contract_code: HashMap<H256, Vec<u8>>,
 
     pub block_metadata: BlockMetadata,
 }

--- a/evm/tests/transfer_to_new_addr.rs
+++ b/evm/tests/transfer_to_new_addr.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use eth_trie_utils::partial_trie::PartialTrie;
 use hex_literal::hex;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -31,6 +33,7 @@ fn test_simple_transfer() -> anyhow::Result<()> {
         transactions_trie: PartialTrie::Empty,
         receipts_trie: PartialTrie::Empty,
         storage_tries: vec![],
+        contract_code: HashMap::new(),
         block_metadata,
     };
 


### PR DESCRIPTION
Added a mapping between an account's `code_hash` field and the actual contract byte code in `GenerationInputs`.