### PR TITLE
Allow non-tight degree bound

### DIFF
--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use maybe_rayon::*;
+use plonky2_field::types::Field;
 
 use crate::field::extension::Extendable;
 use crate::field::fft::FftRootTable;
@@ -188,7 +189,8 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 &format!("reduce batch of {} polynomials", polynomials.len()),
                 alpha.reduce_polys_base(polys_coeff)
             );
-            let quotient = composition_poly.divide_by_linear(*point);
+            let mut quotient = composition_poly.divide_by_linear(*point);
+            quotient.coeffs.push(F::Extension::ZERO); // pad back to power of two
             alpha.shift_poly(&mut final_poly);
             final_poly += quotient;
         }

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -8,7 +8,6 @@ use crate::field::extension::Extendable;
 use crate::field::fft::FftRootTable;
 use crate::field::packed::PackedField;
 use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
-use crate::field::types::Field;
 use crate::fri::proof::FriProof;
 use crate::fri::prover::fri_proof;
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo};

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -193,9 +193,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             alpha.shift_poly(&mut final_poly);
             final_poly += quotient;
         }
-        // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
-        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
-        final_poly.coeffs.insert(0, F::Extension::ZERO);
 
         let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);
         let lde_final_values = timed!(

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -262,9 +262,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             sum = self.div_add_extension(numerator, denominator, sum);
         }
 
-        // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
-        // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
-        self.mul_extension(sum, subgroup_x)
+        sum
     }
 
     fn fri_verifier_query_round<C: GenericConfig<D, F = F>>(

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -157,9 +157,7 @@ pub(crate) fn fri_combine_initial<
         sum += numerator / denominator;
     }
 
-    // Multiply the final polynomial by `X`, so that `final_poly` has the maximum degree for
-    // which the LDT will pass. See github.com/mir-protocol/plonky2/pull/436 for details.
-    sum * subgroup_x
+    sum
 }
 
 fn fri_verifier_query_round<


### PR DESCRIPTION
Reverts the degree adjustment part of #436. As @jimpo pointed out, the adjustment complicates security by allowing rational functions of the form `poly(x) / x`.

In hindsight a tight degree bound shouldn't be necessary. Ultimately we want to check that some witness function `f(x)` exists satisfying (simplified) `c(f(x)) = Z_H(x) q(x)`.  We only need `f(x)` to be low-degree because that allows us to use polynomial identity testing. With PIT we don't care about exact degree bounds; a negligible degree change will have a negligible effect on PIT soundness.