### PR TITLE
ECC ASM functions renaming

### DIFF
--- a/evm/src/cpu/kernel/asm/curve/bn254/curve_add.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/curve_add.asm
@@ -2,7 +2,7 @@
 
 // BN254 elliptic curve addition.
 // Uses the standard affine addition formula.
-global ec_add:
+global bn_add:
     // Uncomment for test inputs.
     // PUSH 0xdeadbeef
     // PUSH 2
@@ -16,27 +16,27 @@ global ec_add:
     // stack: y0, x0, y0, x1, y1, retdest
     DUP2
     // stack: x0, y0, x0, y0, x1, y1, retdest
-    %ec_check
+    %bn_check
     // stack: isValid(x0, y0), x0, y0, x1, y1, retdest
     DUP5
     // stack: x1, isValid(x0, y0), x0, y0, x1, y1, retdest
     DUP5
     // stack: x1, y1, isValid(x0, y0), x0, y0, x1, y1, retdest
-    %ec_check
+    %bn_check
     // stack: isValid(x1, y1), isValid(x0, y0), x0, y0, x1, y1, retdest
     AND
     // stack: isValid(x1, y1) & isValid(x0, y0), x0, y0, x1, y1, retdest
-    %jumpi(ec_add_valid_points)
+    %jumpi(bn_add_valid_points)
     // stack: x0, y0, x1, y1, retdest
 
     // Otherwise return
     %pop4
     // stack: retdest
-    %ec_invalid_input
+    %bn_invalid_input
 
 // BN254 elliptic curve addition.
 // Assumption: (x0,y0) and (x1,y1) are valid points.
-global ec_add_valid_points:
+global bn_add_valid_points:
     // stack: x0, y0, x1, y1, retdest
 
     // Check if the first point is the identity.
@@ -46,7 +46,7 @@ global ec_add_valid_points:
     // stack: x0, y0, x0, y0, x1, y1, retdest
     %ec_isidentity
     // stack: (x0,y0)==(0,0), x0, y0, x1, y1, retdest
-    %jumpi(ec_add_first_zero)
+    %jumpi(bn_add_first_zero)
     // stack: x0, y0, x1, y1, retdest
 
     // Check if the second point is the identity.
@@ -56,7 +56,7 @@ global ec_add_valid_points:
     // stack: x1, y1, x0, y0, x1, y1, retdest
     %ec_isidentity
     // stack: (x1,y1)==(0,0), x0, y0, x1, y1, retdest
-    %jumpi(ec_add_snd_zero)
+    %jumpi(bn_add_snd_zero)
     // stack: x0, y0, x1, y1, retdest
 
     // Check if both points have the same x-coordinate.
@@ -66,7 +66,7 @@ global ec_add_valid_points:
     // stack: x0, x1, x0, y0, x1, y1, retdest
     EQ
     // stack: x0 == x1, x0, y0, x1, y1, retdest
-    %jumpi(ec_add_equal_first_coord)
+    %jumpi(bn_add_equal_first_coord)
     // stack: x0, y0, x1, y1, retdest
 
     // Otherwise, we can use the standard formula.
@@ -85,11 +85,11 @@ global ec_add_valid_points:
     // stack: x0 - x1, y0 - y1, x0, y0, x1, y1, retdest
     %moddiv
     // stack: lambda, x0, y0, x1, y1, retdest
-    %jump(ec_add_valid_points_with_lambda)
+    %jump(bn_add_valid_points_with_lambda)
 
 // BN254 elliptic curve addition.
 // Assumption: (x0,y0) == (0,0)
-ec_add_first_zero:
+bn_add_first_zero:
     // stack: x0, y0, x1, y1, retdest
     // Just return (x1,y1)
     %stack (x0, y0, x1, y1, retdest) -> (retdest, x1, y1)
