### PR TITLE
SSTORE gas

### DIFF
--- a/evm/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm/src/cpu/kernel/asm/core/access_lists.asm
@@ -54,7 +54,7 @@ insert_accessed_addresses_found:
 
 
 %macro insert_accessed_storage_keys
-    %stack (addr, key) -> (addr, key, %%after)
+    %stack (addr, key, value) -> (addr, key, value, %%after)
     %jump(insert_accessed_storage_keys)
 %%after:
     // stack: cold_access
@@ -63,14 +63,14 @@ insert_accessed_addresses_found:
 /// Inserts the storage key into the access list if it is not already present.
 /// Return 1 if the storage key was inserted, 0 if it was already present.
 global insert_accessed_storage_keys:
-    // stack: addr, key, retdest
+    // stack: addr, key, value, retdest
     %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)
-    // stack: len, addr, key, retdest
+    // stack: len, addr, key, value, retdest
     PUSH 0
 insert_accessed_storage_keys_loop:
-    %stack (i, len, addr, key, retdest) -> (i, len, i, len, addr, key, retdest)
+    %stack (i, len, addr, key, value, retdest) -> (i, len, i, len, addr, key, value, retdest)
     EQ %jumpi(insert_storage_key)
-    // stack: i, len, addr, key, retdest
+    // stack: i, len, addr, key, value, retdest
     DUP1 %increment %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
     // stack: loaded_key, i, len, addr, key, retdest
     DUP2 %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
@@ -82,21 +82,26 @@ insert_accessed_storage_keys_loop:
     MUL // AND
     %jumpi(insert_accessed_storage_keys_found)
     // stack: i, len, addr, key, retdest
-    %add_const(2)
+    %add_const(3)
     %jump(insert_accessed_storage_keys_loop)
 
 insert_storage_key:
-    // stack: i, len, addr, key, retdest
+    // stack: i, len, addr, key, value, retdest
     DUP1 %increment
-    %stack (i_plus_1, i, len, addr, key, retdest) -> (i, addr, i_plus_1, key, i_plus_1, retdest)
+    DUP1 %increment
+    %stack (i_plus_2, i_plus_1, i, len, addr, key, value) -> (i, addr, i_plus_1, key, i_plus_2, value, i_plus_2, value)
     %mstore_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS) // Store new address at the end of the array.
     %mstore_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS) // Store new key after that
-    // stack: i_plus_1, retdest
+    %mstore_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS) // Store new value after that
+    // stack: i_plus_2, value, retdest
     %increment
-    %mstore_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN) // Store new length in front of the array.
-    PUSH 1 // Return 1 to indicate that the storage key was inserted.
-    SWAP1 JUMP
+    %mstore_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN) // Store new length.
+    %stack (value, retdest) -> (retdest, 1, value) // Return 1 to indicate that the storage key was inserted.
+    JUMP
 
 insert_accessed_storage_keys_found:
-    %stack (i, len, addr, key, retdest) -> (retdest, 0) // Return 0 to indicate that the storage key was already present.
+    // stack: i, len, addr, key, retdest
+    %add_const(2)
+    %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
+    %stack (value, len, addr, key, retdest) -> (retdest, 0, value) // Return 0 to indicate that the storage key was already present.
     JUMP

--- a/evm/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm/src/cpu/kernel/asm/core/access_lists.asm
@@ -72,16 +72,16 @@ insert_accessed_storage_keys_loop:
     EQ %jumpi(insert_storage_key)
     // stack: i, len, addr, key, value, retdest
     DUP1 %increment %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
-    // stack: loaded_key, i, len, addr, key, retdest
+    // stack: loaded_key, i, len, addr, key, value, retdest
     DUP2 %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
-    // stack: loaded_addr, loaded_key, i, len, addr, key, retdest
+    // stack: loaded_addr, loaded_key, i, len, addr, key, value, retdest
     DUP5 EQ
