### PR TITLE
Fix generic const expressions warning

### DIFF
--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -4,6 +4,7 @@
 // `[dev-dependencies]`.
 
 #![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
 #![allow(clippy::upper_case_acronyms)]
 
 use core::num::ParseIntError;

--- a/plonky2/src/lib.rs
+++ b/plonky2/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::upper_case_acronyms)]
+#![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 


### PR DESCRIPTION
Pull request #873 introduced the use of the incomplete `generic_const_exprs` feature ([here](https://github.com/mir-protocol/plonky2/pull/873/files#diff-ab60f6df9f439d7609ceba5ffaa210cfdee8e1c25fae13c3e2c799e0b3c92d04R4)) but did not disable the compiler warning for it, which seems to have been causing CI failures on main and branches since. This PR disables the warning for incomplete features in Plonky2.