### PR TITLE
Use static `KERNEL` in tests

### DIFF
--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -8,7 +8,6 @@ use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
 
 use crate::cpu::kernel::aggregator::KERNEL;
-use crate::cpu::kernel::assembler::Kernel;
 use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cpu::kernel::constants::txn_fields::NormalizedTxnField;
@@ -80,17 +79,15 @@ pub struct Interpreter<'a> {
     running: bool,
 }
 
-pub fn run_with_kernel(
-    // TODO: Remove param and just use KERNEL.
-    kernel: &Kernel,
+pub fn run_interpreter(
     initial_offset: usize,
     initial_stack: Vec<U256>,
-) -> anyhow::Result<Interpreter> {
+) -> anyhow::Result<Interpreter<'static>> {
     run(
-        &kernel.code,
+        &KERNEL.code,
         initial_offset,
         initial_stack,
-        &kernel.prover_inputs,
+        &KERNEL.prover_inputs,
     )
 }
 

--- a/evm/src/cpu/kernel/tests/ecrecover.rs
+++ b/evm/src/cpu/kernel/tests/ecrecover.rs
@@ -3,35 +3,23 @@ use std::str::FromStr;
 use anyhow::Result;
 use ethereum_types::U256;
 
-use crate::cpu::kernel::aggregator::combined_kernel;
-use crate::cpu::kernel::assembler::Kernel;
-use crate::cpu::kernel::interpreter::run_with_kernel;
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::interpreter::run_interpreter;
 use crate::cpu::kernel::tests::u256ify;
 
