### PR TITLE
Fix `copy_returndata_to_mem`

### DIFF
--- a/evm/src/cpu/kernel/asm/core/call.asm
+++ b/evm/src/cpu/kernel/asm/core/call.asm
@@ -297,12 +297,16 @@ global after_call_instruction:
 
 %macro copy_returndata_to_mem
     // stack: kexit_info, new_ctx, success, ret_offset, ret_size
+    SWAP4
+    %returndatasize
+    // stack: returndata_size, ret_size, new_ctx, success, ret_offset, kexit_info
+    %min
     GET_CONTEXT
-    %stack (ctx, kexit_info, new_ctx, success, ret_offset, ret_size) ->
+    %stack (ctx, n, new_ctx, success, ret_offset, kexit_info) ->
         (
             ctx, @SEGMENT_MAIN_MEMORY, ret_offset, // DST
             ctx, @SEGMENT_RETURNDATA, 0,           // SRC
-            ret_size, %%after,                     // count, retdest
+            n, %%after,                     // count, retdest
             kexit_info, success
         )
     %jump(memcpy)


### PR DESCRIPTION
Have to take the minimum with returndata size.