@@ -97,7 +97,7 @@ ec_add_first_zero:
 
 // BN254 elliptic curve addition.
 // Assumption: (x1,y1) == (0,0)
-ec_add_snd_zero:
+bn_add_snd_zero:
     // stack: x0, y0, x1, y1, retdest
 
     // Just return (x0,y0)
@@ -106,7 +106,7 @@ ec_add_snd_zero:
 
 // BN254 elliptic curve addition.
 // Assumption: lambda = (y0 - y1)/(x0 - x1)
-ec_add_valid_points_with_lambda:
+bn_add_valid_points_with_lambda:
     // stack: lambda, x0, y0, x1, y1, retdest
 
     // Compute x2 = lambda^2 - x1 - x0
@@ -153,7 +153,7 @@ ec_add_valid_points_with_lambda:
 
 // BN254 elliptic curve addition.
 // Assumption: (x0,y0) and (x1,y1) are valid points and x0 == x1
-ec_add_equal_first_coord:
+bn_add_equal_first_coord:
     // stack: x0, y0, x1, y1, retdest with x0 == x1
 
     // Check if the points are equal
@@ -163,7 +163,7 @@ ec_add_equal_first_coord:
     // stack: y1, y0, x0, y0, x1, y1, retdest
     EQ
     // stack: y1 == y0, x0, y0, x1, y1, retdest
-    %jumpi(ec_add_equal_points)
+    %jumpi(bn_add_equal_points)
     // stack: x0, y0, x1, y1, retdest
 
     // Otherwise, one is the negation of the other so we can return (0,0).
@@ -181,7 +181,7 @@ ec_add_equal_first_coord:
 // BN254 elliptic curve addition.
 // Assumption: x0 == x1 and y0 == y1
 // Standard doubling formula.
-ec_add_equal_points:
+bn_add_equal_points:
     // stack: x0, y0, x1, y1, retdest
 
     // Compute lambda = 3/2 * x0^2 / y0
@@ -203,19 +203,19 @@ ec_add_equal_points:
     // stack: y0, 3/2 * x0^2, x0, y0, x1, y1, retdest
     %moddiv
     // stack: lambda, x0, y0, x1, y1, retdest
-    %jump(ec_add_valid_points_with_lambda)
+    %jump(bn_add_valid_points_with_lambda)
 
 // BN254 elliptic curve doubling.
 // Assumption: (x0,y0) is a valid point.
 // Standard doubling formula.
-global ec_double:
+global bn_double:
     // stack: x, y, retdest
     DUP2 DUP2 %ec_isidentity
     // stack: (x,y)==(0,0), x, y, retdest
     %jumpi(ec_double_retself)
     DUP2 DUP2
     // stack: x, y, x, y, retdest
-    %jump(ec_add_equal_points)
+    %jump(bn_add_equal_points)
 
 // Push the order of the BN254 base field.
 %macro bn_base
@@ -242,7 +242,7 @@ global ec_double:
 
 // Check if (x,y) is a valid curve point.
 // Puts y^2 % N == (x^3 + 3) % N & (x < N) & (y < N) || (x,y)==(0,0) on top of the stack.
-%macro ec_check
+%macro bn_check
     // stack: x, y
     %bn_base
     // stack: N, x, y
@@ -292,17 +292,8 @@ global ec_double:
     // stack: y^2 % N == (x^3 + 3) % N & (x < N) & (y < N) || (x,y)==(0,0)
 %endmacro
 
-// Check if (x,y)==(0,0)
-%macro ec_isidentity
-    // stack: x, y
-    OR
-    // stack: x | y
-    ISZERO
-    // stack: (x,y) == (0,0)
-%endmacro
-
 // Return (u256::MAX, u256::MAX) which is used to indicate the input was invalid.
-%macro ec_invalid_input
+%macro bn_invalid_input
     // stack: retdest
     PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     // stack: u256::MAX, retdest

