### PR TITLE
Remove config from `CommonCircuitData`

### DIFF
--- a/evm/src/bin/assemble.rs
+++ b/evm/src/bin/assemble.rs
@@ -9,5 +9,5 @@ fn main() {
     args.next();
     let file_contents: Vec<_> = args.map(|path| fs::read_to_string(path).unwrap()).collect();
     let assembled = assemble_to_bytes(&file_contents[..]);
-    println!("{}", encode(&assembled));
+    println!("{}", encode(assembled));
 }

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -83,7 +83,7 @@ impl Macro {
         self.params
             .iter()
             .position(|p| p == param)
-            .unwrap_or_else(|| panic!("No such param: {} {:?}", param, &self.params))
+            .unwrap_or_else(|| panic!("No such param: {param} {:?}", &self.params))
     }
 }
 
@@ -140,7 +140,7 @@ fn find_macros(files: &[File]) -> HashMap<MacroSignature, Macro> {
                     items: items.clone(),
                 };
                 let old = macros.insert(signature.clone(), macro_);
-                assert!(old.is_none(), "Duplicate macro signature: {:?}", signature);
+                assert!(old.is_none(), "Duplicate macro signature: {signature:?}");
             }
         }
     }
@@ -186,9 +186,9 @@ fn expand_macro_call(
     };
     let macro_ = macros
         .get(&signature)
-        .unwrap_or_else(|| panic!("No such macro: {:?}", signature));
+        .unwrap_or_else(|| panic!("No such macro: {signature:?}"));
 