-    // stack: loaded_addr==addr, loaded_key, i, len, addr, key, retdest
+    // stack: loaded_addr==addr, loaded_key, i, len, addr, key, value, retdest
     SWAP1 DUP6 EQ
-    // stack: loaded_key==key, loaded_addr==addr, i, len, addr, key, retdest
+    // stack: loaded_key==key, loaded_addr==addr, i, len, addr, key, value, retdest
     MUL // AND
     %jumpi(insert_accessed_storage_keys_found)
-    // stack: i, len, addr, key, retdest
+    // stack: i, len, addr, key, value, retdest
     %add_const(3)
     %jump(insert_accessed_storage_keys_loop)
 
@@ -100,8 +100,8 @@ insert_storage_key:
     JUMP
 
 insert_accessed_storage_keys_found:
-    // stack: i, len, addr, key, retdest
+    // stack: i, len, addr, key, value, retdest
     %add_const(2)
     %mload_kernel(@SEGMENT_ACCESSED_STORAGE_KEYS)
-    %stack (value, len, addr, key, retdest) -> (retdest, 0, value) // Return 0 to indicate that the storage key was already present.
+    %stack (original_value, len, addr, key, value, retdest) -> (retdest, 0, original_value) // Return 0 to indicate that the storage key was already present.
     JUMP

--- a/evm/src/cpu/kernel/asm/core/access_lists.asm
+++ b/evm/src/cpu/kernel/asm/core/access_lists.asm
@@ -60,8 +60,9 @@ insert_accessed_addresses_found:
     // stack: cold_access
 %endmacro
 
-/// Inserts the storage key into the access list if it is not already present.
-/// Return 1 if the storage key was inserted, 0 if it was already present.
+/// Inserts the storage key and value into the access list if it is not already present.
+/// `value` should be the current storage value at the slot `(addr, key)`.
+/// Return `1, original_value` if the storage key was inserted, `0, original_value` if it was already present.
 global insert_accessed_storage_keys:
     // stack: addr, key, value, retdest
     %mload_global_metadata(@GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN)

--- a/evm/src/cpu/kernel/asm/mpt/storage/storage_read.asm
+++ b/evm/src/cpu/kernel/asm/mpt/storage/storage_read.asm
@@ -6,38 +6,42 @@
 global sys_sload:
     // stack: kexit_info, slot
     SWAP1
-    // stack: slot, kexit_info
-    DUP1 %address
-    // stack: addr, slot, slot, kexit_info
-    %insert_accessed_storage_keys PUSH @GAS_COLDSLOAD_MINUS_WARMACCESS
-    MUL
-    PUSH @GAS_WARMACCESS
-    ADD
-    %stack (gas, slot, kexit_info) -> (gas, kexit_info, slot)
-    %charge_gas
-    // stack: kexit_info, slot
-
-    SWAP1
-    %stack (slot) -> (slot, after_storage_read)
+    %stack (slot) -> (slot, after_storage_read, slot)
     %slot_to_storage_key
-    // stack: storage_key, after_storage_read, kexit_info
+    // stack: storage_key, after_storage_read, slot, kexit_info
     PUSH 64 // storage_key has 64 nibbles
     %current_storage_trie
-    // stack: storage_root_ptr, 64, storage_key, after_storage_read, kexit_info
+    // stack: storage_root_ptr, 64, storage_key, after_storage_read, slot, kexit_info
     %jump(mpt_read)
 
+
 after_storage_read:
-    // stack: value_ptr, kexit_info
+    // stack: value_ptr, slot, kexit_info
     DUP1 %jumpi(storage_key_exists)
 
     // Storage key not found. Return default value_ptr = 0,
     // which derefs to 0 since @SEGMENT_TRIE_DATA[0] = 0.
