### PR TITLE
CALL gas

### DIFF
--- a/evm/src/cpu/kernel/asm/core/call.asm
+++ b/evm/src/cpu/kernel/asm/core/call.asm
@@ -259,6 +259,7 @@ global after_call_instruction:
 %endmacro
 
 // Charge gas for *call opcodes and return the sub-context gas limit.
+// Doesn't include memory expansion costs.
 %macro call_charge_gas
     // Compute C_aaccess
     // stack: cold_access, address, gas, kexit_info, value, args_offset, args_size, ret_offset, ret_size
@@ -284,7 +285,6 @@ global after_call_instruction:
     // Compute C_extra
     ADD ADD
 
-
     // Compute C_gascap
     // stack: Cextra, address, gas, kexit_info, value, args_offset, args_size, ret_offset, ret_size
     DUP4 %leftover_gas
@@ -302,14 +302,12 @@ global after_call_instruction:
     DUP7 %min MUL ADD
     // stack: Cgascap, leftover_gas, Cextra, address, gas, kexit_info, value, args_offset, args_size, ret_offset, ret_size
 
-
     // Compute C_call and charge for it.
     %stack (Cgascap, leftover_gas, Cextra) -> (Cextra, Cgascap, Cgascap)
     ADD
     %stack (C_call, Cgascap, address, gas, kexit_info, value, args_offset, args_size, ret_offset, ret_size) ->
         (C_call, kexit_info, Cgascap, address, gas, value, args_offset, args_size, ret_offset, ret_size)
     %charge_gas
-
 
     // Compute C_callgas
     %stack (kexit_info, Cgascap, address, gas, value, args_offset, args_size, ret_offset, ret_size) ->

--- a/evm/src/cpu/kernel/asm/core/util.asm
+++ b/evm/src/cpu/kernel/asm/core/util.asm
@@ -68,6 +68,7 @@
     ADD // OR
 %endmacro
 
+// All but one 64th
 %macro L
     // stack: x
     DUP1 %div_const(64) SWAP1 SUB

--- a/evm/src/cpu/kernel/asm/core/util.asm
+++ b/evm/src/cpu/kernel/asm/core/util.asm
@@ -67,3 +67,8 @@
     SWAP1 %is_empty
     ADD // OR
 %endmacro
+
+%macro L
+    // stack: x
+    DUP1 %div_const(64) SWAP1 SUB
+%endmacro


### PR DESCRIPTION
Add gas calculation for `sys_call`. Will do the other *call opcodes in another PR.
Makes some call tests pass (e.g. `(Non)ZeroValue_CALL, callcall_00`).