### PR TITLE
Remove some older EVM recursion logic

### DIFF
--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -46,11 +46,6 @@ pub(crate) struct AllChallengerState<F: RichField + Extendable<D>, const D: usiz
     pub ctl_challenges: GrandProductChallengeSet<F>,
 }
 
-pub struct AllProofTarget<const D: usize> {
-    pub stark_proofs: [StarkProofTarget<D>; NUM_TABLES],
-    pub public_values: PublicValuesTarget,
-}
-
 /// Memory values which are public.
 #[derive(Debug, Clone, Default)]
 pub struct PublicValues {

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -8,42 +8,32 @@ use plonky2::fri::witness_util::set_fri_proof_target;
 use plonky2::gates::exponentiation::ExponentiationGate;
 use plonky2::gates::gate::GateRef;
 use plonky2::gates::noop::NoopGate;
-use plonky2::hash::hash_types::{HashOut, RichField};
+use plonky2::hash::hash_types::RichField;
 use plonky2::hash::hashing::SPONGE_WIDTH;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
 use plonky2::iop::witness::{PartialWitness, Witness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::circuit_data::{
-    CircuitConfig, CircuitData, VerifierCircuitData, VerifierCircuitTarget,
-};
+use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData};
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
 use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::with_context;
 use plonky2_util::log2_ceil;
 
-use crate::all_stark::{all_cross_table_lookups, AllStark, Table, NUM_TABLES};
+use crate::all_stark::{Table, NUM_TABLES};
 use crate::config::StarkConfig;
 use crate::constraint_consumer::RecursiveConstraintConsumer;
-use crate::cpu::cpu_stark::CpuStark;
-use crate::cross_table_lookup::{
-    verify_cross_table_lookups, verify_cross_table_lookups_circuit, CrossTableLookup,
-    CtlCheckVarsTarget,
-};
-use crate::keccak::keccak_stark::KeccakStark;
-use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
-use crate::logic::LogicStark;
-use crate::memory::memory_stark::MemoryStark;
+use crate::cross_table_lookup::{verify_cross_table_lookups, CrossTableLookup, CtlCheckVarsTarget};
 use crate::permutation::{
-    get_grand_product_challenge_set, get_grand_product_challenge_set_target, GrandProductChallenge,
-    GrandProductChallengeSet, PermutationCheckDataTarget,
+    get_grand_product_challenge_set, GrandProductChallenge, GrandProductChallengeSet,
+    PermutationCheckDataTarget,
 };
 use crate::proof::{
-    AllProof, AllProofTarget, BlockMetadata, BlockMetadataTarget, PublicValues, PublicValuesTarget,
-    StarkOpeningSetTarget, StarkProof, StarkProofChallengesTarget, StarkProofTarget,
-    StarkProofWithMetadata, TrieRoots, TrieRootsTarget,
+    BlockMetadata, BlockMetadataTarget, PublicValues, PublicValuesTarget, StarkOpeningSetTarget,
+    StarkProof, StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
+    TrieRootsTarget,
 };
 use crate::stark::Stark;
 use crate::util::{h160_limbs, h256_limbs};
@@ -57,11 +47,6 @@ pub struct RecursiveAllProof<
     const D: usize,
 > {
     pub recursive_proofs: [ProofWithPublicInputs<F, C, D>; NUM_TABLES],
-}
-
-pub struct RecursiveAllProofTargetWithData<const D: usize> {
-    pub recursive_proofs: [ProofWithPublicInputsTarget<D>; NUM_TABLES],
-    pub verifier_data: [VerifierCircuitTarget; NUM_TABLES],
 }
 
 pub(crate) struct PublicInputs<T: Copy + Eq + PartialEq + Debug> {
@@ -161,84 +146,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             verifier_data.verify(proof)?;
         }
         Ok(())
-    }
-
-    /// Recursively verify every recursive proof.
-    // TODO: Remove? Replaced by fixed_recursive_verifier.
-    pub fn verify_circuit(
-        builder: &mut CircuitBuilder<F, D>,
-        recursive_all_proof_target: RecursiveAllProofTargetWithData<D>,
-        verifier_data: &[VerifierCircuitData<F, C, D>; NUM_TABLES],
-        inner_config: &StarkConfig,
-    ) where
-        [(); C::Hasher::HASH_SIZE]:,
-        <C as GenericConfig<D>>::Hasher: AlgebraicHasher<F>,
-    {
-        let RecursiveAllProofTargetWithData {
-            recursive_proofs,
-            verifier_data: verifier_data_target,
-        } = recursive_all_proof_target;
-        let pis: [_; NUM_TABLES] = std::array::from_fn(|i| {
-            PublicInputs::from_vec(&recursive_proofs[i].public_inputs, inner_config)
-        });
-
-        let mut challenger = RecursiveChallenger::<F, C::Hasher, D>::new(builder);
-        for pi in &pis {
-            for h in &pi.trace_cap {
-                challenger.observe_elements(h);
-            }
-        }
-        let ctl_challenges = get_grand_product_challenge_set_target(
-            builder,
-            &mut challenger,
-            inner_config.num_challenges,
-        );
-        // Check that the correct CTL challenges are used in every proof.
-        for pi in &pis {
-            for i in 0..inner_config.num_challenges {
-                builder.connect(
-                    ctl_challenges.challenges[i].beta,
-                    pi.ctl_challenges.challenges[i].beta,
-                );
-                builder.connect(
-                    ctl_challenges.challenges[i].gamma,
-                    pi.ctl_challenges.challenges[i].gamma,
-                );
-            }
-        }
-
-        let state = challenger.compact(builder);
-        for k in 0..SPONGE_WIDTH {
-            builder.connect(state[k], pis[0].challenger_state_before[k]);
-        }
-        // Check that the challenger state is consistent between proofs.
-        for i in 1..NUM_TABLES {
-            for k in 0..SPONGE_WIDTH {
-                builder.connect(
-                    pis[i].challenger_state_before[k],
-                    pis[i - 1].challenger_state_after[k],
-                );
-            }
-        }
-
-        // Verify the CTL checks.
-        verify_cross_table_lookups_circuit::<F, C, D>(
-            builder,
-            all_cross_table_lookups(),
-            pis.map(|p| p.ctl_zs_last),
-            inner_config,
-        );
-        for (i, (recursive_proof, verifier_data_target)) in recursive_proofs
-            .into_iter()
-            .zip(verifier_data_target)
-            .enumerate()
-        {
-            builder.verify_proof::<C>(
-                &recursive_proof,
-                &verifier_data_target,
-                &verifier_data[i].common,
-            );
-        }
     }
 }
 
