### PR TITLE
Fix copy opcodes when offset is large

### DIFF
--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -183,6 +183,7 @@ extcodecopy_end:
     JUMP
 
 extcodecopy_large_offset:
+    // offset is larger than the code size. So we just have to write zeros.
     // stack: code_size, size, offset, dest_offset, retdest
     GET_CONTEXT
     %stack (context, code_size, size, offset, dest_offset, retdest) -> (context, @SEGMENT_MAIN_MEMORY, dest_offset, 0, size, retdest)

--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -132,6 +132,10 @@ global extcodecopy:
 
 extcodecopy_contd:
     // stack: code_size, size, offset, dest_offset, retdest
+    DUP1 DUP4
+    // stack: offset, code_size, code_size, size, offset, dest_offset, retdest
+    GT %jumpi(extcodecopy_large_offset)
+    // stack: code_size, size, offset, dest_offset, retdest
     SWAP1
     // stack: size, code_size, offset, dest_offset, retdest
     PUSH 0
@@ -178,6 +182,11 @@ extcodecopy_end:
     %stack (i, size, code_size, offset, dest_offset, retdest) -> (retdest)
     JUMP
 
+extcodecopy_large_offset:
+    // stack: code_size, size, offset, dest_offset, retdest
+    GET_CONTEXT
+    %stack (context, code_size, size, offset, dest_offset, retdest) -> (context, @SEGMENT_MAIN_MEMORY, dest_offset, 0, size, retdest)
+    %jump(memset)
 
 // Loads the code at `address` into memory, at the given context and segment, starting at offset 0.
 // Checks that the hash of the loaded code corresponds to the `codehash` in the state trie.

--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -47,24 +47,3 @@ memcpy_finish:
     %pop7
     // stack: retdest
     JUMP
-
-// Copies zeros to `[addr..addr+count]` in the given context and segment.
-global zerocpy:
-    // stack: context, segment, addr, count, retdest
-    %stack (context, segment, addr, count, retdest) -> (0, count, context, segment, addr, retdest)
-zerocpy_loop:
-    // stack: i, count, context, segment, addr, retdest
-    DUP2 DUP2 EQ %jumpi(zerocpy_finish)
-    %stack (i, count, context, segment, addr, retdest) -> (context, segment, addr, 0, addr, i, count, context, segment, retdest)
-    MSTORE_GENERAL
-    // stack: addr, i, count, context, segment, retdest
-    %increment
-    SWAP1
-    %increment
-    %stack (i, addr, count, context, segment, retdest) -> (i, count, context, segment, addr, retdest)
-    %jump(zerocpy_loop)
-
-zerocpy_finish:
-    // stack: i, count, context, segment, addr, retdest
-    %pop5
-    JUMP

--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -47,3 +47,24 @@ memcpy_finish:
     %pop7
     // stack: retdest
     JUMP
+
+// Copies zeros to `[addr..addr+count]` in the given context and segment.
+global zerocpy:
+    // stack: context, segment, addr, count, retdest
+    %stack (context, segment, addr, count, retdest) -> (0, count, context, segment, addr, retdest)
+zerocpy_loop:
+    // stack: i, count, context, segment, addr, retdest
+    DUP2 DUP2 EQ %jumpi(zerocpy_finish)
+    %stack (i, count, context, segment, addr, retdest) -> (context, segment, addr, 0, addr, i, count, context, segment, retdest)
+    MSTORE_GENERAL
+    // stack: addr, i, count, context, segment, retdest
+    %increment
+    SWAP1
+    %increment
+    %stack (i, addr, count, context, segment, retdest) -> (i, count, context, segment, addr, retdest)
+    %jump(zerocpy_loop)
+
+zerocpy_finish:
+    // stack: i, count, context, segment, addr, retdest
+    %pop5
+    JUMP

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -121,7 +121,7 @@ sys_calldataload_after_mload_packing:
     PANIC
 
 // Macro for {CALLDATA,CODE,RETURNDATA}COPY (W_copy in Yellow Paper).
-%macro wcopy(segment)
+%macro wcopy(segment, context_metadata_size)
     // stack: kexit_info, dest_offset, offset, size
     PUSH @GAS_VERYLOW
     DUP5
@@ -136,25 +136,41 @@ sys_calldataload_after_mload_packing:
     DUP1 %ensure_reasonable_offset
     %update_mem_bytes
 
+    %mload_context_metadata($context_metadata_size)
+    // stack: total_size, kexit_info, dest_offset, offset, size
+    DUP4
+    // stack: offset, total_size, kexit_info, dest_offset, offset, size
+    GT %jumpi(%%wcopy_large_offset)
+
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, $segment, offset, size, %%after, kexit_info)
     %jump(memcpy)
+
 %%after:
     // stack: kexit_info
     EXIT_KERNEL
+
 %%wcopy_empty:
     // stack: Gverylow, kexit_info, dest_offset, offset, size
     %charge_gas
     %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)
     EXIT_KERNEL
+
+%%wcopy_large_offset:
+    // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to copy zeros.
+    // stack: kexit_info, dest_offset, offset, size
+    GET_CONTEXT
+    %stack (context, kexit_info, dest_offset, offset, size) ->
+        (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, %%after, kexit_info)
+    %jump(zerocpy)
 %endmacro
 
 global sys_calldatacopy:
-    %wcopy(@SEGMENT_CALLDATA)
+    %wcopy(@SEGMENT_CALLDATA, @CTX_METADATA_CALLDATA_SIZE)
 
 global sys_codecopy:
-    %wcopy(@SEGMENT_CODE)
+    %wcopy(@SEGMENT_CODE, @CTX_METADATA_CODE_SIZE)
 
 global sys_returndatacopy:
-    %wcopy(@SEGMENT_RETURNDATA)
+    %wcopy(@SEGMENT_RETURNDATA, @CTX_METADATA_RETURNDATA_SIZE)

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -162,8 +162,8 @@ sys_calldataload_after_mload_packing:
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
-        (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, %%after, kexit_info)
-    %jump(zerocpy)
+        (context, @SEGMENT_MAIN_MEMORY, dest_offset, 0, size, %%after, kexit_info)
+    %jump(memset)
 %endmacro
 
 global sys_calldatacopy:

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -158,7 +158,7 @@ sys_calldataload_after_mload_packing:
     EXIT_KERNEL
 
 %%wcopy_large_offset:
-    // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to copy zeros.
+    // offset is larger than the size of the {CALLDATA,CODE,RETURNDATA}. So we just have to write zeros.
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->


### PR DESCRIPTION
The `offset` parameter in the *COPY opcodes can be arbitrarily large, leading to an error when trying to access memory directly. Fixed by adding a check for large offsets.