-    %stack (value_ptr, kexit_info) -> (kexit_info, 0)
-    EXIT_KERNEL
+    %stack (value_ptr, slot, kexit_info) -> (slot, 0, kexit_info)
+    %jump(sload_gas)
 
 storage_key_exists:
-    // stack: value_ptr, kexit_info
+    // stack: value_ptr, slot, kexit_info
     %mload_trie_data
-    // stack: value, kexit_info
+    // stack: value, slot, kexit_info
     SWAP1
+    %jump(sload_gas)
+
+sload_gas:
+    %stack (slot, value, kexit_info) -> (slot, value, kexit_info, value)
+    %address
+    // stack: addr, slot, value, kexit_info, value
+    %insert_accessed_storage_keys
+    // stack: cold_access, old_value, kexit_info, value
+    SWAP1 POP
+    // stack: cold_access, kexit_info, value
+    %mul_const(@GAS_COLDSLOAD_MINUS_WARMACCESS)
+    %add_const(@GAS_WARMACCESS)
+    %charge_gas
+    // stack: kexit_info, value
     EXIT_KERNEL
+

--- a/evm/src/cpu/kernel/asm/mpt/storage/storage_read.asm
+++ b/evm/src/cpu/kernel/asm/mpt/storage/storage_read.asm
@@ -1,3 +1,34 @@
+%macro sload_current
+    %stack (slot) -> (slot, %%after)
+    %jump(sload_current)
+%%after:
+%endmacro
+
+global sload_current:
+    %stack (slot) -> (slot, after_storage_read)
+    %slot_to_storage_key
+    // stack: storage_key, after_storage_read
+    PUSH 64 // storage_key has 64 nibbles
+    %current_storage_trie
+    // stack: storage_root_ptr, 64, storage_key, after_storage_read
+    %jump(mpt_read)
+
+global after_storage_read:
+    // stack: value_ptr, retdest
+    DUP1 %jumpi(storage_key_exists)
+
+    // Storage key not found. Return default value_ptr = 0,
+    // which derefs to 0 since @SEGMENT_TRIE_DATA[0] = 0.
+    %stack (value_ptr, retdest) -> (retdest, 0)
+    JUMP
+
+global storage_key_exists:
+    // stack: value_ptr, retdest
+    %mload_trie_data
+    // stack: value, retdest
+    SWAP1
+    JUMP
+
 // Read a word from the current account's storage trie.
 //
 // Pre stack: kexit_info, slot
@@ -6,33 +37,11 @@
 global sys_sload:
     // stack: kexit_info, slot
     SWAP1
-    %stack (slot) -> (slot, after_storage_read, slot)
-    %slot_to_storage_key
-    // stack: storage_key, after_storage_read, slot, kexit_info
-    PUSH 64 // storage_key has 64 nibbles
-    %current_storage_trie
-    // stack: storage_root_ptr, 64, storage_key, after_storage_read, slot, kexit_info
-    %jump(mpt_read)
+    DUP1
+    // stack: slot, slot, kexit_info
+    %sload_current
 
-
-after_storage_read:
-    // stack: value_ptr, slot, kexit_info
-    DUP1 %jumpi(storage_key_exists)
-
-    // Storage key not found. Return default value_ptr = 0,
-    // which derefs to 0 since @SEGMENT_TRIE_DATA[0] = 0.
-    %stack (value_ptr, slot, kexit_info) -> (slot, 0, kexit_info)
-    %jump(sload_gas)
-
-storage_key_exists:
-    // stack: value_ptr, slot, kexit_info
-    %mload_trie_data
-    // stack: value, slot, kexit_info
-    SWAP1
-    %jump(sload_gas)
-
-sload_gas:
-    %stack (slot, value, kexit_info) -> (slot, value, kexit_info, value)
+    %stack (value, slot, kexit_info) -> (slot, value, kexit_info, value)
     %address
     // stack: addr, slot, value, kexit_info, value
     %insert_accessed_storage_keys