@@ -427,85 +334,6 @@ pub(crate) fn add_common_recursion_gates<F: RichField + Extendable<D>, const D: 
     )));
 }
 
-/// Returns the recursive Stark circuit verifier data for every Stark in `AllStark`.
-pub fn all_verifier_data_recursive_stark_proof<
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    const D: usize,
->(
-    all_stark: &AllStark<F, D>,
-    degree_bits: [usize; NUM_TABLES],
-    inner_config: &StarkConfig,
-    circuit_config: &CircuitConfig,
-) -> [VerifierCircuitData<F, C, D>; NUM_TABLES]
-where
-    [(); CpuStark::<F, D>::COLUMNS]:,
-    [(); KeccakStark::<F, D>::COLUMNS]:,
-    [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
-    [(); LogicStark::<F, D>::COLUMNS]:,
-    [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::Hasher::HASH_SIZE]:,
-    C::Hasher: AlgebraicHasher<F>,
-{
-    [
-        recursive_stark_circuit(
-            Table::Cpu,
-            &all_stark.cpu_stark,
-            degree_bits[Table::Cpu as usize],
-            &all_stark.cross_table_lookups,
-            inner_config,
-            circuit_config,
-            0,
-        )
-        .circuit
-        .verifier_data(),
-        recursive_stark_circuit(
-            Table::Keccak,
-            &all_stark.keccak_stark,
-            degree_bits[Table::Keccak as usize],
-            &all_stark.cross_table_lookups,
-            inner_config,
-            circuit_config,
-            0,
-        )
-        .circuit
-        .verifier_data(),
-        recursive_stark_circuit(
-            Table::KeccakSponge,
-            &all_stark.keccak_sponge_stark,
-            degree_bits[Table::KeccakSponge as usize],
-            &all_stark.cross_table_lookups,
-            inner_config,
-            circuit_config,
-            0,
-        )
-        .circuit
-        .verifier_data(),
-        recursive_stark_circuit(
-            Table::Logic,
-            &all_stark.logic_stark,
-            degree_bits[Table::Logic as usize],
-            &all_stark.cross_table_lookups,
-            inner_config,
-            circuit_config,
-            0,
-        )
-        .circuit
-        .verifier_data(),
-        recursive_stark_circuit(
-            Table::Memory,
-            &all_stark.memory_stark,
-            degree_bits[Table::Memory as usize],
-            &all_stark.cross_table_lookups,
-            inner_config,
-            circuit_config,
-            0,
-        )
-        .circuit
-        .verifier_data(),
-    ]
-}
-
 /// Recursively verifies an inner proof.
 fn verify_stark_proof_with_challenges_circuit<
     F: RichField + Extendable<D>,
@@ -634,87 +462,8 @@ fn eval_l_0_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(
     )
 }
 
