### PR TITLE
Add Clone support for ProofWithPublicInputsTarget

### DIFF
--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -112,7 +112,7 @@ pub struct FriProof<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> 
     pub pow_witness: F,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FriProofTarget<const D: usize> {
     pub commit_phase_merkle_caps: Vec<MerkleCapTarget>,
     pub query_round_proofs: Vec<FriQueryRoundTarget<D>>,

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -7,7 +7,7 @@ use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::util::reducing::ReducingFactorTarget;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PolynomialCoeffsExtTarget<const D: usize>(pub Vec<ExtensionTarget<D>>);
 
 impl<const D: usize> PolynomialCoeffsExtTarget<D> {

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -40,7 +40,7 @@ pub struct Proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
     pub opening_proof: FriProof<F, C::Hasher, D>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProofTarget<const D: usize> {
     pub wires_cap: MerkleCapTarget,
     pub plonk_zs_partial_products_cap: MerkleCapTarget,
@@ -283,7 +283,7 @@ pub(crate) struct FriInferredElements<F: RichField + Extendable<D>, const D: usi
     pub Vec<F::Extension>,
 );
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProofWithPublicInputsTarget<const D: usize> {
     pub proof: ProofTarget<D>,
     pub public_inputs: Vec<Target>,


### PR DESCRIPTION
When I have done some recursive example, I found out the lack for Clone derive for ProofWithPublicInputsTarget.

Here example: https://gist.github.com/tikhono/6b3222ccaa2030280efcbc7038eeb373

Does the usage of clone correct? Or lack of this derive is intendant, so there are some reasonings for this?