### PR TITLE
Fix RipeMD padlength issue

### DIFF
--- a/evm/src/cpu/kernel/asm/ripemd/main.asm
+++ b/evm/src/cpu/kernel/asm/ripemd/main.asm
@@ -88,20 +88,20 @@ global process:
 
 
 /// def padlength(length):
-///    t = length % 64
-///    return 56 + 64*(t > 47) - t
+///     t = length % 64
+///     return 56 + 64*(t > 55) - t
 
 %macro padlength
     // stack:          count
     %mod_const(64)
     // stack:      t = count % 64
-    PUSH 47
+    PUSH 55
     DUP2
-    // stack:          t , 47 , t
+    // stack:          t , 55 , t
     GT
-    // stack:          t > 47 , t
+    // stack:          t > 55 , t
     %mul_const(64)
     %add_const(56)
-    // stack: 56 + 64*(t > 47), t 
+    // stack: 56 + 64*(t > 55), t 
     SUB
 %endmacro

--- a/evm/src/cpu/kernel/tests/hash.rs
+++ b/evm/src/cpu/kernel/tests/hash.rs
@@ -23,27 +23,24 @@ fn ripemd(input: Vec<u8>) -> U256 {
     U256::from(&hasher.finalize()[..])
 }
 
-fn make_random_input() -> (u32, Vec<u8>) {
+fn make_random_input() -> Vec<u8> {
     // Generate a random message, between 0 and 9999 bytes.
     let mut rng = thread_rng();
     let num_bytes = rng.gen_range(0..10000);
-    (num_bytes, (0..num_bytes).map(|_| rng.gen()).collect())
+    (0..num_bytes).map(|_| rng.gen()).collect()
 }
 
-fn make_custom_input() -> (u32, Vec<u8>) {
+fn make_custom_input() -> Vec<u8> {
     // Hardcode a custom message
-    (
-        48,
-        vec![
-            86, 124, 206, 245, 74, 57, 250, 43, 60, 30, 254, 43, 143, 144, 242, 215, 13, 103, 237,
-            61, 90, 105, 123, 250, 189, 181, 110, 192, 227, 57, 145, 46, 221, 238, 7, 181, 146,
-            111, 209, 150, 31, 157, 229, 126, 206, 105, 37, 17,
-        ],
-    )
+    vec![
+        86, 124, 206, 245, 74, 57, 250, 43, 60, 30, 254, 43, 143, 144, 242, 215, 13, 103, 237, 61,
+        90, 105, 123, 250, 189, 181, 110, 192, 227, 57, 145, 46, 221, 238, 7, 181, 146, 111, 209,
+        150, 31, 157, 229, 126, 206, 105, 37, 17,
+    ]
 }
 
-fn make_input_stack(length: u32, message: Vec<u8>) -> Vec<U256> {
-    let mut initial_stack = vec![U256::from(length)];
+fn make_input_stack(message: Vec<u8>) -> Vec<U256> {
+    let mut initial_stack = vec![U256::from(message.len())];
     let bytes: Vec<U256> = message.iter().map(|&x| U256::from(x as u32)).collect();
     initial_stack.extend(bytes);
     initial_stack.push(U256::from_str("0xdeadbeef").unwrap());
@@ -52,17 +49,17 @@ fn make_input_stack(length: u32, message: Vec<u8>) -> Vec<U256> {
 }
 
 fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U256) -> Result<()> {
-    // Make the inputs.
-    let (length_random, message_random) = make_random_input();
-    let (length_custom, message_custom) = make_custom_input();
+    // Make the input.
+    let message_random = make_random_input();
+    let message_custom = make_custom_input();
 
     // Hash the message using a standard implementation.
     let expected_random = standard_implementation(message_random.clone());
     let expected_custom = standard_implementation(message_custom.clone());
 
     // Load the message onto the stack.
-    let initial_stack_random = make_input_stack(length_random, message_random);
-    let initial_stack_custom = make_input_stack(length_custom, message_custom);
+    let initial_stack_random = make_input_stack(message_random);
+    let initial_stack_custom = make_input_stack(message_custom);
 
     // Make the kernel.
     let kernel = combined_kernel();
@@ -72,15 +69,12 @@ fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U
     let result_random = run_with_kernel(&kernel, kernel_function, initial_stack_random)?;
     let result_custom = run_with_kernel(&kernel, kernel_function, initial_stack_custom)?;
 
-    // Print stack for debugging
-    // let printable_stack: Vec <String> = result.stack().iter().map(|x| format!("{:x}", x)).collect();
-    // println!("{:#?}", printable_stack);
+    // Extract the final output.
+    let actual_random = result_random.stack()[0];
+    let actual_custom = result_custom.stack()[0];
 
     // Check that the result is correct.
-    let actual_random = result_random.stack()[0];
     assert_eq!(expected_random, actual_random);
-
-    let actual_custom = result_custom.stack()[0];
     assert_eq!(expected_custom, actual_custom);
 
     Ok(())

--- a/evm/src/cpu/kernel/tests/hash.rs
+++ b/evm/src/cpu/kernel/tests/hash.rs
@@ -32,14 +32,17 @@ fn make_random_input() -> (u32, Vec<u8>) {
 
 fn make_custom_input() -> (u32, Vec<u8>) {
     // Hardcode a custom message
-    (48, vec![
-        86, 124, 206, 245, 74, 57, 250, 43, 60, 30, 254, 43, 143, 144, 242, 215, 13, 103, 237, 61,
-        90, 105, 123, 250, 189, 181, 110, 192, 227, 57, 145, 46, 221, 238, 7, 181, 146, 111, 209,
-        150, 31, 157, 229, 126, 206, 105, 37, 17,
-    ])
+    (
+        48,
+        vec![
+            86, 124, 206, 245, 74, 57, 250, 43, 60, 30, 254, 43, 143, 144, 242, 215, 13, 103, 237,
+            61, 90, 105, 123, 250, 189, 181, 110, 192, 227, 57, 145, 46, 221, 238, 7, 181, 146,
+            111, 209, 150, 31, 157, 229, 126, 206, 105, 37, 17,
+        ],
+    )
 }
 
-fn make_input_stack(length: u32, message: Vec<u8>) ->  Vec<U256> {
+fn make_input_stack(length: u32, message: Vec<u8>) -> Vec<U256> {
     let mut initial_stack = vec![U256::from(length)];
     let bytes: Vec<U256> = message.iter().map(|&x| U256::from(x as u32)).collect();
     initial_stack.extend(bytes);
@@ -50,7 +53,7 @@ fn make_input_stack(length: u32, message: Vec<u8>) ->  Vec<U256> {
 
 fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U256) -> Result<()> {
     // Make the inputs.
-    let (length_random, message_random) = make_random_input(); 
+    let (length_random, message_random) = make_random_input();
     let (length_custom, message_custom) = make_custom_input();
 
     // Hash the message using a standard implementation.
@@ -68,7 +71,7 @@ fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U
     // Run the kernel code.
     let result_random = run_with_kernel(&kernel, kernel_function, initial_stack_random)?;
     let result_custom = run_with_kernel(&kernel, kernel_function, initial_stack_custom)?;
-    
+
     // Print stack for debugging
     // let printable_stack: Vec <String> = result.stack().iter().map(|x| format!("{:x}", x)).collect();
     // println!("{:#?}", printable_stack);

--- a/evm/src/cpu/kernel/tests/hash.rs
+++ b/evm/src/cpu/kernel/tests/hash.rs
@@ -23,31 +23,62 @@ fn ripemd(input: Vec<u8>) -> U256 {
     U256::from(&hasher.finalize()[..])
 }
 
-fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U256) -> Result<()> {
-    let kernel = combined_kernel();
-    let mut rng = thread_rng();
-
+fn make_random_input() -> (u32, Vec<u8>) {
     // Generate a random message, between 0 and 9999 bytes.
+    let mut rng = thread_rng();
     let num_bytes = rng.gen_range(0..10000);
-    let message: Vec<u8> = (0..num_bytes).map(|_| rng.gen()).collect();
+    (num_bytes, (0..num_bytes).map(|_| rng.gen()).collect())
+}
 
-    // Hash the message using a standard implementation.
-    let expected = standard_implementation(message.clone());
+fn make_custom_input() -> (u32, Vec<u8>) {
+    // Hardcode a custom message
+    (48, vec![
+        86, 124, 206, 245, 74, 57, 250, 43, 60, 30, 254, 43, 143, 144, 242, 215, 13, 103, 237, 61,
+        90, 105, 123, 250, 189, 181, 110, 192, 227, 57, 145, 46, 221, 238, 7, 181, 146, 111, 209,
+        150, 31, 157, 229, 126, 206, 105, 37, 17,
+    ])
+}
 
-    // Load the message onto the stack.
-    let mut initial_stack = vec![U256::from(num_bytes)];
+fn make_input_stack(length: u32, message: Vec<u8>) ->  Vec<U256> {
+    let mut initial_stack = vec![U256::from(length)];
     let bytes: Vec<U256> = message.iter().map(|&x| U256::from(x as u32)).collect();
     initial_stack.extend(bytes);
     initial_stack.push(U256::from_str("0xdeadbeef").unwrap());
     initial_stack.reverse();
+    initial_stack
+}
+
+fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U256) -> Result<()> {
+    // Make the inputs.
+    let (length_random, message_random) = make_random_input(); 
+    let (length_custom, message_custom) = make_custom_input();
+
+    // Hash the message using a standard implementation.
+    let expected_random = standard_implementation(message_random.clone());
+    let expected_custom = standard_implementation(message_custom.clone());
+
+    // Load the message onto the stack.
+    let initial_stack_random = make_input_stack(length_random, message_random);
+    let initial_stack_custom = make_input_stack(length_custom, message_custom);
+
+    // Make the kernel.
+    let kernel = combined_kernel();
+    let kernel_function = kernel.global_labels[hash_fn_label];
 
     // Run the kernel code.
-    let kernel_function = kernel.global_labels[hash_fn_label];
-    let result = run_with_kernel(&kernel, kernel_function, initial_stack)?;
-    let actual = result.stack()[0];
+    let result_random = run_with_kernel(&kernel, kernel_function, initial_stack_random)?;
+    let result_custom = run_with_kernel(&kernel, kernel_function, initial_stack_custom)?;
+    
+    // Print stack for debugging
+    // let printable_stack: Vec <String> = result.stack().iter().map(|x| format!("{:x}", x)).collect();
+    // println!("{:#?}", printable_stack);
 
     // Check that the result is correct.
-    assert_eq!(expected, actual);
+    let actual_random = result_random.stack()[0];
+    assert_eq!(expected_random, actual_random);
+
+    let actual_custom = result_custom.stack()[0];
+    assert_eq!(expected_custom, actual_custom);
 
     Ok(())
 }


### PR DESCRIPTION
The problem was downstream of an error in my simplification of the original Python implementation. The original paldength definition was:
```python
x = 64 - length % 64
if x < 9:
    x += 64
return x - 8
```
and in my Python code, I had made the error of computing it as
```py
x = 56 - length % 64
return x + (x < 9)*64
```
where I subtracted `64 - 8 = 56` but still checked `x < 9`, rather than what should have been `x < 1`

Note that, to avoid overflow, in the asm it's now
```py
t = length % 64
return 56 + 64*(t > 55) - t
```
where before the check was `t > 47`