-pub fn add_virtual_all_proof<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    all_stark: &AllStark<F, D>,
-    config: &StarkConfig,
-    degree_bits: &[usize],
-    nums_ctl_zs: &[usize],
-) -> AllProofTarget<D> {
-    let stark_proofs = [
-        add_virtual_stark_proof(
-            builder,
-            &all_stark.cpu_stark,
-            config,
-            degree_bits[Table::Cpu as usize],
-            nums_ctl_zs[Table::Cpu as usize],
-        ),
-        add_virtual_stark_proof(
-            builder,
-            &all_stark.keccak_stark,
-            config,
-            degree_bits[Table::Keccak as usize],
-            nums_ctl_zs[Table::Keccak as usize],
-        ),
-        add_virtual_stark_proof(
-            builder,
-            &all_stark.keccak_sponge_stark,
-            config,
-            degree_bits[Table::KeccakSponge as usize],
-            nums_ctl_zs[Table::KeccakSponge as usize],
-        ),
-        add_virtual_stark_proof(
-            builder,
-            &all_stark.logic_stark,
-            config,
-            degree_bits[Table::Logic as usize],
-            nums_ctl_zs[Table::Logic as usize],
-        ),
-        add_virtual_stark_proof(
-            builder,
-            &all_stark.memory_stark,
-            config,
-            degree_bits[Table::Memory as usize],
-            nums_ctl_zs[Table::Memory as usize],
-        ),
-    ];
-
-    let public_values = add_virtual_public_values(builder);
-    AllProofTarget {
-        stark_proofs,
-        public_values,
-    }
-}
-
-/// Returns `RecursiveAllProofTargetWithData` where the proofs targets are virtual and the
-/// verifier data targets are constants.
-pub fn add_virtual_recursive_all_proof<F: RichField + Extendable<D>, H, C, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    verifier_data: &[VerifierCircuitData<F, C, D>; NUM_TABLES],
-) -> RecursiveAllProofTargetWithData<D>
-where
-    H: Hasher<F, Hash = HashOut<F>>,
-    C: GenericConfig<D, F = F, Hasher = H>,
-{
-    let recursive_proofs = std::array::from_fn(|i| {
-        let verifier_data = &verifier_data[i];
-        builder.add_virtual_proof_with_pis::<C>(&verifier_data.common)
-    });
-    let verifier_data = std::array::from_fn(|i| {
-        let verifier_data = &verifier_data[i];
-        VerifierCircuitTarget {
-            constants_sigmas_cap: builder
-                .constant_merkle_cap(&verifier_data.verifier_only.constants_sigmas_cap),
-            circuit_digest: builder.constant_hash(verifier_data.verifier_only.circuit_digest),
-        }
-    });
-    RecursiveAllProofTargetWithData {
-        recursive_proofs,
-        verifier_data,
-    }
-}
-
-pub fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
+#[allow(unused)] // TODO: used later?
+pub(crate) fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> PublicValuesTarget {
     let trie_roots_before = add_virtual_trie_roots(builder);
@@ -727,7 +476,7 @@ pub fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
     }
 }
 
