### PR TITLE
Trie roots now use `H256` instead of `U256`

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 [dependencies]
 plonky2 = { path = "../plonky2", default-features = false, features = ["rand", "timing"] }
 plonky2_util = { path = "../util" }
-eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "c52a04c9f349ac812b886f383a7306b27c8b96dc" }
+eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "dd3595b4ba7923f8d465450d210f17a2b4e20f96" }
 maybe_rayon = { path = "../maybe_rayon" }
 anyhow = "1.0.40"
 env_logger = "0.9.0"
-ethereum-types = "0.13.1"
+ethereum-types = "0.14.0"
 hex = { version = "0.4.3", optional = true }
 hex-literal = "0.3.4"
 itertools = "0.10.3"

--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::{anyhow, bail, ensure};
-use ethereum_types::{BigEndianHash, U256, U512};
+use ethereum_types::{U256, U512};
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
 
@@ -444,7 +444,7 @@ impl<'a> Interpreter<'a> {
             })
             .collect::<Vec<_>>();
         let hash = keccak(bytes);
-        self.push(hash.into_uint());
+        self.push(U256::from_big_endian(hash.as_bytes()));
     }
 
     fn run_prover_input(&mut self) -> anyhow::Result<()> {

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use eth_trie_utils::partial_trie::PartialTrie;
-use ethereum_types::{Address, H256};
+use ethereum_types::{Address, BigEndianHash, H256};
 use plonky2::field::extension::Extendable;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
@@ -86,14 +86,20 @@ pub(crate) fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     };
 
     let trie_roots_before = TrieRoots {
-        state_root: read_metadata(GlobalMetadata::StateTrieRootDigestBefore),
-        transactions_root: read_metadata(GlobalMetadata::TransactionsTrieRootDigestBefore),
-        receipts_root: read_metadata(GlobalMetadata::ReceiptsTrieRootDigestBefore),
+        state_root: H256::from_uint(&read_metadata(GlobalMetadata::StateTrieRootDigestBefore)),
+        transactions_root: H256::from_uint(&read_metadata(
+            GlobalMetadata::TransactionsTrieRootDigestBefore,
+        )),
+        receipts_root: H256::from_uint(&read_metadata(
+            GlobalMetadata::ReceiptsTrieRootDigestBefore,
+        )),
     };
     let trie_roots_after = TrieRoots {
-        state_root: read_metadata(GlobalMetadata::StateTrieRootDigestAfter),
-        transactions_root: read_metadata(GlobalMetadata::TransactionsTrieRootDigestAfter),
-        receipts_root: read_metadata(GlobalMetadata::ReceiptsTrieRootDigestAfter),
+        state_root: H256::from_uint(&read_metadata(GlobalMetadata::StateTrieRootDigestAfter)),
+        transactions_root: H256::from_uint(&read_metadata(
+            GlobalMetadata::TransactionsTrieRootDigestAfter,
+        )),
+        receipts_root: H256::from_uint(&read_metadata(GlobalMetadata::ReceiptsTrieRootDigestAfter)),
     };
 
     let GenerationState {

--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -52,7 +52,7 @@ pub(crate) fn mpt_prover_inputs<F>(
     prover_inputs.push((PartialTrieType::of(trie) as u32).into());
     match trie {
         PartialTrie::Empty => {}
-        PartialTrie::Hash(h) => prover_inputs.push(*h),
+        PartialTrie::Hash(h) => prover_inputs.push(U256::from_big_endian(h.as_bytes())),
         PartialTrie::Branch { children, value } => {
             for child in children {
                 mpt_prover_inputs(child, prover_inputs, parse_leaf);

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -1,4 +1,4 @@
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
 use itertools::Itertools;
 use maybe_rayon::*;
 use plonky2::field::extension::{Extendable, FieldExtension};
@@ -54,9 +54,9 @@ pub struct PublicValues {
 
 #[derive(Debug, Clone, Default)]
 pub struct TrieRoots {
-    pub state_root: U256,
-    pub transactions_root: U256,
-    pub receipts_root: U256,
+    pub state_root: H256,
+    pub transactions_root: H256,
+    pub receipts_root: H256,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -11,7 +11,6 @@ use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::with_context;
 
-use crate::all_stark::{AllStark, Table};
 use crate::config::StarkConfig;
 use crate::constraint_consumer::RecursiveConstraintConsumer;
 use crate::cpu::cpu_stark::CpuStark;
@@ -27,9 +26,13 @@ use crate::proof::{
     StarkProofChallengesTarget, StarkProofTarget, TrieRoots, TrieRootsTarget,
 };
 use crate::stark::Stark;
-use crate::util::{h160_limbs, u256_limbs};
+use crate::util::h160_limbs;
 use crate::vanishing_poly::eval_vanishing_poly_circuit;
 use crate::vars::StarkEvaluationTargets;
+use crate::{
+    all_stark::{AllStark, Table},
+    util::h256_limbs,
+};
 
 pub fn verify_proof_circuit<
     F: RichField + Extendable<D>,
@@ -504,15 +507,15 @@ pub fn set_trie_roots_target<F, W, const D: usize>(
 {
     witness.set_target_arr(
         trie_roots_target.state_root,
-        u256_limbs(trie_roots.state_root),
+        h256_limbs(trie_roots.state_root),
     );
     witness.set_target_arr(
         trie_roots_target.transactions_root,
-        u256_limbs(trie_roots.transactions_root),
+        h256_limbs(trie_roots.transactions_root),
     );
     witness.set_target_arr(
         trie_roots_target.receipts_root,
-        u256_limbs(trie_roots.receipts_root),
+        h256_limbs(trie_roots.receipts_root),
     );
 }
 

--- a/evm/src/util.rs
+++ b/evm/src/util.rs
@@ -1,6 +1,6 @@
 use std::mem::{size_of, transmute_copy, ManuallyDrop};
 
-use ethereum_types::{H160, U256};
+use ethereum_types::{H160, H256, U256};
 use itertools::Itertools;
 use plonky2::field::extension::Extendable;
 use plonky2::field::packed::PackedField;
@@ -53,6 +53,17 @@ pub(crate) fn u256_limbs<F: Field>(u256: U256) -> [F; 8] {
             let hi = (limb_64 >> 32) as u32;
             [lo, hi]
         })
+        .map(F::from_canonical_u32)
+        .collect_vec()
+        .try_into()
+        .unwrap()
+}
+
+/// Returns the 32-bit little-endian limbs of a `H256`.
+pub(crate) fn h256_limbs<F: Field>(h256: H256) -> [F; 8] {
+    h256.0
+        .chunks(4)
+        .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
         .map(F::from_canonical_u32)
         .collect_vec()
         .try_into()


### PR DESCRIPTION
`H256` preserves any leading `0`s, which could be critical in some situations. Also just a slightly more appropriate type for hashes.