### PR TITLE
Add missing feature to field crate

### DIFF
--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::return_self_not_must_use)]
 #![feature(generic_const_exprs)]
+#![feature(stdsimd)]
 #![feature(specialization)]
 #![cfg_attr(not(test), no_std)]
 


### PR DESCRIPTION
Current `main` fails to compile with the the standard "fast compilation" flags: 
```
RUSTFLAGS='-C target-cpu=native' cargo test --release
```
It complains that `#![feature(stdsimd)]` is missing.

Not sure how this got in to main, but it's recent; maybe from the `no-std` PR?