-pub fn add_virtual_trie_roots<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn add_virtual_trie_roots<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> TrieRootsTarget {
     let state_root = builder.add_virtual_target_arr();
@@ -740,7 +489,7 @@ pub fn add_virtual_trie_roots<F: RichField + Extendable<D>, const D: usize>(
     }
 }
 
-pub fn add_virtual_block_metadata<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn add_virtual_block_metadata<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> BlockMetadataTarget {
     let block_beneficiary = builder.add_virtual_target_arr();
@@ -761,7 +510,11 @@ pub fn add_virtual_block_metadata<F: RichField + Extendable<D>, const D: usize>(
     }
 }
 
-pub fn add_virtual_stark_proof<F: RichField + Extendable<D>, S: Stark<F, D>, const D: usize>(
+pub(crate) fn add_virtual_stark_proof<
+    F: RichField + Extendable<D>,
+    S: Stark<F, D>,
+    const D: usize,
+>(
     builder: &mut CircuitBuilder<F, D>,
     stark: &S,
     config: &StarkConfig,
@@ -808,47 +561,7 @@ fn add_virtual_stark_opening_set<F: RichField + Extendable<D>, S: Stark<F, D>, c
     }
 }
 
-pub fn set_recursive_all_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
-    witness: &mut W,
-    recursive_all_proof_target: &RecursiveAllProofTargetWithData<D>,
-    all_proof: &RecursiveAllProof<F, C, D>,
-) where
-    F: RichField + Extendable<D>,
-    C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
-{
-    for i in 0..NUM_TABLES {
-        witness.set_proof_with_pis_target(
-            &recursive_all_proof_target.recursive_proofs[i],
-            &all_proof.recursive_proofs[i],
-        );
-    }
-}
-pub fn set_all_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
-    witness: &mut W,
-    all_proof_target: &AllProofTarget<D>,
-    all_proof: &AllProof<F, C, D>,
-    zero: Target,
-) where
-    F: RichField + Extendable<D>,
-    C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
-{
-    for (pt, p) in all_proof_target
-        .stark_proofs
-        .iter()
-        .zip_eq(&all_proof.stark_proofs)
-    {
-        set_stark_proof_target(witness, pt, &p.proof, zero);
-    }
-    set_public_value_targets(
-        witness,
-        &all_proof_target.public_values,
-        &all_proof.public_values,
-    )
-}
-
-pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
+pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
     witness: &mut W,
     proof_target: &StarkProofTarget<D>,
     proof: &StarkProof<F, C, D>,
@@ -874,7 +587,8 @@ pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
-pub fn set_public_value_targets<F, W, const D: usize>(
+#[allow(unused)] // TODO: used later?
+pub(crate) fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,
     public_values: &PublicValues,
@@ -899,7 +613,7 @@ pub fn set_public_value_targets<F, W, const D: usize>(
     );
 }
 
-pub fn set_trie_roots_target<F, W, const D: usize>(
+pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
     witness: &mut W,
     trie_roots_target: &TrieRootsTarget,
     trie_roots: &TrieRoots,
@@ -921,7 +635,7 @@ pub fn set_trie_roots_target<F, W, const D: usize>(
     );
 }
 