--- a/evm/src/cpu/kernel/asm/curve/bn254/curve_mul.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/curve_mul.asm
@@ -1,6 +1,6 @@
 // BN254 elliptic curve scalar multiplication.
 // Recursive implementation, same algorithm as in `exp.asm`.
-global ec_mul:
+global bn_mul:
     // stack: x, y, s, retdest
     DUP2
     // stack: y, x, y, s, retdest
@@ -14,29 +14,29 @@ global ec_mul:
     // stack: y, x, y, s, retdest
     DUP2
     // stack: x, y, x, y, s, retdest
-    %ec_check
+    %bn_check
     // stack: isValid(x, y), x, y, s, retdest
-    %jumpi(ec_mul_valid_point)
+    %jumpi(bn_mul_valid_point)
     // stack: x, y, s, retdest
     %pop3
-    %ec_invalid_input
+    %bn_invalid_input
 
 // Same algorithm as in `exp.asm`
-ec_mul_valid_point:
-    %stack (x, y, s, retdest) -> (s, ec_mul_after_glv, x, y, bn_msm, ec_mul_end, retdest)
+bn_mul_valid_point:
+    %stack (x, y, s, retdest) -> (s, bn_mul_after_glv, x, y, bn_msm, bn_mul_end, retdest)
     %jump(bn_glv_decompose)
-global ec_mul_after_glv:
-    // stack: bneg, a, b, x, y, bn_msm, ec_mul_after_glv_precompute_and_msm, retdest
+global bn_mul_after_glv:
+    // stack: bneg, a, b, x, y, bn_msm, bn_mul_after_glv_precompute_and_msm, retdest
     // Store bneg at this (otherwise unused) location. Will be used later in the MSM.
     %mstore_kernel(@SEGMENT_KERNEL_BN_TABLE_Q, 1337)
-    // stack: a, b, x, y, bn_msm, ec_mul_after_glv_precompute_and_msm, retdest
-    PUSH ec_mul_after_a SWAP1 PUSH @SEGMENT_KERNEL_BN_WNAF_A PUSH @BN_SCALAR %jump(wnaf)
-global ec_mul_after_a:
-    // stack: b, x, y, bn_msm, ec_mul_after_glv_precompute_and_msm, retdest
-    PUSH ec_mul_after_b SWAP1 PUSH @SEGMENT_KERNEL_BN_WNAF_B PUSH @BN_SCALAR %jump(wnaf)
-global ec_mul_after_b:
-    // stack: x, y, bn_msm, ec_mul_end, retdest
+    // stack: a, b, x, y, bn_msm, bn_mul_after_glv_precompute_and_msm, retdest
+    PUSH bn_mul_after_a SWAP1 PUSH @SEGMENT_KERNEL_BN_WNAF_A PUSH @BN_SCALAR %jump(wnaf)
+global bn_mul_after_a:
+    // stack: b, x, y, bn_msm, bn_mul_after_glv_precompute_and_msm, retdest
+    PUSH bn_mul_after_b SWAP1 PUSH @SEGMENT_KERNEL_BN_WNAF_B PUSH @BN_SCALAR %jump(wnaf)
+global bn_mul_after_b:
+    // stack: x, y, bn_msm, bn_mul_end, retdest
     %jump(bn_precompute_table)
-global ec_mul_end:
+global bn_mul_end:
     %stack (Ax, Ay, retdest) -> (retdest, Ax, Ay)
     JUMP

--- a/evm/src/cpu/kernel/asm/curve/bn254/msm.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/msm.asm
@@ -23,7 +23,7 @@ msm_loop_contd:
     %increment
     //stack: i+1, accx, accy, retdest
     %stack (i, accx, accy, retdest) -> (accx, accy, bn_msm_loop, i, retdest)
-    %jump(ec_double)
+    %jump(bn_double)
 
 msm_end:
     %stack (i, accx, accy, retdest) -> (retdest, accx, accy)
