### PR TITLE
add `or` gadget for `BoolTarget`

### DIFF
--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -337,6 +337,12 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         BoolTarget::new_unsafe(self.mul(b1.target, b2.target))
     }
 
+    // computes the arithmetic extension of logical "or": `b1 + b2 - b1 * b2`
+    pub fn or(&mut self, b1: BoolTarget, b2: BoolTarget) -> BoolTarget {
+        let res_minus_b2 = self.arithmetic(-F::ONE, F::ONE, b1.target, b2.target, b1.target);
+        BoolTarget::new_unsafe(self.add(res_minus_b2, b2.target))
+    }
+
     pub fn _if(&mut self, b: BoolTarget, x: Target, y: Target) -> Target {
         let not_b = self.not(b);
         let maybe_x = self.mul(b.target, x);

--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -337,7 +337,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         BoolTarget::new_unsafe(self.mul(b1.target, b2.target))
     }
 
-    // computes the arithmetic extension of logical "or": `b1 + b2 - b1 * b2`
+    /// computes the arithmetic extension of logical "or": `b1 + b2 - b1 * b2`
     pub fn or(&mut self, b1: BoolTarget, b2: BoolTarget) -> BoolTarget {
         let res_minus_b2 = self.arithmetic(-F::ONE, F::ONE, b1.target, b2.target, b1.target);
         BoolTarget::new_unsafe(self.add(res_minus_b2, b2.target))


### PR DESCRIPTION
This PR adds a "logical or" gadget for `BoolTarget`s.

I was writing some gadgets and found myself writing this over and over again and I thought it would be useful for others.