-    let get_actual_label = |macro_label| format!("@{}.{}", macro_counter, macro_label);
+    let get_actual_label = |macro_label| format!("@{macro_counter}.{macro_label}");
 
     let get_arg = |var| {
         let param_index = macro_.get_param_index(var);
@@ -242,7 +242,7 @@ fn inline_constants(body: Vec<Item>, constants: &HashMap<String, U256>) -> Vec<I
     let resolve_const = |c| {
         *constants
             .get(&c)
-            .unwrap_or_else(|| panic!("No such constant: {}", c))
+            .unwrap_or_else(|| panic!("No such constant: {c}"))
     };
 
     body.into_iter()
@@ -283,15 +283,15 @@ fn find_labels(
             | Item::Repeat(_, _)
             | Item::StackManipulation(_, _)
             | Item::MacroLabelDeclaration(_) => {
-                panic!("Item should have been expanded already: {:?}", item);
+                panic!("Item should have been expanded already: {item:?}");
             }
             Item::GlobalLabelDeclaration(label) => {
                 let old = global_labels.insert(label.clone(), *offset);
-                assert!(old.is_none(), "Duplicate global label: {}", label);
+                assert!(old.is_none(), "Duplicate global label: {label}");
             }
             Item::LocalLabelDeclaration(label) => {
                 let old = local_labels.insert(label.clone(), *offset);
-                assert!(old.is_none(), "Duplicate local label: {}", label);
+                assert!(old.is_none(), "Duplicate local label: {label}");
             }
             Item::Push(target) => *offset += 1 + push_target_size(target) as usize,
             Item::ProverInput(prover_input_fn) => {
@@ -319,7 +319,7 @@ fn assemble_file(
             | Item::Repeat(_, _)
             | Item::StackManipulation(_, _)
             | Item::MacroLabelDeclaration(_) => {
-                panic!("Item should have been expanded already: {:?}", item);
+                panic!("Item should have been expanded already: {item:?}");
             }
             Item::GlobalLabelDeclaration(_) | Item::LocalLabelDeclaration(_) => {
                 // Nothing to do; we processed labels in the prior phase.
@@ -331,7 +331,7 @@ fn assemble_file(
                         let offset = local_labels
                             .get(&label)
                             .or_else(|| global_labels.get(&label))
-                            .unwrap_or_else(|| panic!("No such label: {}", label));
+                            .unwrap_or_else(|| panic!("No such label: {label}"));
                         // We want the BYTES_PER_OFFSET least significant bytes in BE order.
                         // It's easiest to rev the first BYTES_PER_OFFSET bytes of the LE encoding.
                         (0..BYTES_PER_OFFSET)
@@ -339,9 +339,9 @@ fn assemble_file(
                             .map(|i| offset.to_le_bytes()[i as usize])
                             .collect()
                     }
-                    PushTarget::MacroLabel(v) => panic!("Macro label not in a macro: {}", v),
-                    PushTarget::MacroVar(v) => panic!("Variable not in a macro: {}", v),
-                    PushTarget::Constant(c) => panic!("Constant wasn't inlined: {}", c),
+                    PushTarget::MacroLabel(v) => panic!("Macro label not in a macro: {v}"),
+                    PushTarget::MacroVar(v) => panic!("Variable not in a macro: {v}"),
+                    PushTarget::Constant(c) => panic!("Constant wasn't inlined: {c}"),
                 };
                 code.push(get_push_opcode(target_bytes.len() as u8));
                 code.extend(target_bytes);
@@ -362,9 +362,9 @@ fn push_target_size(target: &PushTarget) -> u8 {
     match target {
         PushTarget::Literal(n) => u256_to_trimmed_be_bytes(n).len() as u8,
         PushTarget::Label(_) => BYTES_PER_OFFSET,
-        PushTarget::MacroLabel(v) => panic!("Macro label not in a macro: {}", v),
-        PushTarget::MacroVar(v) => panic!("Variable not in a macro: {}", v),
-        PushTarget::Constant(c) => panic!("Constant wasn't inlined: {}", c),
+        PushTarget::MacroLabel(v) => panic!("Macro label not in a macro: {v}"),
+        PushTarget::MacroVar(v) => panic!("Variable not in a macro: {v}"),
+        PushTarget::Constant(c) => panic!("Constant wasn't inlined: {c}"),
     }
 }
 

--- a/evm/src/cpu/kernel/cost_estimator.rs
+++ b/evm/src/cpu/kernel/cost_estimator.rs
@@ -21,7 +21,7 @@ fn cost_estimate_item(item: &Item) -> u32 {
         Push(Label(_)) => cost_estimate_push(BYTES_PER_OFFSET as usize),
         ProverInput(_) => 1,
         StandardOp(op) => cost_estimate_standard_op(op.as_str()),
-        _ => panic!("Unexpected item: {:?}", item),
+        _ => panic!("Unexpected item: {item:?}"),
     }
 }
 

--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -328,7 +328,7 @@ impl<'a> Interpreter<'a> {
         if self.debug_offsets.contains(&self.offset) {
             println!("At {}, stack={:?}", self.offset_name(), self.stack());
         } else if let Some(label) = self.offset_label() {
-            println!("At {}", label);
+            println!("At {label}");
         }
 
         Ok(())

--- a/evm/src/cpu/kernel/opcodes.rs
+++ b/evm/src/cpu/kernel/opcodes.rs
@@ -134,6 +134,6 @@ pub(crate) fn get_opcode(mnemonic: &str) -> u8 {
         "REVERT" => 0xfd,
         "INVALID" => 0xfe,
         "SELFDESTRUCT" => 0xff,
-        _ => panic!("Unrecognized mnemonic {}", mnemonic),
+        _ => panic!("Unrecognized mnemonic {mnemonic}"),
     }
 }

--- a/evm/src/cpu/kernel/stack/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack/stack_manipulation.rs
@@ -35,7 +35,7 @@ fn expand(names: Vec<StackPlaceholder>, replacements: Vec<StackReplacement>) -> 
             stack_blocks.insert(name.clone(), n);
             (0..n)
                 .map(|i| {
-                    let literal_name = format!("@{}.{}", name, i);
+                    let literal_name = format!("@{name}.{i}");
                     StackItem::NamedItem(literal_name)
                 })
                 .collect_vec()
@@ -52,7 +52,7 @@ fn expand(names: Vec<StackPlaceholder>, replacements: Vec<StackReplacement>) -> 
                     let n = *stack_blocks.get(&name).unwrap();
                     (0..n)
                         .map(|i| {
-                            let literal_name = format!("@{}.{}", name, i);
+                            let literal_name = format!("@{name}.{i}");
                             StackItem::NamedItem(literal_name)
                         })
                         .collect_vec()
@@ -64,7 +64,7 @@ fn expand(names: Vec<StackPlaceholder>, replacements: Vec<StackReplacement>) -> 
             StackReplacement::MacroLabel(_)
             | StackReplacement::MacroVar(_)
             | StackReplacement::Constant(_) => {
-                panic!("Should have been expanded already: {:?}", item)
+                panic!("Should have been expanded already: {item:?}")
             }
         })
         .collect_vec();
@@ -157,7 +157,7 @@ fn shortest_path(
         }
     }
 
-    panic!("No path found from {:?} to {:?}", src, dst)
+    panic!("No path found from {src:?} to {dst:?}")
 }
 
 /// A node in the priority queue used by Dijkstra's algorithm.
@@ -279,7 +279,7 @@ impl StackOp {
                     PushTarget::MacroLabel(_)
                     | PushTarget::MacroVar(_)
                     | PushTarget::Constant(_) => {
-                        panic!("Target should have been expanded already: {:?}", target)
+                        panic!("Target should have been expanded already: {target:?}")
                     }
                 };
                 // This is just a rough estimate; we can update it after implementing PUSH.
