### PR TITLE
EVM shift left/right operations

### DIFF
--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -1,6 +1,5 @@
 use std::ops::{Add, AddAssign, Mul, Neg, Range, Shr, Sub, SubAssign};
 
-use log::error;
 use plonky2::field::extension::Extendable;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;

--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -10,6 +10,9 @@ use crate::arithmetic::columns::{NUM_ARITH_COLUMNS, N_LIMBS};
 /// Emit an error message regarding unchecked range assumptions.
 /// Assumes the values in `cols` are `[cols[0], cols[0] + 1, ...,
 /// cols[0] + cols.len() - 1]`.
+///
+/// TODO: Hamish to delete this when he has implemented and integrated
+/// range checks.
 pub(crate) fn _range_check_error<const RC_BITS: u32>(
     _file: &str,
     _line: u32,

--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -12,20 +12,20 @@ use crate::arithmetic::columns::{NUM_ARITH_COLUMNS, N_LIMBS};
 /// Assumes the values in `cols` are `[cols[0], cols[0] + 1, ...,
 /// cols[0] + cols.len() - 1]`.
 pub(crate) fn _range_check_error<const RC_BITS: u32>(
-    file: &str,
-    line: u32,
-    cols: Range<usize>,
-    signedness: &str,
+    _file: &str,
+    _line: u32,
+    _cols: Range<usize>,
+    _signedness: &str,
 ) {
-    error!(
-        "{}:{}: arithmetic unit skipped {}-bit {} range-checks on columns {}--{}: not yet implemented",
-        line,
-        file,
-        RC_BITS,
-        signedness,
-        cols.start,
-        cols.end - 1,
-    );
+    // error!(
+    //     "{}:{}: arithmetic unit skipped {}-bit {} range-checks on columns {}--{}: not yet implemented",
+    //     line,
+    //     file,
+    //     RC_BITS,
+    //     signedness,
+    //     cols.start,
+    //     cols.end - 1,
+    // );
 }
 
 #[macro_export]

--- a/evm/src/cpu/columns/general.rs
+++ b/evm/src/cpu/columns/general.rs
@@ -9,6 +9,7 @@ pub(crate) union CpuGeneralColumnsView<T: Copy> {
     arithmetic: CpuArithmeticView<T>,
     logic: CpuLogicView<T>,
     jumps: CpuJumpsView<T>,
+    shift: CpuShiftView<T>,
 }
 
 impl<T: Copy> CpuGeneralColumnsView<T> {
@@ -50,6 +51,16 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
     // SAFETY: Each view is a valid interpretation of the underlying array.
     pub(crate) fn jumps_mut(&mut self) -> &mut CpuJumpsView<T> {
         unsafe { &mut self.jumps }
+    }
+
+    // SAFETY: Each view is a valid interpretation of the underlying array.
+    pub(crate) fn shift(&self) -> &CpuShiftView<T> {
+        unsafe { &self.shift }
+    }
+
+    // SAFETY: Each view is a valid interpretation of the underlying array.
+    pub(crate) fn shift_mut(&mut self) -> &mut CpuShiftView<T> {
+        unsafe { &mut self.shift }
     }
 }
 
@@ -142,6 +153,13 @@ pub(crate) struct CpuJumpsView<T: Copy> {
     /// (`input0[0]` is not `JUMPDEST` that is not in an immediate while we are in user mode, or
     /// `input0[1..7]` is nonzero) and `input1` is nonzero.
     pub(crate) should_trap: T,
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct CpuShiftView<T: Copy> {
+    // 1 if the high limbs of the displacement are all zero, 0 if one
+    // or more of the limbs is nonzero.
+    pub(crate) displacement_high_limbs_are_zero: T,
 }
 
 // `u8` is guaranteed to have a `size_of` of 1.

--- a/evm/src/cpu/columns/general.rs
+++ b/evm/src/cpu/columns/general.rs
@@ -160,6 +160,9 @@ pub(crate) struct CpuShiftView<T: Copy> {
     // 1 if the high limbs of the displacement are all zero, 0 if one
     // or more of the limbs is nonzero.
     pub(crate) displacement_high_limbs_are_zero: T,
+    // For a shift amount of displacement: [T], this is the inverse of
+    // sum(displacement[1..]) or zero if the sum is zero.
+    pub(crate) high_limb_sum_inv: T,
 }
 
 // `u8` is guaranteed to have a `size_of` of 1.

--- a/evm/src/cpu/columns/general.rs
+++ b/evm/src/cpu/columns/general.rs
@@ -157,9 +157,6 @@ pub(crate) struct CpuJumpsView<T: Copy> {
 
 #[derive(Copy, Clone)]
 pub(crate) struct CpuShiftView<T: Copy> {
-    // 1 if the high limbs of the displacement are all zero, 0 if one
-    // or more of the limbs is nonzero.
-    pub(crate) displacement_high_limbs_are_zero: T,
     // For a shift amount of displacement: [T], this is the inverse of
     // sum(displacement[1..]) or zero if the sum is zero.
     pub(crate) high_limb_sum_inv: T,

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -11,7 +11,7 @@ use plonky2::hash::hash_types::RichField;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use crate::cpu::columns::{CpuColumnsView, COL_MAP, NUM_CPU_COLUMNS};
 use crate::cpu::{
-    bootstrap_kernel, control_flow, decode, dup_swap, jumps, membus, modfp254, simple_logic, stack,
+    bootstrap_kernel, control_flow, decode, dup_swap, jumps, membus, modfp254, shift, simple_logic, stack,
     stack_bounds, syscalls,
 };
 use crate::cross_table_lookup::Column;
@@ -126,6 +126,7 @@ impl<F: RichField, const D: usize> CpuStark<F, D> {
         let local_values: &mut CpuColumnsView<_> = local_values.borrow_mut();
         decode::generate(local_values);
         membus::generate(local_values);
+        shift::generate(local_values);
         simple_logic::generate(local_values);
         stack_bounds::generate(local_values); // Must come after `decode`.
     }
@@ -151,6 +152,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         jumps::eval_packed(local_values, next_values, yield_constr);
         membus::eval_packed(local_values, yield_constr);
         modfp254::eval_packed(local_values, yield_constr);
+        shift::eval_packed(local_values, yield_constr);
         simple_logic::eval_packed(local_values, yield_constr);
         stack::eval_packed(local_values, yield_constr);
         stack_bounds::eval_packed(local_values, yield_constr);
@@ -172,6 +174,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         jumps::eval_ext_circuit(builder, local_values, next_values, yield_constr);
         membus::eval_ext_circuit(builder, local_values, yield_constr);
         modfp254::eval_ext_circuit(builder, local_values, yield_constr);
+        shift::eval_ext_circuit(builder, local_values, yield_constr);
         simple_logic::eval_ext_circuit(builder, local_values, yield_constr);
         stack::eval_ext_circuit(builder, local_values, yield_constr);
         stack_bounds::eval_ext_circuit(builder, local_values, yield_constr);

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -11,8 +11,8 @@ use plonky2::hash::hash_types::RichField;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 use crate::cpu::columns::{CpuColumnsView, COL_MAP, NUM_CPU_COLUMNS};
 use crate::cpu::{
-    bootstrap_kernel, control_flow, decode, dup_swap, jumps, membus, modfp254, shift, simple_logic, stack,
-    stack_bounds, syscalls,
+    bootstrap_kernel, control_flow, decode, dup_swap, jumps, membus, modfp254, shift, simple_logic,
+    stack, stack_bounds, syscalls,
 };
 use crate::cross_table_lookup::Column;
 use crate::memory::segments::Segment;
@@ -126,7 +126,6 @@ impl<F: RichField, const D: usize> CpuStark<F, D> {
         let local_values: &mut CpuColumnsView<_> = local_values.borrow_mut();
         decode::generate(local_values);
         membus::generate(local_values);
-        shift::generate(local_values);
         simple_logic::generate(local_values);
         stack_bounds::generate(local_values); // Must come after `decode`.
     }

--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -72,6 +72,7 @@ pub(crate) fn combined_kernel() -> Kernel {
         include_str!("asm/sha2/store_pad.asm"),
         include_str!("asm/sha2/temp_words.asm"),
         include_str!("asm/sha2/write_length.asm"),
+        include_str!("asm/shift.asm"),
         include_str!("asm/transactions/router.asm"),
         include_str!("asm/transactions/type_0.asm"),
         include_str!("asm/transactions/type_1.asm"),

--- a/evm/src/cpu/kernel/asm/main.asm
+++ b/evm/src/cpu/kernel/asm/main.asm
@@ -1,5 +1,7 @@
 global main:
-    // First, load all MPT data from the prover.
+    // First, initialise the shift table
+    %shift_table_init
+    // Second, load all MPT data from the prover.
     PUSH txn_loop
     %jump(load_all_mpts)
 

--- a/evm/src/cpu/kernel/asm/shift.asm
+++ b/evm/src/cpu/kernel/asm/shift.asm
@@ -2,24 +2,24 @@
 ///
 /// Specifically, set SHIFT_TABLE_SEGMENT[i] = 2^i for i = 0..255.
 %macro shift_table_init
-    push 1   // 2^0
-    push 0   // initial offset is zero
-    // stack: ost_0, $1
-    %rep 256
-        // stack: ost_i, 2^i
-        dup2
-        dup2
-        // stack: ost_i, 2^i, ost_i, 2^i
-        %mstore_kernel(@SEGMENT_SHIFT_TABLE)
-        // stack: ost_i, 2^i
-        %increment  // FIXME: Check that this is the right offset increment
-        // stack: ost_(i+1), 2^i
-        swap1
-        // stack: 2^i, ost_(i+1)
-        %mul_const(2)
-        // stack: 2^(i+1), ost_(i+1)
-        swap1
-        // stack: ost_(i+1), 2^(i+1)
+    push 1                     // 2^0
+    push 0                     // initial offset is zero
+    push @SEGMENT_SHIFT_TABLE  // segment
+    dup2                       // kernel context is 0
+    %rep 255
+        // stack: context, segment, ost_i, 2^i
+        dup4
+        dup1
+        add
+        // stack: 2^(i+1), context, segment, ost_i, 2^i
+        dup4
+        %increment
+        // stack: ost_(i+1), 2^(i+1), context, segment, ost_i, 2^i
+        dup4
+        dup4
+        // stack: context, segment, ost_(i+1), 2^(i+1), context, segment, ost_i, 2^i
     %endrep
-    %pop2
+    %rep 256
+        mstore_general
+    %endrep
 %endmacro

--- a/evm/src/cpu/kernel/asm/shift.asm
+++ b/evm/src/cpu/kernel/asm/shift.asm
@@ -1,31 +1,24 @@
-// Expects the stack to contain memory offset `ost_i` and current binary power `2^i`
-%macro shift_table_store_2exp
-    // stack: ost_i, 2^i
-    DUP2
-    DUP2
-    // stack: ost_i, 2^i, ost_i, 2^i
-    // stack: ost_i, 2^i, ost_i, 2^i
-    %mstore_kernel(@SEGMENT_SHIFT_TABLE)
-    // stack: ost_i, 2^i
-    %add_const(32)  // TODO: Check that this is the right offset increment
-    // stack: ost_(i+1), 2^i
-    SWAP1
-    // stack: 2^i, ost_(i+1)
-    %mul_const(2)
-    // stack: 2^(i+1), ost_(i+1)
-    SWAP1
-    // stack: ost_(i+1), 2^(i+1)
-%endmacro
-
-// Set segment[i] = 2^i for i = 0..255
-%macro shift_table_init
-    PUSH 1   // 2^0
-    PUSH 0   // initial offset is zero
-    // stack: ost, $1
-    %rep 256  // TODO: Check that this doesn't alter the stack!
+/// Initialise the lookup table of binary powers for doing left/right shifts
+///
+/// Specifically, set SHIFT_TABLE_SEGMENT[i] = 2^i for i = 0..255.
+%macro shift_table_init:
+    push 1   // 2^0
+    push 0   // initial offset is zero
+    // stack: ost_0, $1
+    %rep 256
         // stack: ost_i, 2^i
-        %shift_table_store_2exp
+        dup2
+        dup2
+        // stack: ost_i, 2^i, ost_i, 2^i
+        %mstore_kernel(@SEGMENT_SHIFT_TABLE)
+        // stack: ost_i, 2^i
+        %increment  // FIXME: Check that this is the right offset increment
+        // stack: ost_(i+1), 2^i
+        swap1
+        // stack: 2^i, ost_(i+1)
+        %mul_const(2)
+        // stack: 2^(i+1), ost_(i+1)
+        swap1
         // stack: ost_(i+1), 2^(i+1)
     %endrep
     %pop2
-%endmacro

--- a/evm/src/cpu/kernel/asm/shift.asm
+++ b/evm/src/cpu/kernel/asm/shift.asm
@@ -1,0 +1,31 @@
+// Expects the stack to contain memory offset `ost_i` and current binary power `2^i`
+%macro shift_table_store_2exp
+    // stack: ost_i, 2^i
+    DUP2
+    DUP2
+    // stack: ost_i, 2^i, ost_i, 2^i
+    // stack: ost_i, 2^i, ost_i, 2^i
+    %mstore_kernel(@SEGMENT_SHIFT_TABLE)
+    // stack: ost_i, 2^i
+    %add_const(32)  // TODO: Check that this is the right offset increment
+    // stack: ost_(i+1), 2^i
+    SWAP1
+    // stack: 2^i, ost_(i+1)
+    %mul_const(2)
+    // stack: 2^(i+1), ost_(i+1)
+    SWAP1
+    // stack: ost_(i+1), 2^(i+1)
+%endmacro
+
+// Set segment[i] = 2^i for i = 0..255
+%macro shift_table_init
+    PUSH 1   // 2^0
+    PUSH 0   // initial offset is zero
+    // stack: ost, $1
+    %rep 256  // TODO: Check that this doesn't alter the stack!
+        // stack: ost_i, 2^i
+        %shift_table_store_2exp
+        // stack: ost_(i+1), 2^(i+1)
+    %endrep
+    %pop2
+%endmacro

--- a/evm/src/cpu/kernel/asm/shift.asm
+++ b/evm/src/cpu/kernel/asm/shift.asm
@@ -1,7 +1,7 @@
 /// Initialise the lookup table of binary powers for doing left/right shifts
 ///
 /// Specifically, set SHIFT_TABLE_SEGMENT[i] = 2^i for i = 0..255.
-%macro shift_table_init:
+%macro shift_table_init
     push 1   // 2^0
     push 0   // initial offset is zero
     // stack: ost_0, $1
@@ -22,3 +22,4 @@
         // stack: ost_(i+1), 2^(i+1)
     %endrep
     %pop2
+%endmacro

--- a/evm/src/cpu/mod.rs
+++ b/evm/src/cpu/mod.rs
@@ -8,6 +8,7 @@ mod jumps;
 pub mod kernel;
 pub(crate) mod membus;
 mod modfp254;
+mod shift;
 mod simple_logic;
 mod stack;
 mod stack_bounds;

--- a/evm/src/cpu/shift.rs
+++ b/evm/src/cpu/shift.rs
@@ -107,7 +107,7 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     yield_constr.constraint(builder, t);
 
     let high_limbs_sum = builder.add_many_extension(&displacement.value[1..]);
-    let t = builder.mul_many_extension(&[is_shift, high_limbs_sum, high_limbs_are_zero]);
+    let t = builder.mul_many_extension([is_shift, high_limbs_sum, high_limbs_are_zero]);
     yield_constr.constraint(builder, t);
 
     let small_disp_filter = builder.mul_extension(is_shift, high_limbs_are_zero);

--- a/evm/src/cpu/shift.rs
+++ b/evm/src/cpu/shift.rs
@@ -1,0 +1,132 @@
+use plonky2::field::extension::Extendable;
+use plonky2::field::packed::PackedField;
+use plonky2::field::types::Field;
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::ext_target::ExtensionTarget;
+
+use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
+use crate::cpu::columns::CpuColumnsView;
+use crate::memory::segments::Segment;
+
+fn generate_shl<F: RichField>(lv: &mut CpuColumnsView<F>) {
+    if lv.op.shl == F::ZERO {
+        return;
+    }
+    assert!(lv.op.shl == F::ONE);
+
+    let _val = lv.mem_channels[0].value;
+    let shift = lv.mem_channels[1].value;
+    let shift_limb0 = shift[0].to_canonical_u64();
+    let output = &mut lv.mem_channels[3].value;
+
+    // NB: It is not strictly necessary to check that the shift amount
+    // is less than 256, it is only necessary to check that it is less
+    // than 2^32 since, when looking up shift table values for shifts
+    // between 256 and 2^32-1, the result will be zero. We make the
+    // check explicit here to clarify intent and because it's easy.
+
+    let mut two_exp = [F::ZERO; 8]; // FIXME
+    //let tail_limbs_sum: F = shift[1..].iter().sum(); // TODO: Why doesn't this work?
+    let tail_limbs_sum: u64 = shift[1..].iter().map(|&c| c.to_canonical_u64()).sum();
+    if shift_limb0 < 256 && tail_limbs_sum == 0 {
+        // Shift amount was < 256...
+        let table_val = &mut lv.mem_channels[2];
+
+        table_val.addr_context = F::ZERO; // kernel context
+        table_val.addr_segment = F::from_canonical_u64(Segment::ShiftTable as u64);
+        // FIXME: double-check that each address refers to 256 bits, not 1 byte
+        table_val.addr_virtual = shift[0];
+
+        // FIXME: set two_exp to value at table_val
+    }
+    // else
+    //     Shift amount was >= 256, so the result is zero regardless of
+    //     the input value. Hence we just keep two_exp = 0.
+
+    // FIXME: call arithmetic::mul::generate()
+}
+
+fn generate_shr<F: RichField>(lv: &mut CpuColumnsView<F>) {
+    if lv.op.shr == F::ZERO {
+        return;
+    }
+    assert!(lv.op.shr == F::ONE);
+
+    todo!();
+}
+
+pub fn generate<F: RichField>(lv: &mut CpuColumnsView<F>) {
+    if lv.is_cpu_cycle == F::ZERO {
+        return;
+    }
+    assert_eq!(lv.is_cpu_cycle, F::ONE);
+
+    generate_shl(lv);
+    generate_shr(lv);
+}
+
+fn eval_packed_shl<P: PackedField>(
+    lv: &CpuColumnsView<P>,
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    let is_shl = lv.op.shl;
+    let val = lv.mem_channels[0].value;
+    let shift = lv.mem_channels[1];    // holds the shift displacement d
+    let two_exp = lv.mem_channels[2];  // holds 2^d
+
+    let shift_table_segment = P::Scalar::from_canonical_u64(Segment::ShiftTable as u64);
+
+    // Constrain two_exp mem_channel to be shift table lookup
+    yield_constr.constraint(is_shl * two_exp.addr_context); // kernel mode only
+    yield_constr.constraint(is_shl * (two_exp.addr_segment - shift_table_segment));
+    yield_constr.constraint(is_shl * (two_exp.addr_virtual - shift.value[0]));
+
+    //let tail_limbs_sum: P = shift.value[1..].iter().sum(); // TODO: Why this no work?
+    let tail_limbs_sum: P = shift.value[1..].iter().map(|&x| x).sum();
+    // FIXME: We need to handle this being non-zero
+    yield_constr.constraint(is_shl * tail_limbs_sum);
+
+    // arithmetic::mul::eval_packed_generic(...)
+
+    todo!();
+}
+
+fn eval_packed_shr<P: PackedField>(
+    _lv: &CpuColumnsView<P>,
+    _yield_constr: &mut ConstraintConsumer<P>,
+) {
+    todo!();
+}
+
+pub fn eval_packed<P: PackedField>(
+    lv: &CpuColumnsView<P>,
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    eval_packed_shl(lv, yield_constr);
+    eval_packed_shr(lv, yield_constr);
+}
+
+fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
+    _builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    _lv: &CpuColumnsView<ExtensionTarget<D>>,
+    _yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    todo!();
+}
+
+fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
+    _builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    _lv: &CpuColumnsView<ExtensionTarget<D>>,
+    _yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    todo!();
+}
+
+pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+    lv: &CpuColumnsView<ExtensionTarget<D>>,
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    eval_ext_circuit_shl(builder, lv, yield_constr);
+    eval_ext_circuit_shr(builder, lv, yield_constr);
+}

--- a/evm/src/cpu/shift.rs
+++ b/evm/src/cpu/shift.rs
@@ -5,131 +5,135 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
-use crate::cpu::columns::{CpuColumnsView, MemoryChannelView};
+use crate::cpu::columns::CpuColumnsView;
+use crate::cpu::membus::NUM_GP_CHANNELS;
 use crate::memory::segments::Segment;
 
-fn generate_shl<F: RichField>(lv: &mut CpuColumnsView<F>) {
-    if lv.op.shl == F::ZERO {
-        return;
-    }
-    assert!(lv.op.shl == F::ONE);
-
-    let _val = lv.mem_channels[0].value;
-    let shift = lv.mem_channels[1].value;
-    let shift_limb0 = shift[0].to_canonical_u64();
-    // lv.mem_channels[2] will be set to the location of 2^shift in the shift table.
-
-    let output = &mut lv.mem_channels[3].value;
-
-    // NB: It is not strictly necessary to check that the shift amount
-    // is less than 256, it is only necessary to check that it is less
-    // than 2^32 since, when looking up shift table values for shifts
-    // between 256 and 2^32-1, the result will be zero. We make the
-    // check explicit here to clarify intent and because it's easy.
-
-    let tail_limbs_sum: F = shift[1..].iter().copied().sum();
-    if shift_limb0 < 256 && tail_limbs_sum == F::ZERO {
-        // Shift amount was < 256...
-        let table_val = &mut lv.mem_channels[2];
-
-        // FIXME: Do I need to set table_val.used or table_val.is_read?
-
-        table_val.addr_context = F::ZERO; // kernel context
-        table_val.addr_segment = F::from_canonical_u64(Segment::ShiftTable as u64);
-        // FIXME: double-check that each address refers to 256 bits, not 1 byte
-        table_val.addr_virtual = shift[0];
-
-        // FIXME: set two_exp to value at table_val
-    }
-    // else
-    //     Shift amount was >= 256, so the result is zero regardless of
-    //     the input value. Hence we just keep two_exp = 0.
-
-    // FIXME: call arithmetic::mul::generate() with inputs `val` and
-    // `two_exp` and output in `output`.
-}
-
-fn generate_shr<F: RichField>(lv: &mut CpuColumnsView<F>) {
-    if lv.op.shr == F::ZERO {
-        return;
-    }
-    assert!(lv.op.shr == F::ONE);
-
-    todo!();
-}
-
-pub fn generate<F: RichField>(lv: &mut CpuColumnsView<F>) {
-    if lv.is_cpu_cycle == F::ZERO {
-        return;
-    }
-    assert_eq!(lv.is_cpu_cycle, F::ONE);
-
-    generate_shl(lv);
-    generate_shr(lv);
-}
-
-fn eval_packed_shl<P: PackedField>(
+pub(crate) fn eval_packed<P: PackedField>(
     lv: &CpuColumnsView<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
-    let is_shl = lv.op.shl;
-    let val = lv.mem_channels[0].value;
-    let shift = lv.mem_channels[1];    // holds the shift displacement d
-    let two_exp = lv.mem_channels[2];  // holds 2^d
+    let is_shift = lv.op.shl + lv.op.shr;
+    let val = lv.mem_channels[0];
+    let displacement = lv.mem_channels[1]; // holds the shift displacement d
+    let two_exp = lv.mem_channels[2]; // holds 2^d
+    let output = lv.mem_channels[NUM_GP_CHANNELS - 1]; // should hold val * 2^d (mod 2^256)
 
     let shift_table_segment = P::Scalar::from_canonical_u64(Segment::ShiftTable as u64);
 
-    // Constrain two_exp mem_channel to be be the entry corresponding
-    // to `shift` in the shift table lookup
-    yield_constr.constraint(is_shl * two_exp.addr_context); // kernel mode only
-    yield_constr.constraint(is_shl * (two_exp.addr_segment - shift_table_segment));
-    yield_constr.constraint(is_shl * (two_exp.addr_virtual - shift.value[0]));
+    // Value, displacement, 2^disp, and output channels must be used and read-only.
+    yield_constr.constraint(is_shift * (val.used - P::ONES));
+    yield_constr.constraint(is_shift * (val.is_read - P::ONES));
+    yield_constr.constraint(is_shift * (displacement.used - P::ONES));
+    yield_constr.constraint(is_shift * (displacement.is_read - P::ONES));
+    yield_constr.constraint(is_shift * (output.used - P::ONES));
+    yield_constr.constraint(is_shift * (output.is_read - P::ONES));
+    yield_constr.constraint(is_shift * (two_exp.used - P::ONES));
+    yield_constr.constraint(is_shift * (two_exp.is_read - P::ONES));
 
-    let tail_limbs_sum: P = shift.value[1..].iter().copied().sum();
-    // FIXME: We need to handle this being non-zero
-    yield_constr.constraint(is_shl * tail_limbs_sum);
+    let high_limbs_are_zero = lv.general.shift().displacement_high_limbs_are_zero;
+    yield_constr
+        .constraint(is_shift * (high_limbs_are_zero - high_limbs_are_zero * high_limbs_are_zero));
 
-    // arithmetic::mul::eval_packed_generic(...)
+    let high_limbs_sum: P = displacement.value[1..].iter().copied().sum();
+    yield_constr.constraint(is_shift * high_limbs_sum * high_limbs_are_zero);
 
-    todo!();
+    // When the shift displacement is < 2^32, constrain the two_exp
+    // mem_channel to be the entry corresponding to `displacement` in
+    // the shift table lookup (will be zero if displacement >= 256).
+    let small_disp_filter = is_shift * high_limbs_are_zero;
+    yield_constr.constraint(small_disp_filter * two_exp.addr_context); // kernel mode only
+    yield_constr.constraint(small_disp_filter * (two_exp.addr_segment - shift_table_segment));
+    yield_constr.constraint(small_disp_filter * (two_exp.addr_virtual - displacement.value[0]));
+
+    // When the shift displacement is >= 2^32, constrain two_exp.value
+    // to be zero.
+    let large_disp_filter = is_shift * (P::ONES - high_limbs_are_zero);
+    for &limb in &two_exp.value {
+        yield_constr.constraint(large_disp_filter * limb);
+    }
+
+    // Other channels must be unused
+    for chan in &lv.mem_channels[3..NUM_GP_CHANNELS - 1] {
+        yield_constr.constraint(is_shift * chan.used); // channel is not used
+    }
+
+    // Cross-table lookup must connect the memory channels here to MUL
+    // (in the case of left shift) or DIV (in the case of right shift)
+    // in the arithmetic table. Specifically, the mapping is
+    //
+    // 0 -> 0  (value to be shifted is the same)
+    // 2 -> 1  (two_exp becomes the multiplicand (resp. divisor))
+    // last -> last  (output is the same)
 }
 
-fn eval_packed_shr<P: PackedField>(
-    _lv: &CpuColumnsView<P>,
-    _yield_constr: &mut ConstraintConsumer<P>,
-) {
-    todo!();
-}
-
-pub fn eval_packed<P: PackedField>(
-    lv: &CpuColumnsView<P>,
-    yield_constr: &mut ConstraintConsumer<P>,
-) {
-    eval_packed_shl(lv, yield_constr);
-    eval_packed_shr(lv, yield_constr);
-}
-
-fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
-    _builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
-    _lv: &CpuColumnsView<ExtensionTarget<D>>,
-    _yield_constr: &mut RecursiveConstraintConsumer<F, D>,
-) {
-    todo!();
-}
-
-fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
-    _builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
-    _lv: &CpuColumnsView<ExtensionTarget<D>>,
-    _yield_constr: &mut RecursiveConstraintConsumer<F, D>,
-) {
-    todo!();
-}
-
-pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
     lv: &CpuColumnsView<ExtensionTarget<D>>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
 ) {
-    eval_ext_circuit_shl(builder, lv, yield_constr);
-    eval_ext_circuit_shr(builder, lv, yield_constr);
+    let is_shift = builder.add_extension(lv.op.shl, lv.op.shr);
+    let val = lv.mem_channels[0];
+    let displacement = lv.mem_channels[1];
+    let two_exp = lv.mem_channels[2];
+    let output = lv.mem_channels[NUM_GP_CHANNELS - 1];
+
+    let shift_table_segment = F::from_canonical_u64(Segment::ShiftTable as u64);
+
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, val.used, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, val.is_read, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, displacement.used, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, displacement.is_read, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, output.used, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, output.is_read, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, two_exp.used, is_shift);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(F::ONE, -F::ONE, is_shift, two_exp.is_read, is_shift);
+    yield_constr.constraint(builder, t);
+
+    let high_limbs_are_zero = lv.general.shift().displacement_high_limbs_are_zero;
+    let t = builder.mul_sub_extension(
+        high_limbs_are_zero,
+        high_limbs_are_zero,
+        high_limbs_are_zero,
+    );
+    let t = builder.mul_extension(t, is_shift);
+    yield_constr.constraint(builder, t);
+
+    let high_limbs_sum = builder.add_many_extension(&displacement.value[1..]);
+    let t = builder.mul_many_extension(&[is_shift, high_limbs_sum, high_limbs_are_zero]);
+    yield_constr.constraint(builder, t);
+
+    let small_disp_filter = builder.mul_extension(is_shift, high_limbs_are_zero);
+    let t = builder.mul_extension(small_disp_filter, two_exp.addr_context);
+    yield_constr.constraint(builder, t);
+    let t = builder.arithmetic_extension(
+        F::ONE,
+        -shift_table_segment,
+        small_disp_filter,
+        two_exp.addr_segment,
+        small_disp_filter,
+    );
+    yield_constr.constraint(builder, t);
+    let t = builder.sub_extension(two_exp.addr_virtual, displacement.value[0]);
+    let t = builder.mul_extension(small_disp_filter, t);
+    yield_constr.constraint(builder, t);
+
+    let large_disp_filter =
+        builder.arithmetic_extension(-F::ONE, F::ONE, is_shift, high_limbs_are_zero, is_shift);
+    for &limb in &two_exp.value {
+        let t = builder.mul_extension(large_disp_filter, limb);
+        yield_constr.constraint(builder, t);
+    }
+
+    for chan in &lv.mem_channels[3..NUM_GP_CHANNELS - 1] {
+        let t = builder.mul_extension(is_shift, chan.used);
+        yield_constr.constraint(builder, t);
+    }
 }