-fn test_valid_ecrecover(
-    hash: &str,
-    v: &str,
-    r: &str,
-    s: &str,
-    expected: &str,
-    kernel: &Kernel,
-) -> Result<()> {
-    let ecrecover = kernel.global_labels["ecrecover"];
+fn test_valid_ecrecover(hash: &str, v: &str, r: &str, s: &str, expected: &str) -> Result<()> {
+    let ecrecover = KERNEL.global_labels["ecrecover"];
     let initial_stack = u256ify(["0xdeadbeef", s, r, v, hash])?;
-    let stack = run_with_kernel(kernel, ecrecover, initial_stack)?
-        .stack()
-        .to_vec();
+    let stack = run_interpreter(ecrecover, initial_stack)?.stack().to_vec();
     assert_eq!(stack[0], U256::from_str(expected).unwrap());
 
     Ok(())
 }
 
-fn test_invalid_ecrecover(hash: &str, v: &str, r: &str, s: &str, kernel: &Kernel) -> Result<()> {
-    let ecrecover = kernel.global_labels["ecrecover"];
+fn test_invalid_ecrecover(hash: &str, v: &str, r: &str, s: &str) -> Result<()> {
+    let ecrecover = KERNEL.global_labels["ecrecover"];
     let initial_stack = u256ify(["0xdeadbeef", s, r, v, hash])?;
-    let stack = run_with_kernel(kernel, ecrecover, initial_stack)?
-        .stack()
-        .to_vec();
+    let stack = run_interpreter(ecrecover, initial_stack)?.stack().to_vec();
     assert_eq!(stack, vec![U256::MAX]);
 
     Ok(())
@@ -39,15 +27,12 @@ fn test_invalid_ecrecover(hash: &str, v: &str, r: &str, s: &str, kernel: &Kernel
 
 #[test]
 fn test_ecrecover() -> Result<()> {
-    let kernel = combined_kernel();
-
     test_valid_ecrecover(
         "0x55f77e8909b1f1c9531c4a309bb2d40388e9ed4b87830c8f90363c6b36255fb9",
         "0x1b",
         "0xd667c5a20fa899b253924099e10ae92998626718585b8171eb98de468bbebc",
         "0x58351f48ce34bf134ee611fb5bf255a5733f0029561d345a7d46bfa344b60ac0",
         "0x67f3c0Da351384838d7F7641AB0fCAcF853E1844",
-        &kernel,
     )?;
     test_valid_ecrecover(
         "0x55f77e8909b1f1c9531c4a309bb2d40388e9ed4b87830c8f90363c6b36255fb9",
@@ -55,7 +40,6 @@ fn test_ecrecover() -> Result<()> {
         "0xd667c5a20fa899b253924099e10ae92998626718585b8171eb98de468bbebc",
         "0x58351f48ce34bf134ee611fb5bf255a5733f0029561d345a7d46bfa344b60ac0",
         "0xaA58436DeABb64982a386B2De1A8015AA28fCCc0",
-        &kernel,
     )?;
     test_valid_ecrecover(
         "0x0",
@@ -63,7 +47,6 @@ fn test_ecrecover() -> Result<()> {
         "0x1",
         "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
         "0x3344c6f6eeCA588be132142DB0a32C71ABFAAe7B",
-        &kernel,
     )?;
 
     test_invalid_ecrecover(
@@ -71,28 +54,24 @@ fn test_ecrecover() -> Result<()> {
         "0x42", // v not in {27,28}
         "0x1",
         "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
-        &kernel,
     )?;
     test_invalid_ecrecover(
         "0x0",
         "0x42",
         "0xd667c5a20fa899b253924099e10ae92998626718585b8171eb98de468bbebc",
         "0x0", // s=0
-        &kernel,
     )?;
     test_invalid_ecrecover(
         "0x0",
         "0x42",
         "0x0", // r=0
         "0xd667c5a20fa899b253924099e10ae92998626718585b8171eb98de468bbebc",
-        &kernel,
     )?;
     test_invalid_ecrecover(
         "0x0",
         "0x1c",
         "0x3a18b21408d275dde53c0ea86f9c1982eca60193db0ce15008fa408d43024847", // r^3 + 7 isn't a square
         "0x5db9745f44089305b2f2c980276e7025a594828d878e6e36dd2abd34ca6b9e3d",
-        &kernel,
     )?;
 
     Ok(())

--- a/evm/src/cpu/kernel/tests/exp.rs
+++ b/evm/src/cpu/kernel/tests/exp.rs
@@ -2,50 +2,43 @@ use anyhow::Result;
 use ethereum_types::U256;
 use rand::{thread_rng, Rng};
 
-use crate::cpu::kernel::aggregator::combined_kernel;
-use crate::cpu::kernel::interpreter::{run, run_with_kernel};
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::interpreter::{run, run_interpreter};
 
 #[test]
 fn test_exp() -> Result<()> {
     // Make sure we can parse and assemble the entire kernel.
-    let kernel = combined_kernel();
-    let exp = kernel.global_labels["exp"];
+    let exp = KERNEL.global_labels["exp"];
     let mut rng = thread_rng();
     let a = U256([0; 4].map(|_| rng.gen()));
     let b = U256([0; 4].map(|_| rng.gen()));
 
     // Random input
     let initial_stack = vec![0xDEADBEEFu32.into(), b, a];
-    let stack_with_kernel = run_with_kernel(&kernel, exp, initial_stack)?
-        .stack()
-        .to_vec();
+    let stack_with_kernel = run_interpreter(exp, initial_stack)?.stack().to_vec();
     let initial_stack = vec![b, a];
     let code = [0xa, 0x63, 0xde, 0xad, 0xbe, 0xef, 0x56]; // EXP, PUSH4 deadbeef, JUMP
-    let stack_with_opcode = run(&code, 0, initial_stack, &kernel.prover_inputs)?
+    let stack_with_opcode = run(&code, 0, initial_stack, &KERNEL.prover_inputs)?
         .stack()
         .to_vec();
     assert_eq!(stack_with_kernel, stack_with_opcode);
 
     // 0 base
     let initial_stack = vec![0xDEADBEEFu32.into(), b, U256::zero()];
-    let stack_with_kernel = run_with_kernel(&kernel, exp, initial_stack)?
-        .stack()
-        .to_vec();
+    let stack_with_kernel = run_interpreter(exp, initial_stack)?.stack().to_vec();
     let initial_stack = vec![b, U256::zero()];
     let code = [0xa, 0x63, 0xde, 0xad, 0xbe, 0xef, 0x56]; // EXP, PUSH4 deadbeef, JUMP
-    let stack_with_opcode = run(&code, 0, initial_stack, &kernel.prover_inputs)?
+    let stack_with_opcode = run(&code, 0, initial_stack, &KERNEL.prover_inputs)?
         .stack()
         .to_vec();
     assert_eq!(stack_with_kernel, stack_with_opcode);
 
     // 0 exponent
     let initial_stack = vec![0xDEADBEEFu32.into(), U256::zero(), a];
-    let stack_with_kernel = run_with_kernel(&kernel, exp, initial_stack)?
-        .stack()
-        .to_vec();
+    let stack_with_kernel = run_interpreter(exp, initial_stack)?.stack().to_vec();
     let initial_stack = vec![U256::zero(), a];
     let code = [0xa, 0x63, 0xde, 0xad, 0xbe, 0xef, 0x56]; // EXP, PUSH4 deadbeef, JUMP
-    let stack_with_opcode = run(&code, 0, initial_stack, &kernel.prover_inputs)?
+    let stack_with_opcode = run(&code, 0, initial_stack, &KERNEL.prover_inputs)?
         .stack()
         .to_vec();
     assert_eq!(stack_with_kernel, stack_with_opcode);

--- a/evm/src/cpu/kernel/tests/fields.rs
+++ b/evm/src/cpu/kernel/tests/fields.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use ethereum_types::U256;
 use rand::{thread_rng, Rng};
 
-use crate::cpu::kernel::aggregator::combined_kernel;
-use crate::cpu::kernel::interpreter::run_with_kernel;
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::interpreter::run_interpreter;
 
 // TODO: 107 is hardcoded as a dummy prime for testing
 // should be changed to the proper implementation prime
@@ -137,10 +137,9 @@ fn test_fp6() -> Result<()> {
     let mut input: Vec<u32> = [c, d].into_iter().flatten().flatten().collect();
     input.push(0xdeadbeef);
 
-    let kernel = combined_kernel();
-    let initial_offset = kernel.global_labels["mul_fp6"];
+    let initial_offset = KERNEL.global_labels["mul_fp6"];
     let initial_stack: Vec<U256> = as_stack(input);
-    let final_stack: Vec<U256> = run_with_kernel(&kernel, initial_offset, initial_stack)?
+    let final_stack: Vec<U256> = run_interpreter(initial_offset, initial_stack)?
         .stack()
         .to_vec();
 

--- a/evm/src/cpu/kernel/tests/hash.rs
+++ b/evm/src/cpu/kernel/tests/hash.rs
@@ -6,8 +6,8 @@ use rand::{thread_rng, Rng};
 use ripemd::{Digest, Ripemd160};
 use sha2::Sha256;
 
-use crate::cpu::kernel::aggregator::combined_kernel;
-use crate::cpu::kernel::interpreter::run_with_kernel;
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::interpreter::run_interpreter;
 
 /// Standard Sha2 implementation.
 fn sha2(input: Vec<u8>) -> U256 {
@@ -62,12 +62,11 @@ fn test_hash(hash_fn_label: &str, standard_implementation: &dyn Fn(Vec<u8>) -> U
     let initial_stack_custom = make_input_stack(message_custom);
 
     // Make the kernel.
-    let kernel = combined_kernel();
-    let kernel_function = kernel.global_labels[hash_fn_label];
+    let kernel_function = KERNEL.global_labels[hash_fn_label];
 
     // Run the kernel code.
-    let result_random = run_with_kernel(&kernel, kernel_function, initial_stack_random)?;
-    let result_custom = run_with_kernel(&kernel, kernel_function, initial_stack_custom)?;
+    let result_random = run_interpreter(kernel_function, initial_stack_random)?;
+    let result_custom = run_interpreter(kernel_function, initial_stack_custom)?;
 
     // Extract the final output.
     let actual_random = result_random.stack()[0];

--- a/evm/src/cpu/kernel/tests/ripemd.rs
+++ b/evm/src/cpu/kernel/tests/ripemd.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use ethereum_types::U256;
 use itertools::Itertools;
 
-use crate::cpu::kernel::aggregator::combined_kernel;
-use crate::cpu::kernel::interpreter::run_with_kernel;
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::interpreter::run_interpreter;
 
 fn make_input(word: &str) -> Vec<u32> {
     let mut input: Vec<u32> = vec![word.len().try_into().unwrap()];
@@ -44,10 +44,9 @@ fn test_ripemd_reference() -> Result<()> {
         let input: Vec<u32> = make_input(x);
         let expected = U256::from(y);
 
-        let kernel = combined_kernel();
-        let initial_offset = kernel.global_labels["ripemd_stack"];
+        let initial_offset = KERNEL.global_labels["ripemd_stack"];
         let initial_stack: Vec<U256> = input.iter().map(|&x| U256::from(x)).rev().collect();
-        let final_stack: Vec<U256> = run_with_kernel(&kernel, initial_offset, initial_stack)?
+        let final_stack: Vec<U256> = run_interpreter(initial_offset, initial_stack)?
             .stack()
             .to_vec();
         let actual = final_stack[0];


### PR DESCRIPTION
Instead of passing around a kernel object.