--- a/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -1,3 +1,34 @@
+%macro load_current_value
+    %stack (slot) -> (slot, %%after)
+    %jump(load_current_value)
+%%after:
+%endmacro
+
+load_current_value:
+    %stack (slot) -> (slot, after_storage_read)
+    %slot_to_storage_key
+    // stack: storage_key, after_storage_read
+    PUSH 64 // storage_key has 64 nibbles
+    %current_storage_trie
+    // stack: storage_root_ptr, 64, storage_key, after_storage_read
+    %jump(mpt_read)
+
+after_storage_read:
+    // stack: value_ptr, retdest
+    DUP1 %jumpi(storage_key_exists)
+
+    // Storage key not found. Return default value_ptr = 0,
+    // which derefs to 0 since @SEGMENT_TRIE_DATA[0] = 0.
+    %stack (value_ptr, retdest) -> (retdest, 0)
+    JUMP
+
+storage_key_exists:
+    // stack: value_ptr, retdest
+    %mload_trie_data
+    // stack: value, retdest
+    SWAP1
+    JUMP
+
 // Write a word to the current account's storage trie.
 //
 // Pre stack: kexit_info, slot, value
@@ -6,14 +37,31 @@
 global sys_sstore:
     %check_static
     %stack (kexit_info, slot, value) -> (slot, kexit_info, slot, value)
-    %address %insert_accessed_storage_keys POP // TODO: Use return value in gas calculation.
-    // TODO: Assuming a cold zero -> nonzero write for now.
-    PUSH @GAS_COLDSLOAD
-    PUSH @GAS_SSET
-    ADD
+    %load_current_value
+    %address
+    %stack (addr, current_value, kexit_info, slot, value) -> (addr, slot, current_value, current_value, kexit_info, slot, value)
+    %insert_accessed_storage_keys
+    // stack: cold_access, original_value, current_value, kexit_info, slot, value
+    %mul_const(@GAS_COLDSLOAD)
+    %stack (gas, original_value, current_value, kexit_info, slot, value) ->
+        (value, current_value, current_value, original_value, gas, original_value, current_value, kexit_info, slot, value)
+    EQ SWAP2 EQ ISZERO
+    // stack: current_value==original_value, value==current_value, gas, original_value, current_value, kexit_info, slot, value)
+    OR
+    %jumpi(sstore_warm)
+    // stack: gas, original_value, current_value, kexit_info, slot, value
+    DUP2 ISZERO %mul_const(@GAS_SSET) ADD
+    DUP2 ISZERO ISZERO %mul_const(@GAS_SRESET) ADD
+    %jump(sstore_charge_gas)
+sstore_warm:
+    // stack: gas, original_value, current_value, kexit_info, slot, value)
+    %add_const(@GAS_WARMACCESS)
+sstore_charge_gas:
+    %stack (gas, original_value, current_value, kexit_info, slot, value) -> (gas, kexit_info, current_value, slot, value)
     %charge_gas
 
-    %stack (kexit_info, slot, value) -> (slot, value, kexit_info)
+    %stack (kexit_info, current_value, slot, value) -> (value, current_value, slot, value, kexit_info)
+    EQ %jumpi(sstore_noop)
     // TODO: If value = 0, delete the key instead of inserting 0.
     // stack: slot, value, kexit_info
 
@@ -56,4 +104,9 @@ after_storage_insert:
 
 after_state_insert:
     // stack: kexit_info
+    EXIT_KERNEL
+
+sstore_noop:
+    // stack: slot, value, kexit_info
+    %pop2
     EXIT_KERNEL


### PR DESCRIPTION
Implement gas calculation for SSTORE. 
Works by storing the value in the storage keys access list. That way, the original value (i.e. value before the tx) of a storage slots is stored there and can be used in the gas calculation.
This is rather hacky, so it should probably be redesigned at some point, but in the meantime it helps filtering out tests that fail because of gas miscalculations.