@@ -33,13 +33,13 @@ bn_msm_loop_add_a_nonzero:
     %stack (w, accx, accy, i, retdest) -> (w, accx, accy, msm_loop_add_b, i, retdest)
     %bn_mload_point_a
     // stack: px, py, accx, accy, msm_loop_add_b, i, retdest
-    %jump(ec_add_valid_points)
+    %jump(bn_add_valid_points)
 
 bn_msm_loop_add_b_nonzero:
     %stack (w, accx, accy, i, retdest) -> (w, accx, accy, msm_loop_contd, i, retdest)
     %bn_mload_point_b
     // stack: px, py, accx, accy, msm_loop_contd, i, retdest
-    %jump(ec_add_valid_points)
+    %jump(bn_add_valid_points)
 
 %macro bn_mload_wnaf_a
     // stack: i

--- a/evm/src/cpu/kernel/asm/curve/bn254/precomputation.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/precomputation.asm
@@ -4,7 +4,7 @@
 global bn_precompute_table:
     // stack: Qx, Qy, retdest
     PUSH precompute_table_contd DUP3 DUP3
-    %jump(ec_double)
+    %jump(bn_double)
 precompute_table_contd:
     // stack: Qx2, Qy2, Qx, Qy, retdest
     PUSH 1
@@ -25,7 +25,7 @@ global bn_precompute_table_loop:
     // stack: i+2, Qx2, Qy2, Qx, Qy, retdest
     DUP1 PUSH 16 LT %jumpi(precompute_table_end)
     %stack (i, Qx2, Qy2, Qx, Qy, retdest) -> (Qx, Qy, Qx2, Qy2, precompute_table_loop_contd, i, Qx2, Qy2, retdest)
-    %jump(ec_add_valid_points)
+    %jump(bn_add_valid_points)
 precompute_table_loop_contd:
     %stack (Qx, Qy, i, Qx2, Qy2, retdest) -> (i, Qx2, Qy2, Qx, Qy, retdest)
     %jump(bn_precompute_table_loop)

--- a/evm/src/cpu/kernel/asm/curve/common.asm
+++ b/evm/src/cpu/kernel/asm/curve/common.asm
@@ -13,3 +13,13 @@ global ret_zero_ec_mul:
 global ec_double_retself:
     %stack (x, y, retdest) -> (retdest, x, y)
     JUMP
+
+// Check if (x,y)==(0,0)
+%macro ec_isidentity
+    // stack: x, y
+    OR
+    // stack: x | y
+    ISZERO
+    // stack: (x,y) == (0,0)
+%endmacro
+

--- a/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
+++ b/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
@@ -91,11 +91,11 @@ ecdsa_after_precompute_loop:
     SWAP1 %mul_const(2)
     %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     %stack (Px, Py, i, accx, accy, a0, a1, b0, b1, retdest) -> (Px, Py, accx, accy, ecdsa_after_precompute_loop_contd, i, a0, a1, b0, b1, retdest)
-    %jump(ec_add_valid_points_secp)
+    %jump(secp_add_valid_points)
 ecdsa_after_precompute_loop_contd:
     %stack (accx, accy, i, a0, a1, b0, b1, retdest) -> (i, accx, accy, ecdsa_after_precompute_loop_contd2, i, a0, a1, b0, b1, retdest)
     ISZERO %jumpi(ecdsa_after_precompute_loop_end)
-    %jump(ec_double_secp)
+    %jump(secp_double)
 ecdsa_after_precompute_loop_contd2:
     %stack (accx, accy, i, a0, a1, b0, b1, retdest) -> (i, accx, accy, a0, a1, b0, b1, retdest)
     %decrement %jump(ecdsa_after_precompute_loop)

