### PR TITLE
Incremental release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ members = ["evm", "field", "maybe_rayon", "plonky2", "starky", "util"]
 
 [profile.release]
 opt-level = 3
+incremental = true
 #lto = "fat"
 #codegen-units = 1
 
 [profile.bench]
 opt-level = 3
-
 
 [patch.crates-io]
 plonky2_evm = { path = "evm" }


### PR DESCRIPTION
Since it's a library, in practice release builds are used for slower tests, not for a binary that needs to be reproducible.