### PR TITLE
Use address macro instead of opcode

### DIFF
--- a/evm/src/cpu/kernel/asm/mpt/accounts.asm
+++ b/evm/src/cpu/kernel/asm/mpt/accounts.asm
@@ -1,6 +1,6 @@
 // Return a pointer to the current account's data in the state trie.
 %macro current_account_data
-    ADDRESS %mpt_read_state_trie
+    %address %mpt_read_state_trie
     // stack: account_ptr
     // account_ptr should be non-null as long as the prover provided the proper
     // Merkle data. But a bad prover may not have, and we don't want return a

--- a/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -39,6 +39,6 @@ after_storage_insert:
     // stack: new_account_ptr, retdest
 
     // Save this updated account to the state trie.
-    ADDRESS %addr_to_state_key
+    %address %addr_to_state_key
     // stack: state_key, new_account_ptr, retdest
     %jump(mpt_insert_state_trie)


### PR DESCRIPTION
Unless I'm missing something, `ADDRESS` is not a native instruction