### PR TITLE
Switch a few uses of current-context memory to kernel memory

### DIFF
--- a/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
+++ b/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
@@ -132,7 +132,7 @@ pubkey_to_addr:
     // stack: PKx, PKy, retdest
     PUSH 0
     // stack: 0, PKx, PKy, retdest
-    MSTORE // TODO: switch to kernel memory (like `%mstore_current(@SEGMENT_KERNEL_GENERAL)`).
+    MSTORE // TODO: switch to kernel memory (like `%mstore_kernel(@SEGMENT_KERNEL_GENERAL)`).
     // stack: PKy, retdest
     PUSH 0x20
     // stack: 0x20, PKy, retdest

--- a/evm/src/cpu/kernel/asm/rlp/decode.asm
+++ b/evm/src/cpu/kernel/asm/rlp/decode.asm
@@ -14,7 +14,7 @@
 global decode_rlp_string_len:
     // stack: pos, retdest
     DUP1
-    %mload_current(@SEGMENT_RLP_RAW)
+    %mload_kernel(@SEGMENT_RLP_RAW)
     // stack: first_byte, pos, retdest
     DUP1
     %gt_const(0xb7)
@@ -89,7 +89,7 @@ global decode_rlp_scalar:
 global decode_rlp_list_len:
     // stack: pos, retdest
     DUP1
-    %mload_current(@SEGMENT_RLP_RAW)
+    %mload_kernel(@SEGMENT_RLP_RAW)
     // stack: first_byte, pos, retdest
     SWAP1
     %increment // increment pos
@@ -151,7 +151,7 @@ decode_int_given_len_loop:
     // stack: acc << 8, pos, end_pos, retdest
     DUP2
     // stack: pos, acc << 8, pos, end_pos, retdest
-    %mload_current(@SEGMENT_RLP_RAW)
+    %mload_kernel(@SEGMENT_RLP_RAW)
     // stack: byte, acc << 8, pos, end_pos, retdest
     ADD
     // stack: acc', pos, end_pos, retdest

--- a/evm/src/cpu/kernel/asm/rlp/read_to_memory.asm
+++ b/evm/src/cpu/kernel/asm/rlp/read_to_memory.asm
@@ -23,7 +23,7 @@ read_rlp_to_memory_loop:
     // stack: byte, pos, len, retdest
     DUP2
     // stack: pos, byte, pos, len, retdest
-    %mstore_current(@SEGMENT_RLP_RAW)
+    %mstore_kernel(@SEGMENT_RLP_RAW)
     // stack: pos, len, retdest
     %increment
     // stack: pos', len, retdest

--- a/evm/src/cpu/kernel/asm/transactions/router.asm
+++ b/evm/src/cpu/kernel/asm/transactions/router.asm
@@ -18,14 +18,14 @@ read_txn_from_memory:
     // first byte >= 0xc0, so there is no overlap.
 
     PUSH 0
-    %mload_current(@SEGMENT_RLP_RAW)
+    %mload_kernel(@SEGMENT_RLP_RAW)
     %eq_const(1)
     // stack: first_byte == 1, retdest
     %jumpi(process_type_1_txn)
     // stack: retdest
 
     PUSH 0
-    %mload_current(@SEGMENT_RLP_RAW)
+    %mload_kernel(@SEGMENT_RLP_RAW)
     %eq_const(2)
     // stack: first_byte == 2, retdest
     %jumpi(process_type_2_txn)


### PR DESCRIPTION
E.g. make sure the RLP segment is only used with the kernel context. Using current-context memory would also work, we just need to be consistent.

For transaction parsing etc, the context should be 0 anyway, but explicitly referring to kernel memory feels more idiomatic to me.