### PR TITLE
Redundant `degree_bits`

### DIFF
--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -146,7 +146,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         }
 
         // Verify the CTL checks.
-        let degrees_bits = std::array::from_fn(|i| verifier_data[i].common.degree_bits);
+        let degrees_bits = std::array::from_fn(|i| verifier_data[i].common.degree_bits());
         verify_cross_table_lookups::<F, C, D>(
             cross_table_lookups,
             pis.map(|p| p.ctl_zs_last),
@@ -221,7 +221,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         }
 
         // Verify the CTL checks.
-        let degrees_bits = std::array::from_fn(|i| verifier_data[i].common.degree_bits);
+        let degrees_bits = std::array::from_fn(|i| verifier_data[i].common.degree_bits());
         verify_cross_table_lookups_circuit::<F, C, D>(
             builder,
             cross_table_lookups,

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -190,7 +190,7 @@ fn benchmark(config: &CircuitConfig, log2_inner_size: usize) -> Result<()> {
     info!(
         "Initial proof degree {} = 2^{}",
         cd.degree(),
-        cd.degree_bits
+        cd.degree_bits()
     );
 
     // Recursively verify the proof
@@ -199,7 +199,7 @@ fn benchmark(config: &CircuitConfig, log2_inner_size: usize) -> Result<()> {
     info!(
         "Single recursion proof degree {} = 2^{}",
         cd.degree(),
-        cd.degree_bits
+        cd.degree_bits()
     );
 
     // Add a second layer of recursion to shrink the proof size further
@@ -208,7 +208,7 @@ fn benchmark(config: &CircuitConfig, log2_inner_size: usize) -> Result<()> {
     info!(
         "Double recursion proof degree {} = 2^{}",
         cd.degree(),
-        cd.degree_bits
+        cd.degree_bits()
     );
 
     test_serialization(proof, cd)?;

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -829,7 +829,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let common = CommonCircuitData {
             config: self.config,
             fri_params,
-            degree_bits,
             gates,
             selectors_info,
             quotient_degree_factor,

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -273,8 +273,6 @@ pub struct CommonCircuitData<
 
     pub(crate) fri_params: FriParams,
 
-    pub degree_bits: usize,
-
     /// The types of gates used in this circuit, along with their prefixes.
     pub(crate) gates: Vec<GateRef<F, D>>,
 
@@ -306,16 +304,20 @@ pub struct CommonCircuitData<
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     CommonCircuitData<F, C, D>
 {
+    pub const fn degree_bits(&self) -> usize {
+        self.fri_params.degree_bits
+    }
+
     pub fn degree(&self) -> usize {
-        1 << self.degree_bits
+        1 << self.degree_bits()
     }
 
     pub fn lde_size(&self) -> usize {
-        1 << (self.degree_bits + self.config.fri_config.rate_bits)
+        self.fri_params.lde_size()
     }
 
     pub fn lde_generator(&self) -> F {
-        F::primitive_root_of_unity(self.degree_bits + self.config.fri_config.rate_bits)
+        F::primitive_root_of_unity(self.degree_bits() + self.config.fri_config.rate_bits)
     }
 
     pub fn constraint_degree(&self) -> usize {
@@ -358,7 +360,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         };
 
         // The Z polynomials are also opened at g * zeta.
-        let g = F::Extension::primitive_root_of_unity(self.degree_bits);
+        let g = F::Extension::primitive_root_of_unity(self.degree_bits());
         let zeta_next = g * zeta;
         let zeta_next_batch = FriBatchInfo {
             point: zeta_next,
@@ -384,7 +386,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         };
 
         // The Z polynomials are also opened at g * zeta.
-        let g = F::primitive_root_of_unity(self.degree_bits);
+        let g = F::primitive_root_of_unity(self.degree_bits());
         let zeta_next = builder.mul_const_extension(g, zeta);
         let zeta_next_batch = FriBatchInfoTarget {
             point: zeta_next,

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -61,7 +61,7 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
             commit_phase_merkle_caps,
             final_poly,
             pow_witness,
-            common_data.degree_bits,
+            common_data.degree_bits(),
             &config.fri_config,
         ),
     })
@@ -175,7 +175,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             &self.proof.openings.to_fri_openings(),
             *fri_alpha,
         );
-        let log_n = common_data.degree_bits + common_data.config.fri_config.rate_bits;
+        let log_n = common_data.degree_bits() + common_data.config.fri_config.rate_bits;
         // Simulate the proof verification and collect the inferred elements.
         // The content of the loop is basically the same as the `fri_verifier_query_round` function.
         for &(mut x_index) in fri_query_indices {

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -172,9 +172,9 @@ where
     // To avoid leaking witness data, we want to ensure that our opening locations, `zeta` and
     // `g * zeta`, are not in our subgroup `H`. It suffices to check `zeta` only, since
     // `(g * zeta)^n = zeta^n`, where `n` is the order of `g`.
-    let g = F::Extension::primitive_root_of_unity(common_data.degree_bits);
+    let g = F::Extension::primitive_root_of_unity(common_data.degree_bits());
     ensure!(
-        zeta.exp_power_of_2(common_data.degree_bits) != F::Extension::ONE,
+        zeta.exp_power_of_2(common_data.degree_bits()) != F::Extension::ONE,
         "Opening point is in the subgroup."
     );
 
@@ -342,10 +342,10 @@ fn compute_quotient_polys<
     // steps away since we work on an LDE of degree `max_filtered_constraint_degree`.
     let next_step = 1 << quotient_degree_bits;
 
-    let points = F::two_adic_subgroup(common_data.degree_bits + quotient_degree_bits);
+    let points = F::two_adic_subgroup(common_data.degree_bits() + quotient_degree_bits);
     let lde_size = points.len();
 
-    let z_h_on_coset = ZeroPolyOnCoset::new(common_data.degree_bits, quotient_degree_bits);
+    let z_h_on_coset = ZeroPolyOnCoset::new(common_data.degree_bits(), quotient_degree_bits);
 
     let points_batches = points.par_chunks(BATCH_SIZE);
     let num_batches = ceil_div_usize(points.len(), BATCH_SIZE);

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -66,7 +66,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let partial_products = &proof.openings.partial_products;
 
         let zeta_pow_deg =
-            self.exp_power_of_2_extension(challenges.plonk_zeta, inner_common_data.degree_bits);
+            self.exp_power_of_2_extension(challenges.plonk_zeta, inner_common_data.degree_bits());
         let vanishing_polys_zeta = with_context!(
             self,
             "evaluate the vanishing polynomial at our challenge point, zeta.",
@@ -223,17 +223,17 @@ mod tests {
 
         // Start with a degree 2^14 proof
         let (proof, vd, cd) = dummy_proof::<F, C, D>(&config, 16_000)?;
-        assert_eq!(cd.degree_bits, 14);
+        assert_eq!(cd.degree_bits(), 14);
 
         // Shrink it to 2^13.
         let (proof, vd, cd) =
             recursive_proof::<F, C, C, D>(proof, vd, cd, &config, Some(13), false, false)?;
-        assert_eq!(cd.degree_bits, 13);
+        assert_eq!(cd.degree_bits(), 13);
 
         // Shrink it to 2^12.
         let (proof, _vd, cd) =
             recursive_proof::<F, C, C, D>(proof, vd, cd, &config, None, true, true)?;
-        assert_eq!(cd.degree_bits, 12);
+        assert_eq!(cd.degree_bits(), 12);
 
         test_serialization(&proof, &cd)?;
 
@@ -255,11 +255,11 @@ mod tests {
 
         // An initial dummy proof.
         let (proof, vd, cd) = dummy_proof::<F, C, D>(&standard_config, 4_000)?;
-        assert_eq!(cd.degree_bits, 12);
+        assert_eq!(cd.degree_bits(), 12);
 
         // A standard recursive proof.
         let (proof, vd, cd) = recursive_proof(proof, vd, cd, &standard_config, None, false, false)?;
-        assert_eq!(cd.degree_bits, 12);
+        assert_eq!(cd.degree_bits(), 12);
 
         // A high-rate recursive proof, designed to be verifiable with fewer routed wires.
         let high_rate_config = CircuitConfig {
@@ -273,7 +273,7 @@ mod tests {
         };
         let (proof, vd, cd) =
             recursive_proof::<F, C, C, D>(proof, vd, cd, &high_rate_config, None, true, true)?;
-        assert_eq!(cd.degree_bits, 12);
+        assert_eq!(cd.degree_bits(), 12);
 
         // A final proof, optimized for size.
         let final_config = CircuitConfig {
@@ -289,7 +289,7 @@ mod tests {
         };
         let (proof, _vd, cd) =
             recursive_proof::<F, KC, C, D>(proof, vd, cd, &final_config, None, true, true)?;
-        assert_eq!(cd.degree_bits, 12, "final proof too large");
+        assert_eq!(cd.degree_bits(), 12, "final proof too large");
 
         test_serialization(&proof, &cd)?;
 

--- a/plonky2/src/plonk/verifier.rs
+++ b/plonky2/src/plonk/verifier.rs
@@ -78,7 +78,7 @@ where
     let quotient_polys_zeta = &proof.openings.quotient_polys;
     let zeta_pow_deg = challenges
         .plonk_zeta
-        .exp_power_of_2(common_data.degree_bits);
+        .exp_power_of_2(common_data.degree_bits());
     let z_h_zeta = zeta_pow_deg - F::Extension::ONE;
     // `quotient_polys_zeta` holds `num_challenges * quotient_degree_factor` evaluations.
     // Each chunk of `quotient_degree_factor` holds the evaluations of `t_0(zeta),...,t_{quotient_degree_factor-1}(zeta)`


### PR DESCRIPTION
`degree_bits` is a field of `FriParams` and `CommonCircuitData`, but `FriParams` is also a field of `CommonCircuitData`, so there's some (unchecked) redundancy.
Fixed that by removing `degree_bits` from `CommonCircuitData`.