### PR TITLE
Add aggregation circuit

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -335,8 +335,8 @@ where
         self.root.circuit.prove(root_inputs)
     }
 
-    pub fn verify_root(&self, agg_proof: &ProofWithPublicInputs<F, C, D>) -> anyhow::Result<()> {
-        self.root.circuit.verify(agg_proof.clone())
+    pub fn verify_root(&self, agg_proof: ProofWithPublicInputs<F, C, D>) -> anyhow::Result<()> {
+        self.root.circuit.verify(agg_proof)
     }
 
     pub fn prove_aggregation(
@@ -360,6 +360,7 @@ where
             &self.aggregation.cyclic_vk,
             &self.aggregation.circuit.verifier_only,
         );
+
         self.aggregation.circuit.prove(agg_inputs)
     }
 

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -327,8 +327,10 @@ where
             root_inputs.set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
         }
 
-        root_inputs
-            .set_verifier_data_target(&self.root.cyclic_vk, &self.root.circuit.verifier_only);
+        root_inputs.set_verifier_data_target(
+            &self.root.cyclic_vk,
+            &self.aggregation.circuit.verifier_only,
+        );
 
         self.root.circuit.prove(root_inputs)
     }

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -86,7 +86,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(&all_stark, 9..19, &config);
     let root_proof = all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
-    all_circuits.verify_root(&root_proof)?;
+    all_circuits.verify_root(root_proof.clone())?;
 
     let agg_proof = all_circuits.prove_aggregation(false, &root_proof, false, &root_proof)?;
     all_circuits.verify_aggregation(&agg_proof)

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -86,7 +86,10 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(&all_stark, 9..19, &config);
     let root_proof = all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
-    all_circuits.root.circuit.verify(root_proof)
+    all_circuits.verify_root(&root_proof)?;
+
+    let agg_proof = all_circuits.prove_aggregation(false, &root_proof, false, &root_proof)?;
+    all_circuits.verify_aggregation(&agg_proof)
 }
 
 fn init_logger() {


### PR DESCRIPTION
Which can be used to compress two proofs into one. Each inner proof can be either
- an "EVM root" proof (which typically proves one transaction, though it could be 0 or more)
- another aggregation proof