### PR TITLE
Constrain memory channels in JUMPDEST

### DIFF
--- a/evm/src/cpu/stack.rs
+++ b/evm/src/cpu/stack.rs
@@ -71,9 +71,13 @@ const STACK_BEHAVIORS: OpsColumnsView<Option<StackBehavior>> = OpsColumnsView {
         pushes: true,
         disable_other_channels: true,
     }),
-    gas: None,      // TODO
-    jumpdest: None, // TODO
-    push: None,     // TODO
+    gas: None, // TODO
+    jumpdest: Some(StackBehavior {
+        num_pops: 0,
+        pushes: false,
+        disable_other_channels: true,
+    }),
+    push: None, // TODO
     dup: None,
     swap: None,
     get_context: None, // TODO


### PR DESCRIPTION
I think that's all we need for the JUMPDEST flag.