### PR TITLE
Fix plonky2 compilation with wasm32-unknown-unknown target

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -34,6 +34,9 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 static_assertions = { version = "1.1.0", default-features = false }
 unroll = { version = "0.1.5", default-features = false }
 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", default-features = false, features = ["js"] }
+
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false }
 env_logger = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
Compiling plonky2 for `wasm32-unknown-unknown` currently fails.

Steps to reproduce:

- `rustup update nightly`
- `rustup target add wasm32-unknown-unknown --toolchain nightly`
- `cargo +nightly build --no-default-features --target wasm32-unknown-unknown --manifest-path plonky2/Cargo.toml`

(Note that the whole workspace cannot be compiled to `wasm32-unknown-unknown` because of the hardcoded jemalloc specification in `evm` crate).

The issue is a common one arising when dealing with `rand_core` related crates. Specifying the `getrandom` dependency with the feature "js" enabled when compiling to wasm does the trick.