### PR TITLE
Implement SUBMOD instruction

### DIFF
--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -53,6 +53,8 @@ impl<F: RichField, const D: usize> ArithmeticStark<F, D> {
             compare::generate(local_values, columns::IS_GT);
         } else if local_values[columns::IS_ADDMOD].is_one() {
             modular::generate(local_values, columns::IS_ADDMOD);
+        } else if local_values[columns::IS_SUBMOD].is_one() {
+            modular::generate(local_values, columns::IS_SUBMOD);
         } else if local_values[columns::IS_MULMOD].is_one() {
             modular::generate(local_values, columns::IS_MULMOD);
         } else if local_values[columns::IS_MOD].is_one() {

--- a/evm/src/arithmetic/columns.rs
+++ b/evm/src/arithmetic/columns.rs
@@ -26,7 +26,8 @@ pub const IS_SDIV: usize = IS_DIV + 1;
 pub const IS_MOD: usize = IS_SDIV + 1;
 pub const IS_SMOD: usize = IS_MOD + 1;
 pub const IS_ADDMOD: usize = IS_SMOD + 1;
-pub const IS_MULMOD: usize = IS_ADDMOD + 1;
+pub const IS_SUBMOD: usize = IS_ADDMOD + 1;
+pub const IS_MULMOD: usize = IS_SUBMOD + 1;
 pub const IS_LT: usize = IS_MULMOD + 1;
 pub const IS_GT: usize = IS_LT + 1;
 pub const IS_SLT: usize = IS_GT + 1;
@@ -37,9 +38,9 @@ pub const IS_SAR: usize = IS_SHR + 1;
 
 const START_SHARED_COLS: usize = IS_SAR + 1;
 
-pub(crate) const ALL_OPERATIONS: [usize; 16] = [
-    IS_ADD, IS_MUL, IS_SUB, IS_DIV, IS_SDIV, IS_MOD, IS_SMOD, IS_ADDMOD, IS_MULMOD, IS_LT, IS_GT,
-    IS_SLT, IS_SGT, IS_SHL, IS_SHR, IS_SAR,
+pub(crate) const ALL_OPERATIONS: [usize; 17] = [
+    IS_ADD, IS_MUL, IS_SUB, IS_DIV, IS_SDIV, IS_MOD, IS_SMOD, IS_ADDMOD, IS_SUBMOD, IS_MULMOD,
+    IS_LT, IS_GT, IS_SLT, IS_SGT, IS_SHL, IS_SHR, IS_SAR,
 ];
 
 /// Within the Arithmetic Unit, there are shared columns which can be

--- a/evm/src/arithmetic/modular.rs
+++ b/evm/src/arithmetic/modular.rs
@@ -427,6 +427,7 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
 ) {
     let filter = builder.add_many_extension([
         lv[columns::IS_ADDMOD],
+        lv[columns::IS_SUBMOD],
         lv[columns::IS_MULMOD],
         lv[columns::IS_MOD],
     ]);
@@ -437,11 +438,13 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     let input1 = read_value(lv, MODULAR_INPUT_1);
 
     let add_input = pol_add_ext_circuit(builder, input0, input1);
+    let sub_input = pol_sub_ext_circuit(builder, input0, input1);
     let mul_input = pol_mul_wide_ext_circuit(builder, input0, input1);
     let mod_input = pol_extend_ext_circuit(builder, input0);
 
     for (input, &filter) in [
         (&add_input, &lv[columns::IS_ADDMOD]),
+        (&sub_input, &lv[columns::IS_SUBMOD]),
         (&mul_input, &lv[columns::IS_MULMOD]),
         (&mod_input, &lv[columns::IS_MOD]),
     ] {

--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -118,6 +118,19 @@ pub(crate) fn pol_add_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     sum
 }
 
+/// Return a(x) - b(x); returned array is bigger than necessary to
+/// make the interface consistent with `pol_mul_wide`.
+pub(crate) fn pol_sub<T>(a: [T; N_LIMBS], b: [T; N_LIMBS]) -> [T; 2 * N_LIMBS - 1]
+where
+    T: Sub<Output = T> + Copy + Default,
+{
+    let mut diff = pol_zero();
+    for i in 0..N_LIMBS {
+        diff[i] = a[i] - b[i];
+    }
+    diff
+}
+
 /// a(x) -= b(x), but must have deg(a) >= deg(b).
 pub(crate) fn pol_sub_assign<T>(a: &mut [T], b: &[T])
 where

--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -131,6 +131,19 @@ where
     diff
 }
 
+pub(crate) fn pol_sub_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    a: [ExtensionTarget<D>; N_LIMBS],
+    b: [ExtensionTarget<D>; N_LIMBS],
+) -> [ExtensionTarget<D>; 2 * N_LIMBS - 1] {
+    let zero = builder.zero_extension();
+    let mut sum = [zero; 2 * N_LIMBS - 1];
+    for i in 0..N_LIMBS {
+        sum[i] = builder.sub_extension(a[i], b[i]);
+    }
+    sum
+}
+
 /// a(x) -= b(x), but must have deg(a) >= deg(b).
 pub(crate) fn pol_sub_assign<T>(a: &mut [T], b: &[T])
 where


### PR DESCRIPTION
Implementation of the **non-standard** `SUBMOD` instruction in the arithmetic table.

Does the obvious thing: `SUBMOD(a, b, m) := (a - b) % m`, except that the result is always in the range `[0, m)`. (Cf. typical definitions of `%` which produce a negative result if `a-b` is negative.)