### PR TITLE
Quieter continuous integration

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -45,6 +45,7 @@ jobs:
           args: --all
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Cprefer-dynamic=y
+          RUST_LOG: 1
           CARGO_INCREMENTAL: 1
           RUST_BACKTRACE: 1
 


### PR DESCRIPTION
Only print warning or errors from the log.

The CI currently produces about 0.4GiB of data every single run, the vast majority of it empty or useless debug messages.