-pub fn set_block_metadata_target<F, W, const D: usize>(
+pub(crate) fn set_block_metadata_target<F, W, const D: usize>(
     witness: &mut W,
     block_metadata_target: &BlockMetadataTarget,
     block_metadata: &BlockMetadata,
@@ -957,221 +671,4 @@ pub fn set_block_metadata_target<F, W, const D: usize>(
         block_metadata_target.block_base_fee,
         F::from_canonical_u64(block_metadata.block_base_fee.as_u64()),
     );
-}
-
-#[cfg(test)]
-pub(crate) mod tests {
-    use anyhow::Result;
-    use plonky2::field::extension::Extendable;
-    use plonky2::hash::hash_types::RichField;
-    use plonky2::hash::hashing::SPONGE_WIDTH;
-    use plonky2::iop::challenger::RecursiveChallenger;
-    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
-    use plonky2::plonk::circuit_builder::CircuitBuilder;
-    use plonky2::plonk::circuit_data::{CircuitConfig, VerifierCircuitData};
-    use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
-    use plonky2::plonk::proof::ProofWithPublicInputs;
-
-    use crate::all_stark::{AllStark, Table};
-    use crate::config::StarkConfig;
-    use crate::cpu::cpu_stark::CpuStark;
-    use crate::cross_table_lookup::{CrossTableLookup, CtlCheckVarsTarget};
-    use crate::keccak::keccak_stark::KeccakStark;
-    use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
-    use crate::logic::LogicStark;
-    use crate::memory::memory_stark::MemoryStark;
-    use crate::permutation::{GrandProductChallenge, GrandProductChallengeSet};
-    use crate::proof::{AllChallengerState, AllProof, StarkProof};
-    use crate::recursive_verifier::{
-        add_virtual_stark_proof, set_stark_proof_target,
-        verify_stark_proof_with_challenges_circuit, RecursiveAllProof,
-    };
-    use crate::stark::Stark;
-
-    /// Recursively verify a Stark proof.
-    /// Outputs the recursive proof and the associated verifier data.
-    #[allow(unused)] // TODO: used later?
-    fn recursively_verify_stark_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        S: Stark<F, D>,
-        const D: usize,
-    >(
-        table: Table,
-        stark: S,
-        proof: &StarkProof<F, C, D>,
-        cross_table_lookups: &[CrossTableLookup<F>],
-        ctl_challenges: &GrandProductChallengeSet<F>,
-        challenger_state_before_vals: [F; SPONGE_WIDTH],
-        inner_config: &StarkConfig,
-        circuit_config: &CircuitConfig,
-    ) -> Result<(ProofWithPublicInputs<F, C, D>, VerifierCircuitData<F, C, D>)>
-    where
-        [(); S::COLUMNS]:,
-        [(); C::Hasher::HASH_SIZE]:,
-        C::Hasher: AlgebraicHasher<F>,
-    {
-        let mut builder = CircuitBuilder::<F, D>::new(circuit_config.clone());
-        let mut pw = PartialWitness::new();
-
-        let num_permutation_zs = stark.num_permutation_batches(inner_config);
-        let num_permutation_batch_size = stark.permutation_batch_size();
-        let proof_target = add_virtual_stark_proof(
-            &mut builder,
-            &stark,
-            inner_config,
-            proof.recover_degree_bits(inner_config),
-            proof.num_ctl_zs(),
-        );
-        set_stark_proof_target(&mut pw, &proof_target, proof, builder.zero());
-        builder.register_public_inputs(
-            &proof_target
-                .trace_cap
-                .0
-                .iter()
-                .flat_map(|h| h.elements)
-                .collect::<Vec<_>>(),
-        );
-
-        let ctl_challenges_target = GrandProductChallengeSet {
-            challenges: (0..inner_config.num_challenges)
-                .map(|_| GrandProductChallenge {
-                    beta: builder.add_virtual_public_input(),
-                    gamma: builder.add_virtual_public_input(),
-                })
-                .collect(),
-        };
-        for i in 0..inner_config.num_challenges {
-            pw.set_target(
-                ctl_challenges_target.challenges[i].beta,
-                ctl_challenges.challenges[i].beta,
-            );
-            pw.set_target(
-                ctl_challenges_target.challenges[i].gamma,
-                ctl_challenges.challenges[i].gamma,
-            );
-        }
-
-        let ctl_vars = CtlCheckVarsTarget::from_proof(
-            table,
-            &proof_target,
-            cross_table_lookups,
-            &ctl_challenges_target,
-            num_permutation_zs,
-        );
-
-        let challenger_state_before = std::array::from_fn(|_| builder.add_virtual_public_input());
-        pw.set_target_arr(challenger_state_before, challenger_state_before_vals);
-        let mut challenger =
-            RecursiveChallenger::<F, C::Hasher, D>::from_state(challenger_state_before);
-        let challenges = proof_target.get_challenges::<F, C>(
-            &mut builder,
-            &mut challenger,
-            num_permutation_zs > 0,
-            num_permutation_batch_size,
-            inner_config,
-        );
-        let challenger_state_after = challenger.compact(&mut builder);
-        builder.register_public_inputs(&challenger_state_after);
-
-        builder.register_public_inputs(&proof_target.openings.ctl_zs_last);
-
-        verify_stark_proof_with_challenges_circuit::<F, C, _, D>(
-            &mut builder,
-            &stark,
-            &proof_target,
-            &challenges,
-            &ctl_vars,
-            inner_config,
-        );
-
-        let data = builder.build::<C>();
-        Ok((data.prove(pw)?, data.verifier_data()))
-    }
-
-    /// Recursively verify every Stark proof in an `AllProof`.
-    #[allow(unused)] // TODO: used later?
-    pub fn recursively_verify_all_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
-        all_stark: &AllStark<F, D>,
-        all_proof: &AllProof<F, C, D>,
-        inner_config: &StarkConfig,
-        circuit_config: &CircuitConfig,
-    ) -> Result<RecursiveAllProof<F, C, D>>
-    where
-        [(); CpuStark::<F, D>::COLUMNS]:,
-        [(); KeccakStark::<F, D>::COLUMNS]:,
-        [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
-        [(); LogicStark::<F, D>::COLUMNS]:,
-        [(); MemoryStark::<F, D>::COLUMNS]:,
-        [(); C::Hasher::HASH_SIZE]:,
-        C::Hasher: AlgebraicHasher<F>,
-    {
-        let AllChallengerState {
-            states,
-            ctl_challenges,
-        } = all_proof.get_challenger_states(all_stark, inner_config);
-        Ok(RecursiveAllProof {
-            recursive_proofs: [
-                recursively_verify_stark_proof(
-                    Table::Cpu,
-                    all_stark.cpu_stark,
-                    &all_proof.stark_proofs[Table::Cpu as usize].proof,
-                    &all_stark.cross_table_lookups,
-                    &ctl_challenges,
-                    states[0],
-                    inner_config,
-                    circuit_config,
-                )?
-                .0,
-                recursively_verify_stark_proof(
-                    Table::Keccak,
-                    all_stark.keccak_stark,
-                    &all_proof.stark_proofs[Table::Keccak as usize].proof,
-                    &all_stark.cross_table_lookups,
-                    &ctl_challenges,
-                    states[1],
-                    inner_config,
-                    circuit_config,
-                )?
-                .0,
-                recursively_verify_stark_proof(
-                    Table::KeccakSponge,
-                    all_stark.keccak_sponge_stark,
-                    &all_proof.stark_proofs[Table::KeccakSponge as usize].proof,
-                    &all_stark.cross_table_lookups,
-                    &ctl_challenges,
-                    states[2],
-                    inner_config,
-                    circuit_config,
-                )?
-                .0,
-                recursively_verify_stark_proof(
-                    Table::Logic,
-                    all_stark.logic_stark,
-                    &all_proof.stark_proofs[Table::Logic as usize].proof,
-                    &all_stark.cross_table_lookups,
-                    &ctl_challenges,
-                    states[3],
-                    inner_config,
-                    circuit_config,
-                )?
-                .0,
-                recursively_verify_stark_proof(
-                    Table::Memory,
-                    all_stark.memory_stark,
-                    &all_proof.stark_proofs[Table::Memory as usize].proof,
-                    &all_stark.cross_table_lookups,
-                    &ctl_challenges,
-                    states[4],
-                    inner_config,
-                    circuit_config,
-                )?
-                .0,
-            ],
-        })
-    }
 }


### PR DESCRIPTION
Some logic was replaced by the constant-degree logic in `fixed_recursive_verifier`.