### PR TITLE
Inline some SHA2 constants

### DIFF
--- a/evm/src/cpu/kernel/asm/sha2/compression.asm
+++ b/evm/src/cpu/kernel/asm/sha2/compression.asm
@@ -22,36 +22,15 @@ global sha2_compression:
     // stack: scratch_space_addr, num_blocks, message_schedule_addr, i=0, retdest
     SWAP1
     // stack: num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(28)
-    %mload_kernel_code_u32
-    // stack: h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(24)
-    %mload_kernel_code_u32
-    // stack: g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(20)
-    %mload_kernel_code_u32
-    // stack: f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(16)
-    %mload_kernel_code_u32
-    // stack: e[0], f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(12)
-    %mload_kernel_code_u32
-    // stack: d[0], e[0], f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(8)
-    %mload_kernel_code_u32
-    // stack: c[0], d[0], e[0], f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %add_const(4)
-    %mload_kernel_code_u32
-    // stack: b[0], c[0], d[0], e[0], f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
-    PUSH sha2_constants_h
-    %mload_kernel_code_u32
+    // Push the initial hash values; these constants are called H^(0) in the spec.
+    PUSH 0x5be0cd19 // H^(0)_7
+    PUSH 0x1f83d9ab // H^(0)_6
+    PUSH 0x9b05688c // H^(0)_5
+    PUSH 0x510e527f // H^(0)_4
+    PUSH 0xa54ff53a // H^(0)_3
+    PUSH 0x3c6ef372 // H^(0)_2
+    PUSH 0xbb67ae85 // H^(0)_1
+    PUSH 0x6a09e667 // H^(0)_0
     // stack: a[0], b[0], c[0], d[0], e[0], f[0], g[0], h[0], num_blocks, scratch_space_addr, message_schedule_addr, i=0, retdest
 compression_start_block:
     // Store the current values of the working variables, as the "initial values" to be added back in at the end of this block.

--- a/evm/src/cpu/kernel/asm/sha2/constants.asm
+++ b/evm/src/cpu/kernel/asm/sha2/constants.asm
@@ -63,13 +63,3 @@ global sha2_constants_k:
     BYTES 164, 80, 108, 235
     BYTES 190, 249, 163, 247
     BYTES 198, 113, 120, 242
-
-global sha2_constants_h:
-    BYTES 106, 9, 230, 103
-    BYTES 187, 103, 174, 133
-    BYTES 60, 110, 243, 114
-    BYTES 165, 79, 245, 58
-    BYTES 81, 14, 82, 127
-    BYTES 155, 5, 104, 140
-    BYTES 31, 131, 217, 171
-    BYTES 91, 224, 205, 25


### PR DESCRIPTION
I think `%mload_kernel_code_u32` is good when we need to do random access, but since the indices are constant here, let's just hardcode them like this.

This reduces the assembled size of `compression.asm` from 1827 to 1454 bytes. I think there's still a lot more we could do to shrink it, though it's not that important.