### PR TITLE
Fix `run_constructor`

### DIFF
--- a/evm/src/cpu/kernel/asm/core/create.asm
+++ b/evm/src/cpu/kernel/asm/core/create.asm
@@ -87,7 +87,7 @@ global create_common:
 
 run_constructor:
     // stack: new_ctx, value, address, kexit_info
-    %set_new_ctx_value
+    SWAP1 %set_new_ctx_value
     // stack: new_ctx, address, kexit_info
 
     // Each line in the block below does not change the stack.

--- a/evm/src/cpu/kernel/asm/core/create.asm
+++ b/evm/src/cpu/kernel/asm/core/create.asm
@@ -93,7 +93,6 @@ run_constructor:
     // Each line in the block below does not change the stack.
     DUP2 %set_new_ctx_addr
     %address %set_new_ctx_caller
-    %set_new_ctx_parent_ctx
     %set_new_ctx_parent_pc(after_constructor)
     // stack: new_ctx, address, kexit_info
 


### PR DESCRIPTION
Fixes the crash due to a huge allocation in `returndatacopyPythonBug_Tue_03_48_41-1432`.