### PR TITLE
remove ProofChallenges serialization

### DIFF
--- a/plonky2/examples/fibonacci_serialization.rs
+++ b/plonky2/examples/fibonacci_serialization.rs
@@ -60,16 +60,6 @@ fn main() -> Result<()> {
     let proof_serialized = serde_json::to_string(&proof).unwrap();
     fs::write("proof_with_public_inputs.json", proof_serialized).expect("Unable to write file");
 
-    let proof_challenges = proof
-        .get_challenges(
-            proof.get_public_inputs_hash(),
-            &data.verifier_only.circuit_digest,
-            &data.common,
-        )
-        .unwrap();
-    let proof_challenges_serialized = serde_json::to_string(&proof_challenges).unwrap();
-    fs::write("proof_challenges.json", proof_challenges_serialized).expect("Unable to write file");
-
     println!(
         "100th Fibonacci number mod |F| (starting with {}, {}) is: {}",
         proof.public_inputs[0], proof.public_inputs[1], proof.public_inputs[2]

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -393,7 +393,6 @@ impl<F: RichField + Extendable<D>, HCO: HashConfig, H: Hasher<F, HCO>, const D: 
     }
 }
 
-#[derive(Serialize)]
 pub struct FriChallenges<F: RichField + Extendable<D>, const D: usize> {
     // Scaling factor to combine polynomials.
     pub fri_alpha: F::Extension,

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -276,7 +276,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 }
 
-#[derive(Serialize)]
 pub struct ProofChallenges<F: RichField + Extendable<D>, const D: usize> {
     /// Random values used in Plonk's permutation argument.
     pub plonk_betas: Vec<F>,


### PR DESCRIPTION
Instead, ProofChallenges should be generated in the verifier (e.g. the gnark plonky2 verifier)