### PR TITLE
Implement DIV instruction

### DIFF
--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -59,6 +59,8 @@ impl<F: RichField, const D: usize> ArithmeticStark<F, D> {
             modular::generate(local_values, columns::IS_MULMOD);
         } else if local_values[columns::IS_MOD].is_one() {
             modular::generate(local_values, columns::IS_MOD);
+        } else if local_values[columns::IS_DIV].is_one() {
+            modular::generate(local_values, columns::IS_DIV);
         } else {
             todo!("the requested operation has not yet been implemented");
         }

--- a/evm/src/arithmetic/columns.rs
+++ b/evm/src/arithmetic/columns.rs
@@ -85,11 +85,11 @@ pub(crate) const MODULAR_AUX_INPUT: Range<usize> = AUX_INPUT_1;
 pub(crate) const MODULAR_MOD_IS_ZERO: usize = AUX_INPUT_1.end - 1;
 pub(crate) const MODULAR_OUT_AUX_RED: Range<usize> = AUX_INPUT_2;
 
-#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
+#[allow(unused)] // TODO: Will be used when hooking into the CPU
 pub(crate) const DIV_NUMERATOR: Range<usize> = MODULAR_INPUT_0;
-#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
+#[allow(unused)] // TODO: Will be used when hooking into the CPU
 pub(crate) const DIV_DENOMINATOR: Range<usize> = MODULAR_MODULUS;
-#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
-pub(crate) const DIV_OUTPUT: Range<usize> = MODULAR_QUO_INPUT.start .. MODULAR_QUO_INPUT.start + 16;
+#[allow(unused)] // TODO: Will be used when hooking into the CPU
+pub(crate) const DIV_OUTPUT: Range<usize> = MODULAR_QUO_INPUT.start..MODULAR_QUO_INPUT.start + 16;
 
 pub const NUM_ARITH_COLUMNS: usize = START_SHARED_COLS + NUM_SHARED_COLS;

--- a/evm/src/arithmetic/columns.rs
+++ b/evm/src/arithmetic/columns.rs
@@ -85,4 +85,11 @@ pub(crate) const MODULAR_AUX_INPUT: Range<usize> = AUX_INPUT_1;
 pub(crate) const MODULAR_MOD_IS_ZERO: usize = AUX_INPUT_1.end - 1;
 pub(crate) const MODULAR_OUT_AUX_RED: Range<usize> = AUX_INPUT_2;
 
+#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
+pub(crate) const DIV_NUMERATOR: Range<usize> = MODULAR_INPUT_0;
+#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
+pub(crate) const DIV_DENOMINATOR: Range<usize> = MODULAR_MODULUS;
+#[allow(unused_variables)]  // TODO: Will be used when hooking into the CPU
+pub(crate) const DIV_OUTPUT: Range<usize> = MODULAR_QUO_INPUT.start .. MODULAR_QUO_INPUT.start + 16;
+
 pub const NUM_ARITH_COLUMNS: usize = START_SHARED_COLS + NUM_SHARED_COLS;

--- a/evm/src/arithmetic/modular.rs
+++ b/evm/src/arithmetic/modular.rs
@@ -1,4 +1,5 @@
-//! Support for the EVM modular instructions ADDMOD, MULMOD and MOD.
+//! Support for the EVM modular instructions ADDMOD, MULMOD and MOD,
+//! as well as DIV.
 //!
 //! This crate verifies an EVM modular instruction, which takes three
 //! 256-bit inputs A, B and M, and produces a 256-bit output C satisfying
@@ -82,6 +83,9 @@
 //!    - if modulus is non-zero, correct output is obtained
 //!    - if modulus is 0, then the test output < modulus, checking that
 //!      the output is reduced, will fail, because output is non-negative.
+//!
+//! In the case of DIV, we do something similar, except that we "replace"
+//! the modulus with "2^256" to force the quotient to be zero.
 
 use num::{bigint::Sign, BigInt, One, Zero};
 use plonky2::field::extension::Extendable;
@@ -255,8 +259,7 @@ pub(crate) fn generate<F: RichField>(lv: &mut [F; NUM_ARITH_COLUMNS], filter: us
         columns::IS_ADDMOD => generate_modular_op(lv, filter, pol_add),
         columns::IS_SUBMOD => generate_modular_op(lv, filter, pol_sub),
         columns::IS_MULMOD => generate_modular_op(lv, filter, pol_mul_wide),
-        columns::IS_MOD | columns::IS_DIV
-            => generate_modular_op(lv, filter, |a, _| pol_extend(a)),
+        columns::IS_MOD | columns::IS_DIV => generate_modular_op(lv, filter, |a, _| pol_extend(a)),
         _ => panic!("generate modular operation called with unknown opcode"),
     }
 }


### PR DESCRIPTION
Implements the `DIV` instruction in terms of the `MOD` instruction.

The only real complication is handling the standard's definition that division by zero is zero. With `MOD` we can obtain the correct answer by forcing the modulus to be zero, whereas with `DIV` the modulus acts as the denominator and must be forced to be "`2^256`" to get the correct answer.