### PR TITLE
Bump eth_trie_utils version

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 anyhow = "1.0.40"
 blake2 = "0.10.5"
 env_logger = "0.10.0"
-eth_trie_utils = "0.4.0"
+eth_trie_utils = "0.4.1"
 ethereum-types = "0.14.0"
 hex = { version = "0.4.3", optional = true }
 hex-literal = "0.3.4"


### PR DESCRIPTION
Bump `eth_trie_utils` version to provide `Nibbles::from_h256_be()`.