### PR TITLE
Unify proof type + link public values

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -36,13 +36,31 @@ use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
 use crate::logic::LogicStark;
 use crate::memory::memory_stark::MemoryStark;
 use crate::permutation::{get_grand_product_challenge_set_target, GrandProductChallengeSet};
-use crate::proof::StarkProofWithMetadata;
+use crate::proof::{PublicValues, PublicValuesTarget, StarkProofWithMetadata};
 use crate::prover::prove;
 use crate::recursive_verifier::{
     add_common_recursion_gates, recursive_stark_circuit, PlonkWrapperCircuit, PublicInputs,
     StarkWrapperCircuit,
 };
 use crate::stark::Stark;
+
+/// An EVM proof, corresponding to either a root, an aggregation, or a block proof,
+/// along with public memory values.
+#[derive(Debug, Clone)]
+pub struct EvmProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+where
+    [(); C::HCO::WIDTH]:,
+{
+    pub proof: ProofWithPublicInputs<F, C, D>,
+    // TODO: Do we want to store only trie roots? Or a list of block_metadata?
+    pub public_values: PublicValues,
+}
+
+#[derive(Debug, Clone)]
+pub struct EvmProofTarget<const D: usize> {
+    pub proof_target: ProofWithPublicInputsTarget<D>,
+    pub public_values_target: PublicValuesTarget,
+}
 
 /// The recursion threshold. We end a chain of recursive proofs once we reach this size.
 const THRESHOLD_DEGREE_BITS: usize = 13;

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -54,6 +54,16 @@ pub struct PublicValues {
     pub block_metadata: BlockMetadata,
 }
 
