### PR TITLE
Set CI to use an older version of nightly

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-11-23
           override: true
 
       - name: rust-cache
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2022-11-23
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
Needed until https://github.com/rust-lang/rust/issues/105037 is fixed.