### PR TITLE
Provide methods for serializing Kernel

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -36,6 +36,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 static_assertions = "1.1.0"
 hashbrown = { version = "0.12.3" }
 tiny-keccak = "2.0.2"
+serde_json = "1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.5.0"

--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Error};
 use ethereum_types::{BigEndianHash, H256, U256, U512};
 use itertools::Itertools;
 use plonky2::field::types::Field;
+use serde::{Deserialize, Serialize};
 
 use crate::extension_tower::{FieldExt, Fp12, BLS381, BN254};
 use crate::generation::prover_input::EvmField::{
@@ -19,7 +20,7 @@ use crate::witness::util::{kernel_peek, stack_peek};
 
 /// Prover input function represented as a scoped function name.
 /// Example: `PROVER_INPUT(ff::bn254_base::inverse)` is represented as `ProverInputFn([ff, bn254_base, inverse])`.
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub struct ProverInputFn(Vec<String>);
 
 impl From<Vec<String>> for ProverInputFn {


### PR DESCRIPTION
Introduces methods for serializing / deserializing the Kernel.
Given the time it takes to bootstrap now with the introduction of the precompile files from #983 (>100sec on my machine), it may come in handy to skip the process when working on other parts of the crate.