--- a/evm/src/cpu/kernel/asm/curve/secp256k1/precomputation.asm
+++ b/evm/src/cpu/kernel/asm/curve/secp256k1/precomputation.asm
@@ -30,7 +30,7 @@ global precompute_table:
     DUP5 PUSH @SECP_BASE SUB MUL ADD
     %stack (selectQy, betaQx, Qx, Qy, retdest) -> (2, betaQx, 3, selectQy, betaQx, selectQy, Qx, Qy, precompute_table_contd, retdest)
     %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE) %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
-    %jump(ec_add_valid_points_no_edge_case_secp)
+    %jump(secp_add_valid_points_no_edge_case)
 precompute_table_contd:
     %stack (x, y, retdest) -> (6, x, 7, y, retdest)
     %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE) %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
@@ -46,7 +46,7 @@ precompute_table_loop:
     PUSH 9 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     PUSH 8 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     // stack: Gx, Gy, x, y, precompute_table_loop_contd, x, y, i, retdest
-    %jump(ec_add_valid_points_secp)
+    %jump(secp_add_valid_points)
 precompute_table_loop_contd:
     %stack (Rx, Ry, x, y, i, retdest) -> (i, 8, Rx, i, 9, Ry, x, y, i, retdest)
     ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE) ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
@@ -54,14 +54,14 @@ precompute_table_loop_contd:
     PUSH 17 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     PUSH 16 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     %stack (Gx, Gy, x, y, x, y, i, retdest) -> (Gx, Gy, x, y, precompute_table_loop_contd2, x, y, i, retdest)
-    %jump(ec_add_valid_points_secp)
+    %jump(secp_add_valid_points)
 precompute_table_loop_contd2:
     %stack (Rx, Ry, x, y, i, retdest) -> (i, 16, Rx, i, 17, Ry, x, y, i, retdest)
     ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE) ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     PUSH 25 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     PUSH 24 %mload_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)
     %stack (Gx, Gy, x, y, i, retdest) -> (Gx, Gy, x, y, precompute_table_loop_contd3, i, retdest)
-    %jump(ec_add_valid_points_secp)
+    %jump(secp_add_valid_points)
 precompute_table_loop_contd3:
     %stack (Rx, Ry, i, retdest) -> (i, 24, Rx, i, 25, Ry, i, retdest)
     ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE) ADD %mstore_kernel(@SEGMENT_KERNEL_ECDSA_TABLE)

--- a/evm/src/cpu/kernel/tests/ecc/curve_ops.rs
+++ b/evm/src/cpu/kernel/tests/ecc/curve_ops.rs
@@ -11,9 +11,9 @@ mod bn {
     #[test]
     fn test_ec_ops() -> Result<()> {
         // Make sure we can parse and assemble the entire kernel.
-        let ec_add = KERNEL.global_labels["ec_add"];
-        let ec_double = KERNEL.global_labels["ec_double"];
-        let ec_mul = KERNEL.global_labels["ec_mul"];
+        let ec_add = KERNEL.global_labels["bn_add"];
+        let ec_double = KERNEL.global_labels["bn_double"];
+        let ec_mul = KERNEL.global_labels["bn_mul"];
         let identity = ("0x0", "0x0");
         let invalid = ("0x0", "0x3"); // Not on curve
         let point0 = (
@@ -236,8 +236,8 @@ mod secp {
     fn test_ec_ops() -> Result<()> {
         // Make sure we can parse and assemble the entire kernel.
         let kernel = combined_kernel();
-        let ec_add = kernel.global_labels["ec_add_valid_points_secp"];
-        let ec_double = kernel.global_labels["ec_double_secp"];
+        let ec_add = kernel.global_labels["secp_add_valid_points"];
+        let ec_double = kernel.global_labels["secp_double"];
         let identity = ("0x0", "0x0");
         let point0 = (
             "0xc82ccceebd739e646631b7270ed8c33e96c4940b19db91eaf67da6ec92d109b",


### PR DESCRIPTION
No functional changes, just using a more consistent naming schemes for elliptic curve ASM functions. 