--- a/evm/src/cpu/shift.rs
+++ b/evm/src/cpu/shift.rs
@@ -95,7 +95,9 @@ pub(crate) fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     let t = builder.one_extension();
     let t = builder.sub_extension(t, high_limbs_are_zero);
     let t = builder.mul_sub_extension(high_limbs_sum, high_limbs_sum_inv, t);
+    let t = builder.mul_extension(is_shift, t);
     yield_constr.constraint(builder, t);
+
     let t = builder.mul_many_extension([is_shift, high_limbs_sum, high_limbs_are_zero]);
     yield_constr.constraint(builder, t);
 

--- a/evm/src/memory/segments.rs
+++ b/evm/src/memory/segments.rs
@@ -33,10 +33,13 @@ pub(crate) enum Segment {
     TrieEncodedChild = 13,
     /// A buffer used to store the lengths of the encodings of a branch node's children.
     TrieEncodedChildLen = 14,
+    /// A table of values 2^i for i=0..255 for use with shift
+    /// instructions; initialised by `kernel/asm/shift.asm::init_shift_table()`.
+    ShiftTable = 15,
 }
 
 impl Segment {
-    pub(crate) const COUNT: usize = 15;
+    pub(crate) const COUNT: usize = 16;
 
     pub(crate) fn all() -> [Self; Self::COUNT] {
         [
@@ -55,6 +58,7 @@ impl Segment {
             Self::TrieData,
             Self::TrieEncodedChild,
             Self::TrieEncodedChildLen,
+            Self::ShiftTable,
         ]
     }
 
@@ -76,6 +80,7 @@ impl Segment {
             Segment::TrieData => "SEGMENT_TRIE_DATA",
             Segment::TrieEncodedChild => "SEGMENT_TRIE_ENCODED_CHILD",
             Segment::TrieEncodedChildLen => "SEGMENT_TRIE_ENCODED_CHILD_LEN",
+            Segment::ShiftTable => "SEGMENT_SHIFT_TABLE",
         }
     }
 
@@ -97,6 +102,7 @@ impl Segment {
             Segment::TrieData => 256,
             Segment::TrieEncodedChild => 256,
             Segment::TrieEncodedChildLen => 6,
+            Segment::ShiftTable => 256,
         }
     }
 }

--- a/evm/src/memory/segments.rs
+++ b/evm/src/memory/segments.rs
@@ -41,7 +41,7 @@ pub(crate) enum Segment {
 }
 
 impl Segment {
-    pub(crate) const COUNT: usize = 16;
+    pub(crate) const COUNT: usize = 17;
 
     pub(crate) fn all() -> [Self; Self::COUNT] {
         [


### PR DESCRIPTION
Code to verify shift left/right instructions on the EVM. Doesn't include generation code, that will come later once some upcoming changes from @nbgl are merged. I think the lack of generation code is probably the cause of the failing test. It is not currently connected to the arithmetic table, but that will be handled in a follow-up PR.