@@ -326,8 +326,8 @@ impl StackOp {
         match self {
             StackOp::Push(target) => Item::Push(target),
             Pop => Item::StandardOp("POP".into()),
-            StackOp::Dup(n) => Item::StandardOp(format!("DUP{}", n)),
-            StackOp::Swap(n) => Item::StandardOp(format!("SWAP{}", n)),
+            StackOp::Dup(n) => Item::StandardOp(format!("DUP{n}")),
+            StackOp::Swap(n) => Item::StandardOp(format!("SWAP{n}")),
         }
     }
 }

--- a/evm/src/cpu/kernel/tests/curve_ops.rs
+++ b/evm/src/cpu/kernel/tests/curve_ops.rs
@@ -150,7 +150,7 @@ mod bn {
         assert_eq!(stack, vec![U256::MAX, U256::MAX]);
 
         // Multiple calls
-        let ec_mul_hex = format!("0x{:x}", ec_mul);
+        let ec_mul_hex = format!("0x{ec_mul:x}");
         let initial_stack = u256ify([
             "0xdeadbeef",
             s,
@@ -288,7 +288,7 @@ mod secp {
         assert_eq!(stack, u256ify([identity.1, identity.0])?);
 
         // Multiple calls
-        let ec_mul_hex = format!("0x{:x}", ec_mul);
+        let ec_mul_hex = format!("0x{ec_mul:x}");
         let initial_stack = u256ify([
             "0xdeadbeef",
             s,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -235,7 +235,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             .zip(verifier_data_target)
             .enumerate()
         {
-            builder.verify_proof(
+            builder.verify_proof::<C>(
                 recursive_proof,
                 &verifier_data_target,
                 &verifier_data[i].common,
@@ -579,7 +579,7 @@ where
 {
     let recursive_proofs = std::array::from_fn(|i| {
         let verifier_data = &verifier_data[i];
-        builder.add_virtual_proof_with_pis(&verifier_data.common)
+        builder.add_virtual_proof_with_pis::<C>(&verifier_data.common)
     });
     let verifier_data = std::array::from_fn(|i| {
         let verifier_data = &verifier_data[i];

--- a/field/src/extension/algebra.rs
+++ b/field/src/extension/algebra.rs
@@ -45,7 +45,7 @@ impl<F: OEF<D>, const D: usize> Display for ExtensionAlgebra<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "({})", self.0[0])?;
         for i in 1..D {
-            write!(f, " + ({})*b^{}", self.0[i], i)?;
+            write!(f, " + ({})*b^{i}", self.0[i])?;
         }
         Ok(())
     }

--- a/insertion/src/insertion_gate.rs
+++ b/insertion/src/insertion_gate.rs
@@ -73,7 +73,7 @@ impl<F: RichField + Extendable<D>, const D: usize> InsertionGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/benches/hashing.rs
+++ b/plonky2/benches/hashing.rs
@@ -24,7 +24,7 @@ pub(crate) fn bench_keccak<F: RichField>(c: &mut Criterion) {
 
 pub(crate) fn bench_poseidon<F: Poseidon>(c: &mut Criterion) {
     c.bench_function(
-        &format!("poseidon<{}, {}>", type_name::<F>(), SPONGE_WIDTH),
+        &format!("poseidon<{}, {SPONGE_WIDTH}>", type_name::<F>()),
         |b| {
             b.iter_batched(
                 || F::rand_arr::<SPONGE_WIDTH>(),

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -32,7 +32,7 @@ use structopt::StructOpt;
 type ProofTuple<F, C, const D: usize> = (
     ProofWithPublicInputs<F, C, D>,
     VerifierOnlyCircuitData<C, D>,
-    CommonCircuitData<F, C, D>,
+    CommonCircuitData<F, D>,
 );
 
 #[derive(Clone, StructOpt, Debug)]
@@ -112,7 +112,7 @@ where
     let (inner_proof, inner_vd, inner_cd) = inner;
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
     let mut pw = PartialWitness::new();
-    let pt = builder.add_virtual_proof_with_pis(inner_cd);
+    let pt = builder.add_virtual_proof_with_pis::<InnerC>(inner_cd);
     pw.set_proof_with_pis_target(&pt, inner_proof);
 
     let inner_data = VerifierCircuitTarget {
@@ -121,7 +121,7 @@ where
     };
     pw.set_verifier_data_target(&inner_data, inner_vd);
 
-    builder.verify_proof(pt, &inner_data, inner_cd);
+    builder.verify_proof::<InnerC>(pt, &inner_data, inner_cd);
     builder.print_gate_counts(0);
 
     if let Some(min_degree_bits) = min_degree_bits {
@@ -150,7 +150,7 @@ where
 fn test_serialization<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     proof: &ProofWithPublicInputs<F, C, D>,
     vd: &VerifierOnlyCircuitData<C, D>,
-    cd: &CommonCircuitData<F, C, D>,
+    cd: &CommonCircuitData<F, D>,
 ) -> Result<()>
 where
     [(); C::Hasher::HASH_SIZE]:,

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -31,7 +31,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F>
         let x_squared = witness.get_target(self.x_squared);
         let x = x_squared.sqrt().unwrap();
 
-        println!("Square root: {}", x);
+        println!("Square root: {x}");
 
         out_buffer.set_target(self.x, x);
     }
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     let proof = data.prove(pw.clone())?;
 
     let x_squared_actual = proof.public_inputs[0];
-    println!("Field element (square): {}", x_squared_actual);
+    println!("Field element (square): {x_squared_actual}");
 
     data.verify(proof)
 }

--- a/plonky2/src/bin/generate_constants.rs
+++ b/plonky2/src/bin/generate_constants.rs
@@ -21,7 +21,7 @@ pub(crate) fn main() {
     // Print the constants in the format we prefer in our code.
     for chunk in constants.chunks(4) {
         for (i, c) in chunk.iter().enumerate() {
-            print!("{:#018x},", c);
+            print!("{c:#018x},");
             if i != chunk.len() - 1 {
                 print!(" ");
             }

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -176,7 +176,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             with_context!(
                 self,
                 level,
-                &format!("verify one (of {}) query rounds", num_queries),
+                &format!("verify one (of {num_queries}) query rounds"),
                 self.fri_verifier_query_round::<C>(
                     instance,
                     challenges,
@@ -207,7 +207,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         {
             with_context!(
                 self,
-                &format!("verify {}'th initial Merkle proof", i),
+                &format!("verify {i}'th initial Merkle proof"),
                 self.verify_merkle_proof_to_cap_with_cap_index::<H>(
                     evals.clone(),
                     x_index_bits,

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -53,7 +53,7 @@ impl ArithmeticGate {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticGate {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -51,7 +51,7 @@ impl<const D: usize> ArithmeticExtensionGate<D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticExtensionGate<D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -49,7 +49,7 @@ impl<const B: usize> BaseSumGate<B> {
 
 impl<F: RichField + Extendable<D>, const D: usize, const B: usize> Gate<F, D> for BaseSumGate<B> {
     fn id(&self) -> String {
-        format!("{:?} + Base: {}", self, B)
+        format!("{self:?} + Base: {B}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -33,7 +33,7 @@ impl ConstantGate {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -70,7 +70,7 @@ impl<F: RichField + Extendable<D>, const D: usize> ExponentiationGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ExponentiationGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/high_degree_interpolation.rs
+++ b/plonky2/src/gates/high_degree_interpolation.rs
@@ -87,7 +87,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
     for HighDegreeInterpolationGate<F, D>
 {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/low_degree_interpolation.rs
+++ b/plonky2/src/gates/low_degree_interpolation.rs
@@ -80,7 +80,7 @@ impl<F: RichField + Extendable<D>, const D: usize> LowDegreeInterpolationGate<F,
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LowDegreeInterpolationGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -48,7 +48,7 @@ impl<const D: usize> MulExtensionGate<D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGate<D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -98,7 +98,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PoseidonGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PoseidonGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<WIDTH={}>", self, SPONGE_WIDTH)
+        format!("{self:?}<WIDTH={SPONGE_WIDTH}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -117,7 +117,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> PoseidonMdsGate<F,
 
 impl<F: RichField + Extendable<D> + Poseidon, const D: usize> Gate<F, D> for PoseidonMdsGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<WIDTH={}>", self, SPONGE_WIDTH)
+        format!("{self:?}<WIDTH={SPONGE_WIDTH}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -115,7 +115,7 @@ impl<F: RichField + Extendable<D>, const D: usize> RandomAccessGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -55,7 +55,7 @@ impl<const D: usize> ReducingGate<D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingGate<D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -58,7 +58,7 @@ impl<const D: usize> ReducingExtensionGate<D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingExtensionGate<D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -22,7 +22,7 @@ pub(crate) fn generate_partial_witness<
 >(
     inputs: PartialWitness<F>,
     prover_data: &'a ProverOnlyCircuitData<F, C, D>,
-    common_data: &'a CommonCircuitData<F, C, D>,
+    common_data: &'a CommonCircuitData<F, D>,
 ) -> PartitionWitness<'a, F> {
     let config = &common_data.config;
     let generators = &prover_data.generators;

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -106,7 +106,7 @@ impl CircuitConfig {
 pub struct CircuitData<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     pub prover_only: ProverOnlyCircuitData<F, C, D>,
     pub verifier_only: VerifierOnlyCircuitData<C, D>,
-    pub common: CommonCircuitData<F, C, D>,
+    pub common: CommonCircuitData<F, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
@@ -196,7 +196,7 @@ pub struct ProverCircuitData<
     const D: usize,
 > {
     pub prover_only: ProverOnlyCircuitData<F, C, D>,
-    pub common: CommonCircuitData<F, C, D>,
+    pub common: CommonCircuitData<F, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
@@ -223,7 +223,7 @@ pub struct VerifierCircuitData<
     const D: usize,
 > {
     pub verifier_only: VerifierOnlyCircuitData<C, D>,
-    pub common: CommonCircuitData<F, C, D>,
+    pub common: CommonCircuitData<F, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
@@ -287,17 +287,13 @@ pub struct VerifierOnlyCircuitData<C: GenericConfig<D>, const D: usize> {
 
 /// Circuit data required by both the prover and the verifier.
 #[derive(Debug, Eq, PartialEq)]
-pub struct CommonCircuitData<
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    const D: usize,
-> {
+pub struct CommonCircuitData<F: RichField + Extendable<D>, const D: usize> {
     pub config: CircuitConfig,
 
     pub(crate) fri_params: FriParams,
 
     /// The types of gates used in this circuit, along with their prefixes.
-    pub(crate) gates: Vec<GateRef<C::F, D>>,
+    pub(crate) gates: Vec<GateRef<F, D>>,
 
     /// Information on the circuit's selector polynomials.
     pub(crate) selectors_info: SelectorsInfo,
@@ -314,15 +310,13 @@ pub struct CommonCircuitData<
     pub(crate) num_public_inputs: usize,
 
     /// The `{k_i}` valued used in `S_ID_i` in Plonk's permutation argument.
-    pub(crate) k_is: Vec<C::F>,
+    pub(crate) k_is: Vec<F>,
 
     /// The number of partial products needed to compute the `Z` polynomials.
     pub(crate) num_partial_products: usize,
 }
 
-impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
-    CommonCircuitData<F, C, D>
-{
+impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
     pub const fn degree_bits(&self) -> usize {
         self.fri_params.degree_bits
     }

--- a/plonky2/src/plonk/conditional_recursive_verifier.rs
+++ b/plonky2/src/plonk/conditional_recursive_verifier.rs
@@ -30,7 +30,7 @@ pub(crate) fn dummy_proof<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> Result<(
     ProofWithPublicInputs<F, C, D>,
     VerifierOnlyCircuitData<C, D>,
@@ -80,7 +80,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_verifier_data0: &VerifierCircuitTarget,
         proof_with_pis1: &ProofWithPublicInputsTarget<D>,
         inner_verifier_data1: &VerifierCircuitTarget,
-        inner_common_data: &CommonCircuitData<F, C, D>,
+        inner_common_data: &CommonCircuitData<F, D>,
     ) where
         C::Hasher: AlgebraicHasher<F>,
     {
@@ -144,7 +144,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             ),
         };
 
-        self.verify_proof(selected_proof, &selected_verifier_data, inner_common_data);
+        self.verify_proof::<C>(selected_proof, &selected_verifier_data, inner_common_data);
     }
 
     /// Conditionally verify a proof with a new generated dummy proof.
@@ -153,18 +153,18 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         condition: BoolTarget,
         proof_with_pis: &ProofWithPublicInputsTarget<D>,
         inner_verifier_data: &VerifierCircuitTarget,
-        inner_common_data: &CommonCircuitData<F, C, D>,
+        inner_common_data: &CommonCircuitData<F, D>,
     ) -> (ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)
     where
         C::Hasher: AlgebraicHasher<F>,
     {
-        let dummy_proof = self.add_virtual_proof_with_pis(inner_common_data);
+        let dummy_proof = self.add_virtual_proof_with_pis::<C>(inner_common_data);
         let dummy_verifier_data = VerifierCircuitTarget {
             constants_sigmas_cap: self
                 .add_virtual_cap(inner_common_data.config.fri_config.cap_height),
             circuit_digest: self.add_virtual_hash(),
         };
-        self.conditionally_verify_proof(
+        self.conditionally_verify_proof::<C>(
             condition,
             proof_with_pis,
             inner_verifier_data,
@@ -406,10 +406,10 @@ mod tests {
         // Conditionally verify the two proofs.
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::new();
-        let pt = builder.add_virtual_proof_with_pis(&data.common);
+        let pt = builder.add_virtual_proof_with_pis::<C>(&data.common);
         pw.set_proof_with_pis_target(&pt, &proof);
-        let dummy_pt = builder.add_virtual_proof_with_pis(&data.common);
-        pw.set_proof_with_pis_target(&dummy_pt, &dummy_proof);
+        let dummy_pt = builder.add_virtual_proof_with_pis::<C>(&data.common);
+        pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof);
         let inner_data = VerifierCircuitTarget {
             constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
             circuit_digest: builder.add_virtual_hash(),
@@ -421,7 +421,7 @@ mod tests {
         };
         pw.set_verifier_data_target(&dummy_inner_data, &dummy_data);
         let b = builder.constant_bool(F::rand().0 % 2 == 0);
-        builder.conditionally_verify_proof(
+        builder.conditionally_verify_proof::<C>(
             b,
             &pt,
             &inner_data,

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -30,7 +30,7 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
     final_poly: &PolynomialCoeffs<F::Extension>,
     pow_witness: F,
     circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> anyhow::Result<ProofChallenges<F, D>> {
     let config = &common_data.config;
     let num_challenges = config.num_challenges;
@@ -74,7 +74,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub(crate) fn fri_query_indices(
         &self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Vec<usize>> {
         Ok(self
             .get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?
@@ -87,7 +87,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<ProofChallenges<F, D>> {
         let Proof {
             wires_cap,
@@ -103,7 +103,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 },
         } = &self.proof;
 
-        get_challenges(
+        get_challenges::<F, C, D>(
             public_inputs_hash,
             wires_cap,
             plonk_zs_partial_products_cap,
@@ -126,7 +126,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<ProofChallenges<F, D>> {
         let CompressedProof {
             wires_cap,
@@ -142,7 +142,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 },
         } = &self.proof;
 
-        get_challenges(
+        get_challenges::<F, C, D>(
             public_inputs_hash,
             wires_cap,
             plonk_zs_partial_products_cap,
@@ -160,7 +160,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub(crate) fn get_inferred_elements(
         &self,
         challenges: &ProofChallenges<F, D>,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> FriInferredElements<F, D> {
         let ProofChallenges {
             plonk_zeta,
@@ -244,7 +244,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         final_poly: &PolynomialCoeffsExtTarget<D>,
         pow_witness: Target,
         inner_circuit_digest: HashOutTarget,
-        inner_common_data: &CommonCircuitData<F, C, D>,
+        inner_common_data: &CommonCircuitData<F, D>,
     ) -> ProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
@@ -292,7 +292,7 @@ impl<const D: usize> ProofWithPublicInputsTarget<D> {
         builder: &mut CircuitBuilder<F, D>,
         public_inputs_hash: HashOutTarget,
         inner_circuit_digest: HashOutTarget,
-        inner_common_data: &CommonCircuitData<F, C, D>,
+        inner_common_data: &CommonCircuitData<F, D>,
     ) -> ProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
@@ -311,7 +311,7 @@ impl<const D: usize> ProofWithPublicInputsTarget<D> {
                 },
         } = &self.proof;
 
-        builder.get_challenges(
+        builder.get_challenges::<C>(
             public_inputs_hash,
             wires_cap,
             plonk_zs_partial_products_cap,

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -82,7 +82,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub fn compress(
         self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<CompressedProofWithPublicInputs<F, C, D>> {
         let indices = self.fri_query_indices(circuit_digest, common_data)?;
         let compressed_proof = self.proof.compress(&indices, &common_data.fri_params);
@@ -106,7 +106,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
     pub fn from_bytes(
         bytes: Vec<u8>,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
         let mut buffer = Buffer::new(bytes);
         let proof = buffer.read_proof_with_public_inputs(common_data)?;
@@ -178,7 +178,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub fn decompress(
         self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>>
     where
         [(); C::Hasher::HASH_SIZE]:,
@@ -198,7 +198,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub(crate) fn verify(
         self,
         verifier_data: &VerifierOnlyCircuitData<C, D>,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<()>
     where
         [(); C::Hasher::HASH_SIZE]:,
@@ -240,7 +240,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
     pub fn from_bytes(
         bytes: Vec<u8>,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
         let mut buffer = Buffer::new(bytes);
         let proof = buffer.read_compressed_proof_with_public_inputs(common_data)?;
@@ -303,7 +303,7 @@ impl<F: RichField + Extendable<D>, const D: usize> OpeningSet<F, D> {
         wires_commitment: &PolynomialBatch<F, C, D>,
         zs_partial_products_commitment: &PolynomialBatch<F, C, D>,
         quotient_polys_commitment: &PolynomialBatch<F, C, D>,
-        common_data: &CommonCircuitData<F, C, D>,
+        common_data: &CommonCircuitData<F, D>,
     ) -> Self {
         let eval_commitment = |z: F::Extension, c: &PolynomialBatch<F, C, D>| {
             c.polynomials

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -28,7 +28,7 @@ use crate::util::transpose;
 
 pub fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     prover_data: &ProverOnlyCircuitData<F, C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     inputs: PartialWitness<F>,
     timing: &mut TimingTree,
 ) -> Result<ProofWithPublicInputs<F, C, D>>
@@ -233,7 +233,7 @@ fn all_wires_permutation_partial_products<
     betas: &[F],
     gammas: &[F],
     prover_data: &ProverOnlyCircuitData<F, C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> Vec<Vec<PolynomialValues<F>>> {
     (0..common_data.config.num_challenges)
         .map(|i| {
@@ -260,7 +260,7 @@ fn wires_permutation_partial_products_and_zs<
     beta: F,
     gamma: F,
     prover_data: &ProverOnlyCircuitData<F, C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> Vec<PolynomialValues<F>> {
     let degree = common_data.quotient_degree_factor;
     let subgroup = &prover_data.subgroup;
@@ -318,7 +318,7 @@ fn compute_quotient_polys<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     prover_data: &'a ProverOnlyCircuitData<F, C, D>,
     public_inputs_hash: &<<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
     wires_commitment: &'a PolynomialBatch<F, C, D>,
@@ -424,7 +424,7 @@ fn compute_quotient_polys<
                 public_inputs_hash,
             );
 
-            let mut quotient_values_batch = eval_vanishing_poly_base_batch(
+            let mut quotient_values_batch = eval_vanishing_poly_base_batch::<F, C, D>(
                 common_data,
                 &indices_batch,
                 &shifted_xs_batch,

--- a/plonky2/src/plonk/validate_shape.rs
+++ b/plonky2/src/plonk/validate_shape.rs
@@ -8,7 +8,7 @@ use crate::plonk::proof::{OpeningSet, Proof, ProofWithPublicInputs};
 
 pub(crate) fn validate_proof_with_pis_shape<F, C, const D: usize>(
     proof_with_pis: &ProofWithPublicInputs<F, C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> anyhow::Result<()>
 where
     F: RichField + Extendable<D>,
@@ -32,7 +32,7 @@ where
 
 fn validate_proof_shape<F, C, const D: usize>(
     proof: &Proof<F, C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> anyhow::Result<()>
 where
     F: RichField + Extendable<D>,

--- a/plonky2/src/plonk/vanishing_poly.rs
+++ b/plonky2/src/plonk/vanishing_poly.rs
@@ -25,7 +25,7 @@ pub(crate) fn eval_vanishing_poly<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     x: F::Extension,
     vars: EvaluationVars<F, D>,
     local_zs: &[F::Extension],
@@ -39,7 +39,7 @@ pub(crate) fn eval_vanishing_poly<
     let max_degree = common_data.quotient_degree_factor;
     let num_prods = common_data.num_partial_products;
 
-    let constraint_terms = evaluate_gate_constraints(common_data, vars);
+    let constraint_terms = evaluate_gate_constraints::<F, C, D>(common_data, vars);
 
     // The L_0(x) (Z(x) - 1) vanishing terms.
     let mut vanishing_z_1_terms = Vec::new();
@@ -100,7 +100,7 @@ pub(crate) fn eval_vanishing_poly_base_batch<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     indices_batch: &[usize],
     xs_batch: &[F],
     vars_batch: EvaluationVarsBaseBatch<F>,
@@ -126,7 +126,8 @@ pub(crate) fn eval_vanishing_poly_base_batch<
 
     let num_gate_constraints = common_data.num_gate_constraints;
 
-    let constraint_terms_batch = evaluate_gate_constraints_base_batch(common_data, vars_batch);
+    let constraint_terms_batch =
+        evaluate_gate_constraints_base_batch::<F, C, D>(common_data, vars_batch);
     debug_assert!(constraint_terms_batch.len() == n * num_gate_constraints);
 
     let num_challenges = common_data.config.num_challenges;
@@ -210,7 +211,7 @@ pub fn evaluate_gate_constraints<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     vars: EvaluationVars<F, D>,
 ) -> Vec<F::Extension> {
     let mut constraints = vec![F::Extension::ZERO; common_data.num_gate_constraints];
@@ -244,7 +245,7 @@ pub fn evaluate_gate_constraints_base_batch<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     vars_batch: EvaluationVarsBaseBatch<F>,
 ) -> Vec<F> {
     let mut constraints_batch = vec![F::ZERO; common_data.num_gate_constraints * vars_batch.len()];
@@ -276,7 +277,7 @@ pub fn evaluate_gate_constraints_circuit<
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     vars: EvaluationTargets<D>,
 ) -> Vec<ExtensionTarget<D>> {
     let mut all_gate_constraints = vec![builder.zero_extension(); common_data.num_gate_constraints];
@@ -311,7 +312,7 @@ pub(crate) fn eval_vanishing_poly_circuit<
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
     x: ExtensionTarget<D>,
     x_pow_deg: ExtensionTarget<D>,
     vars: EvaluationTargets<D>,
@@ -329,7 +330,7 @@ pub(crate) fn eval_vanishing_poly_circuit<
     let constraint_terms = with_context!(
         builder,
         "evaluate gate constraints",
-        evaluate_gate_constraints_circuit(builder, common_data, vars,)
+        evaluate_gate_constraints_circuit::<F, C, D>(builder, common_data, vars,)
     );
 
     // The L_0(x) (Z(x) - 1) vanishing terms.

--- a/plonky2/src/plonk/verifier.rs
+++ b/plonky2/src/plonk/verifier.rs
@@ -15,7 +15,7 @@ use crate::plonk::vars::EvaluationVars;
 pub(crate) fn verify<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     proof_with_pis: ProofWithPublicInputs<F, C, D>,
     verifier_data: &VerifierOnlyCircuitData<C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> Result<()>
 where
     [(); C::Hasher::HASH_SIZE]:,
@@ -47,7 +47,7 @@ pub(crate) fn verify_with_challenges<
     public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
     challenges: ProofChallenges<F, D>,
     verifier_data: &VerifierOnlyCircuitData<C, D>,
-    common_data: &CommonCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
 ) -> Result<()>
 where
     [(); C::Hasher::HASH_SIZE]:,
@@ -65,7 +65,7 @@ where
     let partial_products = &proof.openings.partial_products;
 
     // Evaluate the vanishing polynomial at our challenge point, zeta.
-    let vanishing_polys_zeta = eval_vanishing_poly(
+    let vanishing_polys_zeta = eval_vanishing_poly::<F, C, D>(
         common_data,
         challenges.plonk_zeta,
         vars,

--- a/u32/src/gates/add_many_u32.rs
+++ b/u32/src/gates/add_many_u32.rs
@@ -84,7 +84,7 @@ impl<F: RichField + Extendable<D>, const D: usize> U32AddManyGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32AddManyGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/u32/src/gates/arithmetic_u32.rs
+++ b/u32/src/gates/arithmetic_u32.rs
@@ -86,7 +86,7 @@ impl<F: RichField + Extendable<D>, const D: usize> U32ArithmeticGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/u32/src/gates/comparison.rs
+++ b/u32/src/gates/comparison.rs
@@ -91,7 +91,7 @@ impl<F: RichField + Extendable<D>, const D: usize> ComparisonGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/u32/src/gates/range_check_u32.rs
+++ b/u32/src/gates/range_check_u32.rs
@@ -48,7 +48,7 @@ impl<F: RichField + Extendable<D>, const D: usize> U32RangeCheckGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32RangeCheckGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/u32/src/gates/subtraction_u32.rs
+++ b/u32/src/gates/subtraction_u32.rs
@@ -80,7 +80,7 @@ impl<F: RichField + Extendable<D>, const D: usize> U32SubtractionGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32SubtractionGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -31,7 +31,7 @@ pub fn log2_ceil(n: usize) -> usize {
 /// Computes `log_2(n)`, panicking if `n` is not a power of two.
 pub fn log2_strict(n: usize) -> usize {
     let res = n.trailing_zeros();
-    assert!(n.wrapping_shr(res) == 1, "Not a power of two: {}", n);
+    assert!(n.wrapping_shr(res) == 1, "Not a power of two: {n}");
     // Tell the optimizer about the semantics of `log2_strict`. i.e. it can replace `n` with
     // `1 << res` and vice versa.
     assume(n == 1 << res);

--- a/waksman/src/gates/assert_le.rs
+++ b/waksman/src/gates/assert_le.rs
@@ -84,7 +84,7 @@ impl<F: RichField + Extendable<D>, const D: usize> AssertLessThanGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThanGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {

--- a/waksman/src/gates/switch.rs
+++ b/waksman/src/gates/switch.rs
@@ -74,7 +74,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGate<F, D> {
 
 impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, D> {
     fn id(&self) -> String {
-        format!("{:?}<D={}>", self, D)
+        format!("{self:?}<D={D}>")
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {


### PR DESCRIPTION
Remove the `C: GenericConfig<D, F = F>` generic from `CommonCircuitData<F, C, D>`.
Useful for #782 to add an `Option<CommonCircuitData<F, D>>` to `CircuitBuilder<F, D>`.
Also fix the new clippy lint for format strings.