### PR TITLE
Make le_sum public

### DIFF
--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -33,7 +33,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     /// Takes an iterator of bits `(b_i)` and returns `sum b_i * 2^i`, i.e.,
     /// the number with little-endian bit representation given by `bits`.
-    pub(crate) fn le_sum(&mut self, bits: impl Iterator<Item = impl Borrow<BoolTarget>>) -> Target {
+    pub fn le_sum(&mut self, bits: impl Iterator<Item = impl Borrow<BoolTarget>>) -> Target {
         let bits = bits.map(|b| *b.borrow()).collect_vec();
         let num_bits = bits.len();
         assert!(


### PR DESCRIPTION
Methods like split_le are public. le_sum is the inverse map so useful to have it pub as well (at the very least, we’d like to access it).