+/// Memory values  which are public over an aggregaton of blocks.
+#[derive(Debug, Clone, Default)]
+pub struct AggregatedPublicValues {
+    pub trie_roots_before: TrieRoots,
+    pub trie_roots_after: TrieRoots,
+    /// Represents the leftmost and rightmost block_metadata of the associated
+    /// aggregation proof, to allow combination on both sides with another proof.
+    pub block_metadata_pair: (BlockMetadata, BlockMetadata),
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct TrieRoots {
     pub state_root: H256,
@@ -79,6 +89,16 @@ pub struct PublicValuesTarget {
     pub trie_roots_before: TrieRootsTarget,
     pub trie_roots_after: TrieRootsTarget,
     pub block_metadata: BlockMetadataTarget,
+}
+
+/// Memory values which are public over an aggregaton of blocks.
+#[derive(Debug, Clone)]
+pub struct AggregatedPublicValuesTarget {
+    pub trie_roots_before: TrieRootsTarget,
+    pub trie_roots_after: TrieRootsTarget,
+    /// Represents the leftmost and rightmost block_metadata of the associated
+    /// aggregation proof, to allow combination on both sides with another proof.
+    pub block_metadata_pair: (BlockMetadataTarget, BlockMetadataTarget),
 }
 
 #[derive(Debug, Clone)]

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -54,16 +54,6 @@ pub struct PublicValues {
     pub block_metadata: BlockMetadata,
 }
 
-/// Memory values  which are public over an aggregaton of blocks.
-#[derive(Debug, Clone, Default)]
-pub struct AggregatedPublicValues {
-    pub trie_roots_before: TrieRoots,
-    pub trie_roots_after: TrieRoots,
-    /// Represents the leftmost and rightmost block_metadata of the associated
-    /// aggregation proof, to allow combination on both sides with another proof.
-    pub block_metadata_pair: (BlockMetadata, BlockMetadata),
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct TrieRoots {
     pub state_root: H256,
@@ -84,29 +74,18 @@ pub struct BlockMetadata {
 
 /// Memory values which are public.
 /// Note: All the larger integers are encoded with 32-bit limbs in little-endian order.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct PublicValuesTarget {
     pub trie_roots_before: TrieRootsTarget,
     pub trie_roots_after: TrieRootsTarget,
     pub block_metadata: BlockMetadataTarget,
 }
 
-/// Memory values which are public over an aggregaton of blocks.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct AggregatedPublicValuesTarget {
-    pub trie_roots_before: TrieRootsTarget,
-    pub trie_roots_after: TrieRootsTarget,
-    /// Represents the leftmost and rightmost block_metadata of the associated
-    /// aggregation proof, to allow combination on both sides with another proof.
-    pub block_metadata_pair: (BlockMetadataTarget, BlockMetadataTarget),
-}
-
-impl AggregatedPublicValuesTarget {
+impl PublicValuesTarget {
     pub fn to_buffer(&self, buffer: &mut Vec<u8>) -> IoResult<()> {
         self.trie_roots_before.to_buffer(buffer)?;
         self.trie_roots_after.to_buffer(buffer)?;
-        self.block_metadata_pair.0.to_buffer(buffer)?;
-        self.block_metadata_pair.1.to_buffer(buffer)?;
+        self.block_metadata.to_buffer(buffer)?;
 
         Ok(())
     }
@@ -114,15 +93,12 @@ impl AggregatedPublicValuesTarget {
     pub fn from_buffer(buffer: &mut Buffer) -> IoResult<Self> {
         let trie_roots_before = TrieRootsTarget::from_buffer(buffer)?;
         let trie_roots_after = TrieRootsTarget::from_buffer(buffer)?;
-        let block_metadata_pair = (
-            BlockMetadataTarget::from_buffer(buffer)?,
-            BlockMetadataTarget::from_buffer(buffer)?,
-        );
+        let block_metadata = BlockMetadataTarget::from_buffer(buffer)?;
 
         Ok(Self {
             trie_roots_before,
             trie_roots_after,
-            block_metadata_pair,
+            block_metadata,
         })
     }
 }

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -74,18 +74,21 @@ pub struct BlockMetadata {
 
 /// Memory values which are public.
 /// Note: All the larger integers are encoded with 32-bit limbs in little-endian order.
+#[derive(Debug, Clone)]
 pub struct PublicValuesTarget {
     pub trie_roots_before: TrieRootsTarget,
     pub trie_roots_after: TrieRootsTarget,
     pub block_metadata: BlockMetadataTarget,
 }
 
+#[derive(Debug, Clone)]
 pub struct TrieRootsTarget {
     pub state_root: [Target; 8],
     pub transactions_root: [Target; 8],
     pub receipts_root: [Target; 8],
 }
 
+#[derive(Debug, Clone)]
 pub struct BlockMetadataTarget {
     pub block_beneficiary: [Target; 5],
     pub block_timestamp: Target,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -498,7 +498,6 @@ fn eval_l_0_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(
     )
 }
 
-#[allow(unused)] // TODO: used later?
 pub(crate) fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> PublicValuesTarget {
@@ -623,7 +622,6 @@ pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: 
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
-#[allow(unused)] // TODO: used later?
 pub(crate) fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -33,8 +33,9 @@ use crate::permutation::{
     PermutationCheckDataTarget,
 };
 use crate::proof::{
-    BlockMetadata, BlockMetadataTarget, PublicValues, PublicValuesTarget, StarkOpeningSetTarget,
-    StarkProof, StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
+    AggregatedPublicValues, AggregatedPublicValuesTarget, BlockMetadata, BlockMetadataTarget,
+    PublicValues, PublicValuesTarget, StarkOpeningSetTarget, StarkProof,
+    StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
     TrieRootsTarget,
 };
 use crate::stark::Stark;
@@ -498,6 +499,23 @@ fn eval_l_0_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(
     )
 }
 
+pub(crate) fn add_virtual_aggregated_public_values<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+) -> AggregatedPublicValuesTarget {
+    let trie_roots_before = add_virtual_trie_roots(builder);
+    let trie_roots_after = add_virtual_trie_roots(builder);
+    let block_metadata_pair = (
+        add_virtual_block_metadata(builder),
+        add_virtual_block_metadata(builder),
+    );
+    AggregatedPublicValuesTarget {
+        trie_roots_before,
+        trie_roots_after,
+        block_metadata_pair,
+    }
+}
+
+#[allow(unused)] // TODO: used later?
 pub(crate) fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> PublicValuesTarget {
@@ -622,6 +640,37 @@ pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: 
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
+pub(crate) fn set_aggregated_public_value_targets<F, W, const D: usize>(
+    witness: &mut W,
+    public_values_target: &AggregatedPublicValuesTarget,
+    public_values: &AggregatedPublicValues,
+) where
+    F: RichField + Extendable<D>,
+    W: Witness<F>,
+{
+    set_trie_roots_target(
+        witness,
+        &public_values_target.trie_roots_before,
+        &public_values.trie_roots_before,
+    );
+    set_trie_roots_target(
+        witness,
+        &public_values_target.trie_roots_after,
+        &public_values.trie_roots_after,
+    );
+    set_block_metadata_target(
+        witness,
+        &public_values_target.block_metadata_pair.0,
+        &public_values.block_metadata_pair.0,
+    );
+    set_block_metadata_target(
+        witness,
+        &public_values_target.block_metadata_pair.1,
+        &public_values.block_metadata_pair.1,
+    );
+}
+
+#[allow(unused)] // TODO: used later?
 pub(crate) fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -33,9 +33,8 @@ use crate::permutation::{
     PermutationCheckDataTarget,
 };
 use crate::proof::{
-    AggregatedPublicValues, AggregatedPublicValuesTarget, BlockMetadata, BlockMetadataTarget,
-    PublicValues, PublicValuesTarget, StarkOpeningSetTarget, StarkProof,
-    StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
+    BlockMetadata, BlockMetadataTarget, PublicValues, PublicValuesTarget, StarkOpeningSetTarget,
+    StarkProof, StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
     TrieRootsTarget,
 };
 use crate::stark::Stark;
@@ -499,23 +498,6 @@ fn eval_l_0_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(
     )
 }
 
-pub(crate) fn add_virtual_aggregated_public_values<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-) -> AggregatedPublicValuesTarget {
-    let trie_roots_before = add_virtual_trie_roots(builder);
-    let trie_roots_after = add_virtual_trie_roots(builder);
-    let block_metadata_pair = (
-        add_virtual_block_metadata(builder),
-        add_virtual_block_metadata(builder),
-    );
-    AggregatedPublicValuesTarget {
-        trie_roots_before,
-        trie_roots_after,
-        block_metadata_pair,
-    }
-}
-
-#[allow(unused)] // TODO: used later?
 pub(crate) fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
 ) -> PublicValuesTarget {
@@ -640,37 +622,6 @@ pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: 
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
-pub(crate) fn set_aggregated_public_value_targets<F, W, const D: usize>(
-    witness: &mut W,
-    public_values_target: &AggregatedPublicValuesTarget,
-    public_values: &AggregatedPublicValues,
-) where
-    F: RichField + Extendable<D>,
-    W: Witness<F>,
-{
-    set_trie_roots_target(
-        witness,
-        &public_values_target.trie_roots_before,
-        &public_values.trie_roots_before,
-    );
-    set_trie_roots_target(
-        witness,
-        &public_values_target.trie_roots_after,
-        &public_values.trie_roots_after,
-    );
-    set_block_metadata_target(
-        witness,
-        &public_values_target.block_metadata_pair.0,
-        &public_values.block_metadata_pair.0,
-    );
-    set_block_metadata_target(
-        witness,
-        &public_values_target.block_metadata_pair.1,
-        &public_values.block_metadata_pair.1,
-    );
-}
-
-#[allow(unused)] // TODO: used later?
 pub(crate) fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -61,7 +61,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
-        &[9..18, 9..15, 9..15, 9..10, 9..12, 9..18], // Minimal ranges to prove an empty list
+        &[9..17, 9..15, 9..15, 9..10, 9..13, 9..19], // Minimal ranges to prove an empty list
         &config,
     );
 
@@ -124,9 +124,12 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     all_circuits.verify_root(root_proof.clone())?;
 
-    // We can duplicate the root_proof here because the state hasn't mutated.
+    // We can duplicate the proofs here because the state hasn't mutated.
     let agg_proof = all_circuits.prove_aggregation(false, &root_proof, false, &root_proof)?;
-    all_circuits.verify_aggregation(&agg_proof)
+    all_circuits.verify_aggregation(&agg_proof)?;
+
+    let block_proof = all_circuits.prove_block(None, &agg_proof)?;
+    all_circuits.verify_block(&block_proof)
 }
 
 fn init_logger() {

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -191,7 +191,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         }
     }
 
-    pub fn observe_element(&mut self, target: Target) {
+    pub(crate) fn observe_element(&mut self, target: Target) {
         // Any buffered outputs are now invalid, since they wouldn't reflect this input.
         self.output_buffer.clear();
 

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -191,7 +191,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
         }
     }
 
-    pub(crate) fn observe_element(&mut self, target: Target) {
+    pub fn observe_element(&mut self, target: Target) {
         // Any buffered outputs are now invalid, since they wouldn't reflect this input.
         self.output_buffer.clear();
 


### PR DESCRIPTION
This PR unifies the proof type in `fixed_recursive_verifier`, so that we deal with the same `EvmProof` at any level of the tree, and includes check on the public values trie roots when merging proofs. A few design questions / assumptions I wasn't sure on how you were envisioning things:

- I assumed two proofs to be aggregated to be representing consecutive chain states
- I assumed root proofs may not represent an entire block, hence the need to check consistency across txn / receipt tries as well in the case where block metadata of two proofs to merge match
- ~~For checking that `block_metadata` match, I only considered `block_timestamp`, although we could extend it to the other fields as well.~~
- ~~The above also stores the latest `block_metadata` when aggregating two proofs. Do we want to keep track of all the block metadatas from past proofs?~~
- Given the function definition of `prove_block()`, the consistency check between trie roots assumes the block proof (if any) is always on the left side.