### PR TITLE
Enable stack constraints

### DIFF
--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -156,7 +156,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         pc::eval_packed(local_values, yield_constr);
         shift::eval_packed(local_values, yield_constr);
         simple_logic::eval_packed(local_values, yield_constr);
-        stack::eval_packed(local_values, &mut dummy_yield_constr);
+        stack::eval_packed(local_values, yield_constr);
         stack_bounds::eval_packed(local_values, &mut dummy_yield_constr);
         syscalls::eval_packed(local_values, next_values, yield_constr);
     }
@@ -186,7 +186,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for CpuStark<F, D
         pc::eval_ext_circuit(builder, local_values, yield_constr);
         shift::eval_ext_circuit(builder, local_values, yield_constr);
         simple_logic::eval_ext_circuit(builder, local_values, yield_constr);
-        stack::eval_ext_circuit(builder, local_values, &mut dummy_yield_constr);
+        stack::eval_ext_circuit(builder, local_values, yield_constr);
         stack_bounds::eval_ext_circuit(builder, local_values, &mut dummy_yield_constr);
         syscalls::eval_ext_circuit(builder, local_values, next_values, yield_constr);
     }

--- a/evm/src/cpu/stack.rs
+++ b/evm/src/cpu/stack.rs
@@ -29,7 +29,7 @@ const BASIC_BINARY_OP: Option<StackBehavior> = Some(StackBehavior {
     disable_other_channels: true,
 });
 const BASIC_TERNARY_OP: Option<StackBehavior> = Some(StackBehavior {
-    num_pops: 2,
+    num_pops: 3,
     pushes: true,
     disable_other_channels: true,
 });
@@ -60,8 +60,16 @@ const STACK_BEHAVIORS: OpsColumnsView<Option<StackBehavior>> = OpsColumnsView {
     xor: BASIC_BINARY_OP,
     not: BASIC_UNARY_OP,
     byte: BASIC_BINARY_OP,
-    shl: BASIC_BINARY_OP,
-    shr: BASIC_BINARY_OP,
+    shl: Some(StackBehavior {
+        num_pops: 2,
+        pushes: true,
+        disable_other_channels: false,
+    }),
+    shr: Some(StackBehavior {
+        num_pops: 2,
+        pushes: true,
+        disable_other_channels: false,
+    }),
     keccak_general: None, // TODO
     prover_input: None,   // TODO
     pop: None,            // TODO


### PR DESCRIPTION
Makes stack constraints pass by changing the shift left/right behaviors such that `disable_other_channels = false` (those channels are already constrained in `shift.rs`). It also sets the number of pops of `BASIC_TERNARY_OP` to 3.