### PR TITLE
Serialization refactor

### DIFF
--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -117,7 +117,9 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
         let mut buffer = Buffer::new(bytes);
-        let proof = buffer.read_proof_with_public_inputs(common_data)?;
+        let proof = buffer
+            .read_proof_with_public_inputs(common_data)
+            .map_err(anyhow::Error::msg)?;
         Ok(proof)
     }
 }
@@ -233,7 +235,9 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buffer = Vec::new();
-        let _ = buffer.write_compressed_proof_with_public_inputs(self);
+        buffer
+            .write_compressed_proof_with_public_inputs(self)
+            .expect("Writing to a byte-vector cannot fail.");
         buffer
     }
 
@@ -243,7 +247,9 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
         let mut buffer = Buffer::new(bytes);
-        let proof = buffer.read_compressed_proof_with_public_inputs(common_data)?;
+        let proof = buffer
+            .read_compressed_proof_with_public_inputs(common_data)
+            .map_err(anyhow::Error::msg)?;
         Ok(proof)
     }
 }

--- a/plonky2/src/util/serialization.rs
+++ b/plonky2/src/util/serialization.rs
@@ -459,7 +459,7 @@ pub trait Read {
         C: GenericConfig<D, F = F>,
     {
         let proof = self.read_compressed_proof(common_data)?;
-        let public_inputs = self.read_field_vec((self.remaining() as usize) / size_of::<u64>())?;
+        let public_inputs = self.read_field_vec(self.remaining() / size_of::<u64>())?;
         Ok(CompressedProofWithPublicInputs {
             proof,
             public_inputs,


### PR DESCRIPTION
Followup to #806.

A few goals here
- Zero dependencies on std.
- Provide a single (memory buffering) impl of `Write` to make sure there's no confusion.
- Move closer to the `std::io` APIs. Hopefully they will be available without std at some point (there have been some discussions...).

More specifically, this
- Changes `Buffer` to not use std's `Cursor`.
- Removes `impl Write` for `Buffer`, since it's implemented for `Vec<u8>`.
- Adds a concrete I/O error type to mimic `std::io`'s.
- Combines `Position` and `Size` into `Remaining`.