### PR TITLE
Fix compile time problems and generic hash implementation

### DIFF
--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -8,7 +8,6 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
@@ -328,10 +327,7 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
         cross_table_lookups: &'a [CrossTableLookup<F>],
         ctl_challenges: &'a GrandProductChallengeSet<F>,
         num_permutation_zs: &[usize; NUM_TABLES],
-    ) -> [Vec<Self>; NUM_TABLES]
-    where
-        [(); C::HCO::WIDTH]:,
-    {
+    ) -> [Vec<Self>; NUM_TABLES] {
         let mut ctl_zs = proofs
             .iter()
             .zip(num_permutation_zs)

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -15,7 +15,7 @@ use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{
     CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget,
 };
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 use plonky2::recursion::cyclic_recursion::check_cyclic_proof_verifier_data;
 use plonky2::recursion::dummy_circuit::cyclic_base_proof;
@@ -265,7 +265,6 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F> + 'static,
     C::Hasher: AlgebraicHasher<F>,
-    [(); C::Hasher::HASH_SIZE]:,
     [(); CpuStark::<F, D>::COLUMNS]:,
     [(); KeccakStark::<F, D>::COLUMNS]:,
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
@@ -710,7 +709,6 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     C::Hasher: AlgebraicHasher<F>,
-    [(); C::Hasher::HASH_SIZE]:,
 {
     pub fn to_buffer(
         &self,
@@ -806,7 +804,6 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     C::Hasher: AlgebraicHasher<F>,
-    [(); C::Hasher::HASH_SIZE]:,
 {
     pub fn to_buffer(
         &self,

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -61,7 +61,7 @@ where
         &self,
         all_stark: &AllStark<F, D>,
         config: &StarkConfig,
-    ) -> AllChallengerState<F, C::HCO, D>
+    ) -> AllChallengerState<F, C::HCO, C::Hasher, D>
     where
         [(); C::HCO::WIDTH]:,
         [(); C::HCI::WIDTH]:,

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -1,10 +1,9 @@
 use plonky2::field::extension::Extendable;
 use plonky2::fri::proof::{FriProof, FriProofTarget};
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
 use crate::all_stark::{AllStark, NUM_TABLES};
 use crate::config::StarkConfig;
@@ -161,8 +160,6 @@ impl<const D: usize> StarkProofTarget<D> {
     ) -> StarkProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let StarkProofTarget {
             permutation_ctl_zs_cap,

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -14,20 +14,13 @@ use crate::permutation::{
 };
 use crate::proof::*;
 
-impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D>
-where
-    [(); C::HCO::WIDTH]:,
-{
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D> {
     /// Computes all Fiat-Shamir challenges used in the STARK proof.
     pub(crate) fn get_challenges(
         &self,
         all_stark: &AllStark<F, D>,
         config: &StarkConfig,
-    ) -> AllProofChallenges<F, D>
-    where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
-    {
+    ) -> AllProofChallenges<F, D> {
         let mut challenger = Challenger::<F, C::HCO, C::Hasher>::new();
 
         for proof in &self.stark_proofs {
@@ -61,11 +54,7 @@ where
         &self,
         all_stark: &AllStark<F, D>,
         config: &StarkConfig,
-    ) -> AllChallengerState<F, C::HCO, C::Hasher, D>
-    where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
-    {
+    ) -> AllChallengerState<F, C::HCO, C::Hasher, D> {
         let mut challenger = Challenger::<F, C::HCO, C::Hasher>::new();
 
         for proof in &self.stark_proofs {
@@ -110,11 +99,7 @@ where
         stark_use_permutation: bool,
         stark_permutation_batch_size: usize,
         config: &StarkConfig,
-    ) -> StarkProofChallenges<F, D>
-    where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
-    {
+    ) -> StarkProofChallenges<F, D> {
         let degree_bits = self.recover_degree_bits(config);
 
         let StarkProof {

--- a/evm/src/permutation.rs
+++ b/evm/src/permutation.rs
@@ -9,7 +9,7 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -201,16 +201,16 @@ fn poly_product_elementwise<F: Field>(
     product
 }
 
-fn get_grand_product_challenge<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+fn get_grand_product_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
 ) -> GrandProductChallenge<F> {
     let beta = challenger.get_challenge();
     let gamma = challenger.get_challenge();
     GrandProductChallenge { beta, gamma }
 }
 
-pub(crate) fn get_grand_product_challenge_set<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+pub(crate) fn get_grand_product_challenge_set<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
     num_challenges: usize,
 ) -> GrandProductChallengeSet<F> {
     let challenges = (0..num_challenges)
@@ -219,8 +219,8 @@ pub(crate) fn get_grand_product_challenge_set<F: RichField, HC: HashConfig, H: H
     GrandProductChallengeSet { challenges }
 }
 
-pub(crate) fn get_n_grand_product_challenge_sets<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+pub(crate) fn get_n_grand_product_challenge_sets<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
     num_challenges: usize,
     num_sets: usize,
 ) -> Vec<GrandProductChallengeSet<F>> {
@@ -231,15 +231,14 @@ pub(crate) fn get_n_grand_product_challenge_sets<F: RichField, HC: HashConfig, H
 
 fn get_grand_product_challenge_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
 ) -> GrandProductChallenge<Target>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let beta = challenger.get_challenge(builder);
     let gamma = challenger.get_challenge(builder);
@@ -248,16 +247,15 @@ where
 
 pub(crate) fn get_grand_product_challenge_set_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
 ) -> GrandProductChallengeSet<Target>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let challenges = (0..num_challenges)
         .map(|_| get_grand_product_challenge_target(builder, challenger))
@@ -267,17 +265,16 @@ where
 
 pub(crate) fn get_n_grand_product_challenge_sets_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
     num_sets: usize,
 ) -> Vec<GrandProductChallengeSet<Target>>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     (0..num_sets)
         .map(|_| get_grand_product_challenge_set_target(builder, challenger, num_challenges))

--- a/evm/src/permutation.rs
+++ b/evm/src/permutation.rs
@@ -203,10 +203,7 @@ fn poly_product_elementwise<F: Field>(
 
 fn get_grand_product_challenge<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     challenger: &mut Challenger<F, HC, H>,
-) -> GrandProductChallenge<F>
-where
-    [(); HC::WIDTH]:,
-{
+) -> GrandProductChallenge<F> {
     let beta = challenger.get_challenge();
     let gamma = challenger.get_challenge();
     GrandProductChallenge { beta, gamma }
@@ -215,10 +212,7 @@ where
 pub(crate) fn get_grand_product_challenge_set<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     challenger: &mut Challenger<F, HC, H>,
     num_challenges: usize,
-) -> GrandProductChallengeSet<F>
-where
-    [(); HC::WIDTH]:,
-{
+) -> GrandProductChallengeSet<F> {
     let challenges = (0..num_challenges)
         .map(|_| get_grand_product_challenge(challenger))
         .collect();
@@ -229,10 +223,7 @@ pub(crate) fn get_n_grand_product_challenge_sets<F: RichField, HC: HashConfig, H
     challenger: &mut Challenger<F, HC, H>,
     num_challenges: usize,
     num_sets: usize,
-) -> Vec<GrandProductChallengeSet<F>>
-where
-    [(); HC::WIDTH]:,
-{
+) -> Vec<GrandProductChallengeSet<F>> {
     (0..num_sets)
         .map(|_| get_grand_product_challenge_set(challenger, num_challenges))
         .collect()

--- a/evm/src/permutation.rs
+++ b/evm/src/permutation.rs
@@ -9,7 +9,6 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -236,10 +235,7 @@ fn get_grand_product_challenge_target<
 >(
     builder: &mut CircuitBuilder<F, D>,
     challenger: &mut RecursiveChallenger<F, H, D>,
-) -> GrandProductChallenge<Target>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> GrandProductChallenge<Target> {
     let beta = challenger.get_challenge(builder);
     let gamma = challenger.get_challenge(builder);
     GrandProductChallenge { beta, gamma }
@@ -253,10 +249,7 @@ pub(crate) fn get_grand_product_challenge_set_target<
     builder: &mut CircuitBuilder<F, D>,
     challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
-) -> GrandProductChallengeSet<Target>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> GrandProductChallengeSet<Target> {
     let challenges = (0..num_challenges)
         .map(|_| get_grand_product_challenge_target(builder, challenger))
         .collect();
@@ -272,10 +265,7 @@ pub(crate) fn get_n_grand_product_challenge_sets_target<
     challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
     num_sets: usize,
-) -> Vec<GrandProductChallengeSet<Target>>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> Vec<GrandProductChallengeSet<Target>> {
     (0..num_sets)
         .map(|_| get_grand_product_challenge_set_target(builder, challenger, num_challenges))
         .collect()

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -22,19 +22,13 @@ use crate::permutation::GrandProductChallengeSet;
 
 /// A STARK proof for each table, plus some metadata used to create recursive wrapper proofs.
 #[derive(Debug, Clone)]
-pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
-where
-    [(); C::HCO::WIDTH]:,
-{
+pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     pub stark_proofs: [StarkProofWithMetadata<F, C, D>; NUM_TABLES],
     pub(crate) ctl_challenges: GrandProductChallengeSet<F>,
     pub public_values: PublicValues,
 }
 
-impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D>
-where
-    [(); C::HCO::WIDTH]:,
-{
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D> {
     pub fn degree_bits(&self, config: &StarkConfig) -> [usize; NUM_TABLES] {
         core::array::from_fn(|i| self.stark_proofs[i].proof.recover_degree_bits(config))
     }

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -7,7 +7,6 @@ use plonky2::fri::structure::{
     FriOpeningBatch, FriOpeningBatchTarget, FriOpenings, FriOpeningsTarget,
 };
 use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -43,7 +42,7 @@ pub(crate) struct AllProofChallenges<F: RichField + Extendable<D>, const D: usiz
 pub(crate) struct AllChallengerState<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     /// Sponge state of the challenger before starting each proof,
     /// along with the final state after all proofs are done. This final state isn't strictly needed.
-    pub states: [<H::Permutation as PlonkyPermutation<F>>::State; NUM_TABLES + 1],
+    pub states: [H::Permutation; NUM_TABLES + 1],
     pub ctl_challenges: GrandProductChallengeSet<F>,
 }
 
@@ -119,8 +118,7 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
 {
-    pub(crate) init_challenger_state:
-        <<C::Hasher as Hasher<F>>::Permutation as PlonkyPermutation<F>>::State,
+    pub(crate) init_challenger_state: <C::Hasher as Hasher<F>>::Permutation,
     pub(crate) proof: StarkProof<F, C, D>,
 }
 

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -7,7 +7,7 @@ use plonky2::fri::structure::{
     FriOpeningBatch, FriOpeningBatchTarget, FriOpenings, FriOpeningsTarget,
 };
 use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
-use plonky2::hash::hashing::{HashConfig, PlonkyPermutation};
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -40,12 +40,7 @@ pub(crate) struct AllProofChallenges<F: RichField + Extendable<D>, const D: usiz
 }
 
 #[allow(unused)] // TODO: should be used soon
-pub(crate) struct AllChallengerState<
-    F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: Hasher<F, HC>,
-    const D: usize,
-> {
+pub(crate) struct AllChallengerState<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     /// Sponge state of the challenger before starting each proof,
     /// along with the final state after all proofs are done. This final state isn't strictly needed.
     pub states: [<H::Permutation as PlonkyPermutation<F>>::State; NUM_TABLES + 1],
@@ -105,15 +100,15 @@ pub struct BlockMetadataTarget {
 #[derive(Debug, Clone)]
 pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     /// Merkle cap of LDEs of trace values.
-    pub trace_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub trace_cap: MerkleCap<F, C::Hasher>,
     /// Merkle cap of LDEs of permutation Z values.
-    pub permutation_ctl_zs_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub permutation_ctl_zs_cap: MerkleCap<F, C::Hasher>,
     /// Merkle cap of LDEs of trace values.
-    pub quotient_polys_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub quotient_polys_cap: MerkleCap<F, C::Hasher>,
     /// Purported values of each polynomial at the challenge point.
     pub openings: StarkOpeningSet<F, D>,
     /// A batch FRI argument for all openings.
-    pub opening_proof: FriProof<F, C::HCO, C::Hasher, D>,
+    pub opening_proof: FriProof<F, C::Hasher, D>,
 }
 
 /// A `StarkProof` along with some metadata about the initial Fiat-Shamir state, which is used when
@@ -125,7 +120,7 @@ where
     C: GenericConfig<D, F = F>,
 {
     pub(crate) init_challenger_state:
-        <<C::Hasher as Hasher<F, C::HCO>>::Permutation as PlonkyPermutation<F>>::State,
+        <<C::Hasher as Hasher<F>>::Permutation as PlonkyPermutation<F>>::State,
     pub(crate) proof: StarkProof<F, C, D>,
 }
 

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -11,9 +11,8 @@ use plonky2::field::types::Field;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
 use plonky2::fri::oracle::PolynomialBatch;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
 use plonky2::iop::challenger::Challenger;
-use plonky2::plonk::config::{GenericConfig, Hasher};
+use plonky2::plonk::config::GenericConfig;
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use plonky2::util::transpose;
@@ -56,9 +55,6 @@ where
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
     [(); LogicStark::<F, D>::COLUMNS]:,
     [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::Hasher::HASH_SIZE]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     let (proof, _outputs) = prove_with_outputs(all_stark, config, inputs, timing)?;
     Ok(proof)
@@ -75,14 +71,11 @@ pub fn prove_with_outputs<F, C, const D: usize>(
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
-    [(); C::Hasher::HASH_SIZE]:,
     [(); CpuStark::<F, D>::COLUMNS]:,
     [(); KeccakStark::<F, D>::COLUMNS]:,
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
     [(); LogicStark::<F, D>::COLUMNS]:,
     [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     timed!(timing, "build kernel", Lazy::force(&KERNEL));
     let (traces, public_values, outputs) = timed!(
@@ -110,9 +103,6 @@ where
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
     [(); LogicStark::<F, D>::COLUMNS]:,
     [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::Hasher::HASH_SIZE]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     let rate_bits = config.fri_config.rate_bits;
     let cap_height = config.fri_config.cap_height;
@@ -195,14 +185,11 @@ fn prove_with_commitments<F, C, const D: usize>(
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
-    [(); C::Hasher::HASH_SIZE]:,
     [(); CpuStark::<F, D>::COLUMNS]:,
     [(); KeccakStark::<F, D>::COLUMNS]:,
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
     [(); LogicStark::<F, D>::COLUMNS]:,
     [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     let cpu_proof = timed!(
         timing,
@@ -293,8 +280,6 @@ where
     C: GenericConfig<D, F = F>,
     S: Stark<F, D>,
     [(); S::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     let degree = trace_poly_values[0].len();
     let degree_bits = log2_strict(degree);

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -136,7 +136,7 @@ where
         .iter()
         .map(|c| c.merkle_tree.cap.clone())
         .collect::<Vec<_>>();
-    let mut challenger = Challenger::<F, C::HCO, C::Hasher>::new();
+    let mut challenger = Challenger::<F, C::Hasher>::new();
     for cap in &trace_caps {
         challenger.observe_cap(cap);
     }
@@ -179,7 +179,7 @@ fn prove_with_commitments<F, C, const D: usize>(
     trace_poly_values: [Vec<PolynomialValues<F>>; NUM_TABLES],
     trace_commitments: Vec<PolynomialBatch<F, C, D>>,
     ctl_data_per_table: [CtlData<F>; NUM_TABLES],
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    challenger: &mut Challenger<F, C::Hasher>,
     timing: &mut TimingTree,
 ) -> Result<[StarkProofWithMetadata<F, C, D>; NUM_TABLES]>
 where
@@ -272,7 +272,7 @@ pub(crate) fn prove_single_table<F, C, S, const D: usize>(
     trace_poly_values: &[PolynomialValues<F>],
     trace_commitment: &PolynomialBatch<F, C, D>,
     ctl_data: &CtlData<F>,
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    challenger: &mut Challenger<F, C::Hasher>,
     timing: &mut TimingTree,
 ) -> Result<StarkProofWithMetadata<F, C, D>>
 where

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -138,7 +138,10 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         }
 
         let state = challenger.compact();
-        ensure!(state == pis[0].challenger_state_before);
+        ensure!(state
+            .into_iter()
+            .zip(pis[0].challenger_state_before)
+            .all(|(x, y)| x == y));
         // Check that the challenger state is consistent between proofs.
         for i in 1..NUM_TABLES {
             ensure!(pis[i].challenger_state_before == pis[i - 1].challenger_state_after);
@@ -241,7 +244,7 @@ where
 
         inputs.set_target_arr(
             self.init_challenger_state_target,
-            proof_with_metadata.init_challenger_state,
+            proof_with_metadata.init_challenger_state.as_ref(),
         );
 
         self.circuit.prove(inputs)
@@ -675,15 +678,15 @@ pub(crate) fn set_trie_roots_target<F, W, const D: usize>(
 {
     witness.set_target_arr(
         trie_roots_target.state_root,
-        h256_limbs(trie_roots.state_root),
+        &h256_limbs(trie_roots.state_root),
     );
     witness.set_target_arr(
         trie_roots_target.transactions_root,
-        h256_limbs(trie_roots.transactions_root),
+        &h256_limbs(trie_roots.transactions_root),
     );
     witness.set_target_arr(
         trie_roots_target.receipts_root,
-        h256_limbs(trie_roots.receipts_root),
+        &h256_limbs(trie_roots.receipts_root),
     );
 }
 
@@ -697,7 +700,7 @@ pub(crate) fn set_block_metadata_target<F, W, const D: usize>(
 {
     witness.set_target_arr(
         block_metadata_target.block_beneficiary,
-        h160_limbs(block_metadata.block_beneficiary),
+        &h160_limbs(block_metadata.block_beneficiary),
     );
     witness.set_target(
         block_metadata_target.block_timestamp,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -173,7 +173,7 @@ where
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<()> {
         buffer.write_circuit_data(&self.circuit, gate_serializer, generator_serializer)?;
-        buffer.write_target_vec(&self.init_challenger_state_target.as_ref())?;
+        buffer.write_target_vec(self.init_challenger_state_target.as_ref())?;
         buffer.write_target(self.zero_target)?;
         self.stark_proof_target.to_buffer(buffer)?;
         self.ctl_challenges_target.to_buffer(buffer)?;

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -139,9 +139,11 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
         let state = challenger.compact();
         ensure!(state
-            .into_iter()
+            .as_ref()
+            .iter()
             .zip(pis[0].challenger_state_before)
-            .all(|(x, y)| x == y));
+            .all(|(&x, y)| x == y));
+
         // Check that the challenger state is consistent between proofs.
         for i in 1..NUM_TABLES {
             ensure!(pis[i].challenger_state_before == pis[i - 1].challenger_state_after);

--- a/evm/src/stark_testing.rs
+++ b/evm/src/stark_testing.rs
@@ -3,11 +3,11 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use plonky2::field::types::{Field, Sample};
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
-use plonky2::plonk::config::GenericConfig;
+use plonky2::plonk::config::{GenericConfig, Hasher};
 use plonky2::util::transpose;
 use plonky2_util::{log2_ceil, log2_strict};
 
@@ -87,8 +87,8 @@ pub fn test_stark_circuit_constraints<
 ) -> Result<()>
 where
     [(); S::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     // Compute native constraint evaluation on random values.
     let vars = StarkEvaluationVars {

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -5,7 +5,6 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::types::Field;
 use plonky2::fri::verifier::verify_fri_proof;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
 use plonky2::plonk::config::GenericConfig;
 use plonky2::plonk::plonk_common::reduce_with_powers;
 
@@ -37,8 +36,6 @@ where
     [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
     [(); LogicStark::<F, D>::COLUMNS]:,
     [(); MemoryStark::<F, D>::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
 {
     let AllProofChallenges {
         stark_challenges,
@@ -120,7 +117,6 @@ pub(crate) fn verify_stark_proof_with_challenges<
 ) -> Result<()>
 where
     [(); S::COLUMNS]:,
-    [(); C::HCO::WIDTH]:,
 {
     log::debug!("Checking proof: {}", type_name::<S>());
     validate_proof_shape(stark, proof, config, ctl_vars.len())?;

--- a/plonky2/benches/hashing.rs
+++ b/plonky2/benches/hashing.rs
@@ -6,16 +6,14 @@ use plonky2::field::types::Sample;
 use plonky2::hash::hash_types::{BytesHash, RichField};
 use plonky2::hash::keccak::KeccakHash;
 use plonky2::hash::poseidon::{Poseidon, SPONGE_WIDTH};
-use plonky2::plonk::config::{Hasher, KeccakHashConfig};
+use plonky2::plonk::config::Hasher;
 use tynm::type_name;
 
 pub(crate) fn bench_keccak<F: RichField>(c: &mut Criterion) {
     c.bench_function("keccak256", |b| {
         b.iter_batched(
             || (BytesHash::<32>::rand(), BytesHash::<32>::rand()),
-            |(left, right)| {
-                <KeccakHash<32> as Hasher<F, KeccakHashConfig>>::two_to_one(left, right)
-            },
+            |(left, right)| <KeccakHash<32> as Hasher<F>>::two_to_one(left, right),
             BatchSize::SmallInput,
         )
     });

--- a/plonky2/benches/merkle.rs
+++ b/plonky2/benches/merkle.rs
@@ -1,23 +1,17 @@
-#![feature(generic_const_exprs)]
-
 mod allocator;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use plonky2::field::goldilocks_field::GoldilocksField;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
 use plonky2::hash::keccak::KeccakHash;
 use plonky2::hash::merkle_tree::MerkleTree;
 use plonky2::hash::poseidon::PoseidonHash;
-use plonky2::plonk::config::{Hasher, KeccakHashConfig, PoseidonHashConfig};
+use plonky2::plonk::config::Hasher;
 use tynm::type_name;
 
 const ELEMS_PER_LEAF: usize = 135;
 
-pub(crate) fn bench_merkle_tree<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(c: &mut Criterion)
-where
-    [(); HC::WIDTH]:,
-{
+pub(crate) fn bench_merkle_tree<F: RichField, H: Hasher<F>>(c: &mut Criterion) {
     let mut group = c.benchmark_group(&format!(
         "merkle-tree<{}, {}>",
         type_name::<F>(),
@@ -29,14 +23,14 @@ where
         let size = 1 << size_log;
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             let leaves = vec![F::rand_vec(ELEMS_PER_LEAF); size];
-            b.iter(|| MerkleTree::<F, HC, H>::new(leaves.clone(), 0));
+            b.iter(|| MerkleTree::<F, H>::new(leaves.clone(), 0));
         });
     }
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    bench_merkle_tree::<GoldilocksField, PoseidonHashConfig, PoseidonHash>(c);
-    bench_merkle_tree::<GoldilocksField, KeccakHashConfig, KeccakHash<25>>(c);
+    bench_merkle_tree::<GoldilocksField, PoseidonHash>(c);
+    bench_merkle_tree::<GoldilocksField, KeccakHash<25>>(c);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -237,7 +237,7 @@ fn main() -> Result<()> {
     builder.try_init()?;
 
     // Initialize randomness source
-    let rng_seed = options.seed.unwrap_or_else(|| OsRng::default().next_u64());
+    let rng_seed = options.seed.unwrap_or_else(|| OsRng.next_u64());
     info!("Using random seed {rng_seed:16x}");
     let _rng = ChaCha8Rng::seed_from_u64(rng_seed);
     // TODO: Use `rng` to create deterministic runs

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -3,8 +3,6 @@
 // put it in `src/bin/`, but then we wouldn't have access to
 // `[dev-dependencies]`.
 
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
 #![allow(clippy::upper_case_acronyms)]
 
 use core::num::ParseIntError;
@@ -15,11 +13,10 @@ use anyhow::{anyhow, Context as _, Result};
 use log::{info, Level, LevelFilter};
 use plonky2::gates::noop::NoopGate;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::{CircuitConfig, CommonCircuitData, VerifierOnlyCircuitData};
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, PoseidonGoldilocksConfig};
 use plonky2::plonk::proof::{CompressedProofWithPublicInputs, ProofWithPublicInputs};
 use plonky2::plonk::prover::prove;
 use plonky2::util::serialization::DefaultGateSerializer;
@@ -68,11 +65,7 @@ struct Options {
 fn dummy_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     config: &CircuitConfig,
     log2_size: usize,
-) -> Result<ProofTuple<F, C, D>>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> Result<ProofTuple<F, C, D>> {
     // 'size' is in degree, but we want number of noop gates. A non-zero amount of padding will be added and size will be rounded to the next power of two. To hit our target size, we go just under the previous power of two and hope padding is less than half the proof.
     let num_dummy_gates = match log2_size {
         0 => return Err(anyhow!("size must be at least 1")),
@@ -110,10 +103,6 @@ fn recursive_proof<
 ) -> Result<ProofTuple<F, C, D>>
 where
     InnerC::Hasher: AlgebraicHasher<F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <InnerC::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <InnerC::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let (inner_proof, inner_vd, inner_cd) = inner;
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
@@ -155,11 +144,7 @@ fn test_serialization<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
     proof: &ProofWithPublicInputs<F, C, D>,
     vd: &VerifierOnlyCircuitData<C, D>,
     cd: &CommonCircuitData<F, D>,
-) -> Result<()>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> Result<()> {
     let proof_bytes = proof.to_bytes();
     info!("Proof length: {} bytes", proof_bytes.len());
     let proof_from_bytes = ProofWithPublicInputs::from_bytes(proof_bytes, cd)?;

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -76,7 +76,7 @@ impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for CustomGeneratorS
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F> + 'static,
-    C::Hasher: AlgebraicHasher<F, C::HCO>,
+    C::Hasher: AlgebraicHasher<F>,
 {
     impl_generator_serializer! {
         CustomGeneratorSerializer,

--- a/plonky2/src/fri/challenges.rs
+++ b/plonky2/src/fri/challenges.rs
@@ -12,14 +12,10 @@ use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
 
-impl<F: RichField, HCO: HashConfig, H: Hasher<F, HCO>> Challenger<F, HCO, H>
-where
-    [(); HCO::WIDTH]:,
-{
+impl<F: RichField, HCO: HashConfig, H: Hasher<F, HCO>> Challenger<F, HCO, H> {
     pub fn observe_openings<const D: usize>(&mut self, openings: &FriOpenings<F, D>)
     where
         F: RichField + Extendable<D>,
-        [(); HCO::WIDTH]:,
     {
         for v in &openings.batches {
             self.observe_extension_elements(&v.values);
@@ -36,8 +32,6 @@ where
     ) -> FriChallenges<F, D>
     where
         F: RichField + Extendable<D>,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
     {
         let num_fri_queries = config.num_query_rounds;
         let lde_size = 1 << (degree_bits + config.rate_bits);

--- a/plonky2/src/fri/challenges.rs
+++ b/plonky2/src/fri/challenges.rs
@@ -5,7 +5,6 @@ use crate::fri::structure::{FriOpenings, FriOpeningsTarget};
 use crate::fri::FriConfig;
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::challenger::{Challenger, RecursiveChallenger};
 use crate::iop::target::Target;
@@ -67,8 +66,6 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
 
 impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
     RecursiveChallenger<F, H, D>
-where
-    [(); H::Permutation::WIDTH]:,
 {
     pub fn observe_openings(&mut self, openings: &FriOpeningsTarget<D>) {
         for v in &openings.batches {

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -14,7 +14,6 @@ use crate::fri::prover::fri_proof;
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo};
 use crate::fri::FriParams;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
 use crate::hash::merkle_tree::MerkleTree;
 use crate::iop::challenger::Challenger;
 use crate::plonk::config::GenericConfig;
@@ -48,10 +47,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         cap_height: usize,
         timing: &mut TimingTree,
         fft_root_table: Option<&FftRootTable<F>>,
-    ) -> Self
-    where
-        [(); C::HCO::WIDTH]:,
-    {
+    ) -> Self {
         let coeffs = timed!(
             timing,
             "IFFT",
@@ -76,10 +72,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         cap_height: usize,
         timing: &mut TimingTree,
         fft_root_table: Option<&FftRootTable<F>>,
-    ) -> Self
-    where
-        [(); C::HCO::WIDTH]:,
-    {
+    ) -> Self {
         let degree = polynomials[0].len();
         let lde_values = timed!(
             timing,
@@ -172,11 +165,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         challenger: &mut Challenger<F, C::HCO, C::Hasher>,
         fri_params: &FriParams,
         timing: &mut TimingTree,
-    ) -> FriProof<F, C::HCO, C::Hasher, D>
-    where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
-    {
+    ) -> FriProof<F, C::HCO, C::Hasher, D> {
         assert!(D > 1, "Not implemented for D=1.");
         let alpha = challenger.get_extension_challenge::<D>();
         let mut alpha = ReducingFactor::new(alpha);

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -30,7 +30,7 @@ pub const SALT_SIZE: usize = 4;
 pub struct PolynomialBatch<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 {
     pub polynomials: Vec<PolynomialCoeffs<F>>,
-    pub merkle_tree: MerkleTree<F, C::HCO, C::Hasher>,
+    pub merkle_tree: MerkleTree<F, C::Hasher>,
     pub degree_log: usize,
     pub rate_bits: usize,
     pub blinding: bool,
@@ -162,10 +162,10 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     pub fn prove_openings(
         instance: &FriInstanceInfo<F, D>,
         oracles: &[&Self],
-        challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+        challenger: &mut Challenger<F, C::Hasher>,
         fri_params: &FriParams,
         timing: &mut TimingTree,
-    ) -> FriProof<F, C::HCO, C::Hasher, D> {
+    ) -> FriProof<F, C::Hasher, D> {
         assert!(D > 1, "Not implemented for D=1.");
         let alpha = challenger.get_extension_challenge::<D>();
         let mut alpha = ReducingFactor::new(alpha);

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -10,7 +10,6 @@ use crate::field::polynomial::PolynomialCoeffs;
 use crate::fri::FriParams;
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::{MerkleProof, MerkleProofTarget};
 use crate::hash::merkle_tree::MerkleCap;
 use crate::hash::path_compression::{compress_merkle_proofs, decompress_merkle_proofs};
@@ -243,10 +242,7 @@ impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> CompressedFriPr
         challenges: &ProofChallenges<F, D>,
         fri_inferred_elements: FriInferredElements<F, D>,
         params: &FriParams,
-    ) -> FriProof<F, H, D>
-    where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) -> FriProof<F, H, D> {
         let CompressedFriProof {
             commit_phase_merkle_caps,
             query_round_proofs,

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -10,7 +10,7 @@ use crate::field::polynomial::PolynomialCoeffs;
 use crate::fri::FriParams;
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{MerkleCapTarget, RichField};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::{MerkleProof, MerkleProofTarget};
 use crate::hash::merkle_tree::MerkleCap;
 use crate::hash::path_compression::{compress_merkle_proofs, decompress_merkle_proofs};
@@ -23,14 +23,9 @@ use crate::plonk::proof::{FriInferredElements, ProofChallenges};
 /// Evaluations and Merkle proof produced by the prover in a FRI query step.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct FriQueryStep<
-    F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: Hasher<F, HC>,
-    const D: usize,
-> {
+pub struct FriQueryStep<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     pub evals: Vec<F::Extension>,
-    pub merkle_proof: MerkleProof<F, HC, H>,
+    pub merkle_proof: MerkleProof<F, H>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -43,11 +38,11 @@ pub struct FriQueryStepTarget<const D: usize> {
 /// before they are combined into a composition polynomial.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct FriInitialTreeProof<F: RichField, HC: HashConfig, H: Hasher<F, HC>> {
-    pub evals_proofs: Vec<(Vec<F>, MerkleProof<F, HC, H>)>,
+pub struct FriInitialTreeProof<F: RichField, H: Hasher<F>> {
+    pub evals_proofs: Vec<(Vec<F>, MerkleProof<F, H>)>,
 }
 
-impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> FriInitialTreeProof<F, HC, H> {
+impl<F: RichField, H: Hasher<F>> FriInitialTreeProof<F, H> {
     pub(crate) fn unsalted_eval(&self, oracle_index: usize, poly_index: usize, salted: bool) -> F {
         self.unsalted_evals(oracle_index, salted)[poly_index]
     }
@@ -82,14 +77,9 @@ impl FriInitialTreeProofTarget {
 /// Proof for a FRI query round.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct FriQueryRound<
-    F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: Hasher<F, HC>,
-    const D: usize,
-> {
-    pub initial_trees_proof: FriInitialTreeProof<F, HC, H>,
-    pub steps: Vec<FriQueryStep<F, HC, H, D>>,
+pub struct FriQueryRound<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
+    pub initial_trees_proof: FriInitialTreeProof<F, H>,
+    pub steps: Vec<FriQueryStep<F, H, D>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -101,28 +91,22 @@ pub struct FriQueryRoundTarget<const D: usize> {
 /// Compressed proof of the FRI query rounds.
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct CompressedFriQueryRounds<
-    F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: Hasher<F, HC>,
-    const D: usize,
-> {
+pub struct CompressedFriQueryRounds<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     /// Query indices.
     pub indices: Vec<usize>,
     /// Map from initial indices `i` to the `FriInitialProof` for the `i`th leaf.
-    pub initial_trees_proofs: HashMap<usize, FriInitialTreeProof<F, HC, H>>,
+    pub initial_trees_proofs: HashMap<usize, FriInitialTreeProof<F, H>>,
     /// For each FRI query step, a map from indices `i` to the `FriQueryStep` for the `i`th leaf.
-    pub steps: Vec<HashMap<usize, FriQueryStep<F, HC, H, D>>>,
+    pub steps: Vec<HashMap<usize, FriQueryStep<F, H, D>>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct FriProof<F: RichField + Extendable<D>, HC: HashConfig, H: Hasher<F, HC>, const D: usize>
-{
+pub struct FriProof<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     /// A Merkle cap for each reduced polynomial in the commit phase.
-    pub commit_phase_merkle_caps: Vec<MerkleCap<F, HC, H>>,
+    pub commit_phase_merkle_caps: Vec<MerkleCap<F, H>>,
     /// Query rounds proofs
-    pub query_round_proofs: Vec<FriQueryRound<F, HC, H, D>>,
+    pub query_round_proofs: Vec<FriQueryRound<F, H, D>>,
     /// The final polynomial in coefficient form.
     pub final_poly: PolynomialCoeffs<F::Extension>,
     /// Witness showing that the prover did PoW.
@@ -139,31 +123,20 @@ pub struct FriProofTarget<const D: usize> {
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct CompressedFriProof<
-    F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: Hasher<F, HC>,
-    const D: usize,
-> {
+pub struct CompressedFriProof<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> {
     /// A Merkle cap for each reduced polynomial in the commit phase.
-    pub commit_phase_merkle_caps: Vec<MerkleCap<F, HC, H>>,
+    pub commit_phase_merkle_caps: Vec<MerkleCap<F, H>>,
     /// Compressed query rounds proof.
-    pub query_round_proofs: CompressedFriQueryRounds<F, HC, H, D>,
+    pub query_round_proofs: CompressedFriQueryRounds<F, H, D>,
     /// The final polynomial in coefficient form.
     pub final_poly: PolynomialCoeffs<F::Extension>,
     /// Witness showing that the prover did PoW.
     pub pow_witness: F,
 }
 
-impl<F: RichField + Extendable<D>, HCO: HashConfig, H: Hasher<F, HCO>, const D: usize>
-    FriProof<F, HCO, H, D>
-{
+impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> FriProof<F, H, D> {
     /// Compress all the Merkle paths in the FRI proof and remove duplicate indices.
-    pub fn compress(
-        self,
-        indices: &[usize],
-        params: &FriParams,
-    ) -> CompressedFriProof<F, HCO, H, D> {
+    pub fn compress(self, indices: &[usize], params: &FriParams) -> CompressedFriProof<F, H, D> {
         let FriProof {
             commit_phase_merkle_caps,
             query_round_proofs,
@@ -263,18 +236,16 @@ impl<F: RichField + Extendable<D>, HCO: HashConfig, H: Hasher<F, HCO>, const D: 
     }
 }
 
-impl<F: RichField + Extendable<D>, HCO: HashConfig, H: Hasher<F, HCO>, const D: usize>
-    CompressedFriProof<F, HCO, H, D>
-{
+impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> CompressedFriProof<F, H, D> {
     /// Decompress all the Merkle paths in the FRI proof and reinsert duplicate indices.
     pub(crate) fn decompress(
         self,
         challenges: &ProofChallenges<F, D>,
         fri_inferred_elements: FriInferredElements<F, D>,
         params: &FriParams,
-    ) -> FriProof<F, HCO, H, D>
+    ) -> FriProof<F, H, D>
     where
-        [(); HCO::WIDTH]:,
+        [(); H::Permutation::WIDTH]:,
     {
         let CompressedFriProof {
             commit_phase_merkle_caps,

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -26,11 +26,7 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
     challenger: &mut Challenger<F, C::HCO, C::Hasher>,
     fri_params: &FriParams,
     timing: &mut TimingTree,
-) -> FriProof<F, C::HCO, C::Hasher, D>
-where
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
-{
+) -> FriProof<F, C::HCO, C::Hasher, D> {
     let n = lde_polynomial_values.len();
     assert_eq!(lde_polynomial_coeffs.len(), n);
 
@@ -75,10 +71,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
     mut values: PolynomialValues<F::Extension>,
     challenger: &mut Challenger<F, C::HCO, C::Hasher>,
     fri_params: &FriParams,
-) -> FriCommitedTrees<F, C, D>
-where
-    [(); C::HCO::WIDTH]:,
-{
+) -> FriCommitedTrees<F, C, D> {
     let mut trees = Vec::new();
 
     let mut shift = F::MULTIPLICATIVE_GROUP_GENERATOR;
@@ -123,11 +116,7 @@ where
 fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     challenger: &mut Challenger<F, C::HCO, C::Hasher>,
     config: &FriConfig,
-) -> F
-where
-    [(); C::HCI::WIDTH]:,
-    [(); C::HCO::WIDTH]:,
-{
+) -> F {
     let min_leading_zeros = config.proof_of_work_bits + (64 - F::order().bits()) as u32;
 
     // The easiest implementation would be repeatedly clone our Challenger. With each clone, we'd
@@ -186,10 +175,7 @@ fn fri_prover_query_rounds<
     challenger: &mut Challenger<F, C::HCO, C::Hasher>,
     n: usize,
     fri_params: &FriParams,
-) -> Vec<FriQueryRound<F, C::HCO, C::Hasher, D>>
-where
-    [(); C::HCO::WIDTH]:,
-{
+) -> Vec<FriQueryRound<F, C::HCO, C::Hasher, D>> {
     challenger
         .get_n_challenges(fri_params.config.num_query_rounds)
         .into_par_iter()
@@ -209,10 +195,7 @@ fn fri_prover_query_round<
     trees: &[MerkleTree<F, C::HCO, C::Hasher>],
     mut x_index: usize,
     fri_params: &FriParams,
-) -> FriQueryRound<F, C::HCO, C::Hasher, D>
-where
-    [(); C::HCO::WIDTH]:,
-{
+) -> FriQueryRound<F, C::HCO, C::Hasher, D> {
     let mut query_steps = Vec::new();
     let initial_proof = initial_merkle_trees
         .iter()

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -146,7 +146,7 @@ where
     // state with any inputs (excluding the PoW witness candidate). The second step is to overwrite
     // one more element of our sponge state with the candidate, then apply the permutation,
     // obtaining our duplex's post-state which contains the PoW response.
-    let mut duplex_intermediate_state = challenger.sponge_state;
+    let mut duplex_intermediate_state = challenger.sponge_state.clone();
     let witness_input_pos = challenger.input_buffer.len();
     for (i, input) in challenger.input_buffer.iter().enumerate() {
         duplex_intermediate_state[i] = *input;
@@ -155,7 +155,7 @@ where
     let pow_witness = (0..=F::NEG_ONE.to_canonical_u64())
         .into_par_iter()
         .find_any(|&candidate| {
-            let mut duplex_state = duplex_intermediate_state;
+            let mut duplex_state = duplex_intermediate_state.clone();
             duplex_state[witness_input_pos] = F::from_canonical_u64(candidate);
             duplex_state =
                 <<C as GenericConfig<D>>::Hasher as Hasher<F, C::HCO>>::Permutation::permute(

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -7,7 +7,7 @@ use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::fri::proof::{FriInitialTreeProof, FriProof, FriQueryRound, FriQueryStep};
 use crate::fri::{FriConfig, FriParams};
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::{HashConfig, PlonkyPermutation};
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleTree;
 use crate::iop::challenger::Challenger;
 use crate::plonk::config::{GenericConfig, Hasher};
@@ -18,15 +18,15 @@ use crate::util::timing::TimingTree;
 
 /// Builds a FRI proof.
 pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
-    initial_merkle_trees: &[&MerkleTree<F, C::HCO, C::Hasher>],
+    initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
     // Coefficients of the polynomial on which the LDT is performed. Only the first `1/rate` coefficients are non-zero.
     lde_polynomial_coeffs: PolynomialCoeffs<F::Extension>,
     // Evaluation of the polynomial on the large domain.
     lde_polynomial_values: PolynomialValues<F::Extension>,
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    challenger: &mut Challenger<F, C::Hasher>,
     fri_params: &FriParams,
     timing: &mut TimingTree,
-) -> FriProof<F, C::HCO, C::Hasher, D> {
+) -> FriProof<F, C::Hasher, D> {
     let n = lde_polynomial_values.len();
     assert_eq!(lde_polynomial_coeffs.len(), n);
 
@@ -62,14 +62,14 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
 }
 
 type FriCommitedTrees<F, C, const D: usize> = (
-    Vec<MerkleTree<F, <C as GenericConfig<D>>::HCO, <C as GenericConfig<D>>::Hasher>>,
+    Vec<MerkleTree<F, <C as GenericConfig<D>>::Hasher>>,
     PolynomialCoeffs<<F as Extendable<D>>::Extension>,
 );
 
 fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     mut coeffs: PolynomialCoeffs<F::Extension>,
     mut values: PolynomialValues<F::Extension>,
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    challenger: &mut Challenger<F, C::Hasher>,
     fri_params: &FriParams,
 ) -> FriCommitedTrees<F, C, D> {
     let mut trees = Vec::new();
@@ -84,8 +84,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
             .par_chunks(arity)
             .map(|chunk: &[F::Extension]| flatten(chunk))
             .collect();
-        let tree =
-            MerkleTree::<F, C::HCO, C::Hasher>::new(chunked_values, fri_params.config.cap_height);
+        let tree = MerkleTree::<F, C::Hasher>::new(chunked_values, fri_params.config.cap_height);
 
         challenger.observe_cap(&tree.cap);
         trees.push(tree);
@@ -114,7 +113,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
 
 /// Performs the proof-of-work (a.k.a. grinding) step of the FRI protocol. Returns the PoW witness.
 fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    challenger: &mut Challenger<F, C::Hasher>,
     config: &FriConfig,
 ) -> F {
     let min_leading_zeros = config.proof_of_work_bits + (64 - F::order().bits()) as u32;
@@ -127,8 +126,8 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     // since it stores vectors, which means allocations. We'd like a more compact state to clone.
     //
     // We know that a duplex will be performed right after we send the PoW witness, so we can ignore
-    // any output_buffer, which will be invalidated. We also know input_buffer.len() < HCO::WIDTH,
-    // an invariant of Challenger.
+    // any output_buffer, which will be invalidated. We also know
+    // input_buffer.len() < H::Permutation::WIDTH, an invariant of Challenger.
     //
     // We separate the duplex operation into two steps, one which can be performed now, and the
     // other which depends on the PoW witness candidate. The first step is the overwrite our sponge
@@ -146,11 +145,8 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
         .find_any(|&candidate| {
             let mut duplex_state = duplex_intermediate_state.clone();
             duplex_state[witness_input_pos] = F::from_canonical_u64(candidate);
-            duplex_state =
-                <<C as GenericConfig<D>>::Hasher as Hasher<F, C::HCO>>::Permutation::permute(
-                    duplex_state,
-                );
-            let pow_response = duplex_state[C::HCO::RATE - 1];
+            duplex_state = <C::Hasher as Hasher<F>>::Permutation::permute(duplex_state);
+            let pow_response = duplex_state[<C::Hasher as Hasher<F>>::Permutation::RATE - 1];
             let leading_zeros = pow_response.to_canonical_u64().leading_zeros();
             leading_zeros >= min_leading_zeros
         })
@@ -170,12 +166,12 @@ fn fri_prover_query_rounds<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    initial_merkle_trees: &[&MerkleTree<F, C::HCO, C::Hasher>],
-    trees: &[MerkleTree<F, C::HCO, C::Hasher>],
-    challenger: &mut Challenger<F, C::HCO, C::Hasher>,
+    initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
+    trees: &[MerkleTree<F, C::Hasher>],
+    challenger: &mut Challenger<F, C::Hasher>,
     n: usize,
     fri_params: &FriParams,
-) -> Vec<FriQueryRound<F, C::HCO, C::Hasher, D>> {
+) -> Vec<FriQueryRound<F, C::Hasher, D>> {
     challenger
         .get_n_challenges(fri_params.config.num_query_rounds)
         .into_par_iter()
@@ -191,11 +187,11 @@ fn fri_prover_query_round<
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
-    initial_merkle_trees: &[&MerkleTree<F, C::HCO, C::Hasher>],
-    trees: &[MerkleTree<F, C::HCO, C::Hasher>],
+    initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
+    trees: &[MerkleTree<F, C::Hasher>],
     mut x_index: usize,
     fri_params: &FriParams,
-) -> FriQueryRound<F, C::HCO, C::Hasher, D> {
+) -> FriQueryRound<F, C::Hasher, D> {
     let mut query_steps = Vec::new();
     let initial_proof = initial_merkle_trees
         .iter()

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -134,14 +134,14 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     // state with any inputs (excluding the PoW witness candidate). The second step is to overwrite
     // one more element of our sponge state with the candidate, then apply the permutation,
     // obtaining our duplex's post-state which contains the PoW response.
-    let mut duplex_intermediate_state = challenger.sponge_state.clone();
+    let mut duplex_intermediate_state = challenger.sponge_state;
     let witness_input_pos = challenger.input_buffer.len();
     duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone().into_iter(), 0);
 
     let pow_witness = (0..=F::NEG_ONE.to_canonical_u64())
         .into_par_iter()
         .find_any(|&candidate| {
-            let mut duplex_state = duplex_intermediate_state.clone();
+            let mut duplex_state = duplex_intermediate_state;
             duplex_state.set_elt(F::from_canonical_u64(candidate), witness_input_pos);
             duplex_state.permute();
             let pow_response = duplex_state.squeeze().iter().last().unwrap();

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -14,11 +14,10 @@ use crate::gates::coset_interpolation::CosetInterpolationGate;
 use crate::gates::gate::Gate;
 use crate::gates::random_access::RandomAccessGate;
 use crate::hash::hash_types::{MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::iop::ext_target::{flatten_target, ExtensionTarget};
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
-use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::util::reducing::ReducingFactorTarget;
 use crate::util::{log2_strict, reverse_index_bits_in_place};
 use crate::with_context;
@@ -109,7 +108,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         params: &FriParams,
     ) where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         if let Some(max_arity_bits) = params.max_arity_bits() {
             self.check_recursion_config(max_arity_bits);
@@ -183,9 +181,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         proof: &FriInitialTreeProofTarget,
         initial_merkle_caps: &[MerkleCapTarget],
         cap_index: Target,
-    ) where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) {
         for (i, ((evals, merkle_proof), cap)) in proof
             .evals_proofs
             .iter()
@@ -263,7 +259,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         params: &FriParams,
     ) where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let n_log = log2_strict(n);
 

--- a/plonky2/src/fri/validate_shape.rs
+++ b/plonky2/src/fri/validate_shape.rs
@@ -9,7 +9,7 @@ use crate::plonk::config::GenericConfig;
 use crate::plonk::plonk_common::salt_size;
 
 pub(crate) fn validate_fri_proof_shape<F, C, const D: usize>(
-    proof: &FriProof<F, C::HCO, C::Hasher, D>,
+    proof: &FriProof<F, C::Hasher, D>,
     instance: &FriInstanceInfo<F, D>,
     params: &FriParams,
 ) -> anyhow::Result<()>

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -59,17 +59,18 @@ pub(crate) fn fri_verify_proof_of_work<F: RichField + Extendable<D>, const D: us
     Ok(())
 }
 
-pub fn verify_fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+pub fn verify_fri_proof<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
     instance: &FriInstanceInfo<F, D>,
     openings: &FriOpenings<F, D>,
     challenges: &FriChallenges<F, D>,
     initial_merkle_caps: &[MerkleCap<F, C::HCO, C::Hasher>],
     proof: &FriProof<F, C::HCO, C::Hasher, D>,
     params: &FriParams,
-) -> Result<()>
-where
-    [(); C::HCO::WIDTH]:,
-{
+) -> Result<()> {
     validate_fri_proof_shape::<F, C, D>(proof, instance, params)?;
 
     // Size of the LDE domain.
@@ -111,10 +112,7 @@ fn fri_verify_initial_proof<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     x_index: usize,
     proof: &FriInitialTreeProof<F, HC, H>,
     initial_merkle_caps: &[MerkleCap<F, HC, H>],
-) -> Result<()>
-where
-    [(); HC::WIDTH]:,
-{
+) -> Result<()> {
     for ((evals, merkle_proof), cap) in proof.evals_proofs.iter().zip(initial_merkle_caps) {
         verify_merkle_proof_to_cap::<F, HC, H>(evals.clone(), x_index, cap, merkle_proof)?;
     }
@@ -177,10 +175,7 @@ fn fri_verifier_query_round<
     n: usize,
     round_proof: &FriQueryRound<F, C::HCO, C::Hasher, D>,
     params: &FriParams,
-) -> Result<()>
-where
-    [(); C::HCO::WIDTH]:,
-{
+) -> Result<()> {
     fri_verify_initial_proof::<F, C::HCO, C::Hasher>(
         x_index,
         &round_proof.initial_trees_proof,

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -10,7 +10,6 @@ use crate::fri::structure::{FriBatchInfo, FriInstanceInfo, FriOpenings};
 use crate::fri::validate_shape::validate_fri_proof_shape;
 use crate::fri::{FriConfig, FriParams};
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
 use crate::hash::merkle_proofs::verify_merkle_proof_to_cap;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::plonk::config::{GenericConfig, Hasher};
@@ -67,8 +66,8 @@ pub fn verify_fri_proof<
     instance: &FriInstanceInfo<F, D>,
     openings: &FriOpenings<F, D>,
     challenges: &FriChallenges<F, D>,
-    initial_merkle_caps: &[MerkleCap<F, C::HCO, C::Hasher>],
-    proof: &FriProof<F, C::HCO, C::Hasher, D>,
+    initial_merkle_caps: &[MerkleCap<F, C::Hasher>],
+    proof: &FriProof<F, C::Hasher, D>,
     params: &FriParams,
 ) -> Result<()> {
     validate_fri_proof_shape::<F, C, D>(proof, instance, params)?;
@@ -108,13 +107,13 @@ pub fn verify_fri_proof<
     Ok(())
 }
 
-fn fri_verify_initial_proof<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+fn fri_verify_initial_proof<F: RichField, H: Hasher<F>>(
     x_index: usize,
-    proof: &FriInitialTreeProof<F, HC, H>,
-    initial_merkle_caps: &[MerkleCap<F, HC, H>],
+    proof: &FriInitialTreeProof<F, H>,
+    initial_merkle_caps: &[MerkleCap<F, H>],
 ) -> Result<()> {
     for ((evals, merkle_proof), cap) in proof.evals_proofs.iter().zip(initial_merkle_caps) {
-        verify_merkle_proof_to_cap::<F, HC, H>(evals.clone(), x_index, cap, merkle_proof)?;
+        verify_merkle_proof_to_cap::<F, H>(evals.clone(), x_index, cap, merkle_proof)?;
     }
 
     Ok(())
@@ -126,7 +125,7 @@ pub(crate) fn fri_combine_initial<
     const D: usize,
 >(
     instance: &FriInstanceInfo<F, D>,
-    proof: &FriInitialTreeProof<F, C::HCO, C::Hasher>,
+    proof: &FriInitialTreeProof<F, C::Hasher>,
     alpha: F::Extension,
     subgroup_x: F,
     precomputed_reduced_evals: &PrecomputedReducedOpenings<F, D>,
@@ -169,14 +168,14 @@ fn fri_verifier_query_round<
     instance: &FriInstanceInfo<F, D>,
     challenges: &FriChallenges<F, D>,
     precomputed_reduced_evals: &PrecomputedReducedOpenings<F, D>,
-    initial_merkle_caps: &[MerkleCap<F, C::HCO, C::Hasher>],
-    proof: &FriProof<F, C::HCO, C::Hasher, D>,
+    initial_merkle_caps: &[MerkleCap<F, C::Hasher>],
+    proof: &FriProof<F, C::Hasher, D>,
     mut x_index: usize,
     n: usize,
-    round_proof: &FriQueryRound<F, C::HCO, C::Hasher, D>,
+    round_proof: &FriQueryRound<F, C::Hasher, D>,
     params: &FriParams,
 ) -> Result<()> {
-    fri_verify_initial_proof::<F, C::HCO, C::Hasher>(
+    fri_verify_initial_proof::<F, C::Hasher>(
         x_index,
         &round_proof.initial_trees_proof,
         initial_merkle_caps,
@@ -217,7 +216,7 @@ fn fri_verifier_query_round<
             challenges.fri_betas[i],
         );
 
-        verify_merkle_proof_to_cap::<F, C::HCO, C::Hasher>(
+        verify_merkle_proof_to_cap::<F, C::Hasher>(
             flatten(evals),
             coset_index,
             &proof.commit_phase_merkle_caps[i],

--- a/plonky2/src/fri/witness_util.rs
+++ b/plonky2/src/fri/witness_util.rs
@@ -3,20 +3,18 @@ use itertools::Itertools;
 use crate::field::extension::Extendable;
 use crate::fri::proof::{FriProof, FriProofTarget};
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
 use crate::iop::witness::WitnessWrite;
 use crate::plonk::config::AlgebraicHasher;
 
 /// Set the targets in a `FriProofTarget` to their corresponding values in a `FriProof`.
-pub fn set_fri_proof_target<F, W, HC, H, const D: usize>(
+pub fn set_fri_proof_target<F, W, H, const D: usize>(
     witness: &mut W,
     fri_proof_target: &FriProofTarget<D>,
-    fri_proof: &FriProof<F, HC, H, D>,
+    fri_proof: &FriProof<F, H, D>,
 ) where
     F: RichField + Extendable<D>,
     W: WitnessWrite<F> + ?Sized,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
 {
     witness.set_target(fri_proof_target.pow_witness, fri_proof.pow_witness);
 

--- a/plonky2/src/gadgets/hash.rs
+++ b/plonky2/src/gadgets/hash.rs
@@ -1,27 +1,27 @@
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::config::AlgebraicHasher;
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
-    pub fn permute<HC: HashConfig, H: AlgebraicHasher<F, HC>>(
+    pub fn permute<H: AlgebraicHasher<F>>(
         &mut self,
-        inputs: [Target; HC::WIDTH],
-    ) -> [Target; HC::WIDTH] {
+        inputs: [Target; H::Permutation::WIDTH],
+    ) -> [Target; H::Permutation::WIDTH] {
         // We don't want to swap any inputs, so set that wire to 0.
         let _false = self._false();
-        self.permute_swapped::<HC, H>(inputs, _false)
+        self.permute_swapped::<H>(inputs, _false)
     }
 
     /// Conditionally swap two chunks of the inputs (useful in verifying Merkle proofs), then apply
     /// a cryptographic permutation.
-    pub(crate) fn permute_swapped<HC: HashConfig, H: AlgebraicHasher<F, HC>>(
+    pub(crate) fn permute_swapped<H: AlgebraicHasher<F>>(
         &mut self,
-        inputs: [Target; HC::WIDTH],
+        inputs: [Target; H::Permutation::WIDTH],
         swap: BoolTarget,
-    ) -> [Target; HC::WIDTH] {
+    ) -> [Target; H::Permutation::WIDTH] {
         H::permute_swapped(inputs, swap, self)
     }
 }

--- a/plonky2/src/gadgets/hash.rs
+++ b/plonky2/src/gadgets/hash.rs
@@ -1,15 +1,14 @@
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::PlonkyPermutation;
-use crate::iop::target::{BoolTarget, Target};
+use crate::iop::target::BoolTarget;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::config::AlgebraicHasher;
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn permute<H: AlgebraicHasher<F>>(
         &mut self,
-        inputs: [Target; H::Permutation::WIDTH],
-    ) -> [Target; H::Permutation::WIDTH] {
+        inputs: H::AlgebraicPermutation,
+    ) -> H::AlgebraicPermutation {
         // We don't want to swap any inputs, so set that wire to 0.
         let _false = self._false();
         self.permute_swapped::<H>(inputs, _false)
@@ -19,9 +18,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// a cryptographic permutation.
     pub(crate) fn permute_swapped<H: AlgebraicHasher<F>>(
         &mut self,
-        inputs: [Target; H::Permutation::WIDTH],
+        inputs: H::AlgebraicPermutation,
         swap: BoolTarget,
-    ) -> [Target; H::Permutation::WIDTH] {
+    ) -> H::AlgebraicPermutation {
         H::permute_swapped(inputs, swap, self)
     }
 }

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -8,11 +8,10 @@ use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::field::types::{Field, Sample};
 use crate::gates::gate::Gate;
 use crate::hash::hash_types::{HashOut, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::iop::witness::{PartialWitness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
-use crate::plonk::config::{GenericConfig, Hasher};
+use crate::plonk::config::GenericConfig;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
 use crate::plonk::verifier::verify;
 use crate::util::{log2_ceil, transpose};
@@ -94,11 +93,7 @@ pub fn test_eval_fns<
     const D: usize,
 >(
     gate: G,
-) -> Result<()>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> Result<()> {
     // Test that `eval_unfiltered` and `eval_unfiltered_base` are coherent.
     let wires_base = F::rand_vec(gate.num_wires());
     let constants_base = F::rand_vec(gate.num_constants());

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -8,11 +8,11 @@ use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::field::types::{Field, Sample};
 use crate::gates::gate::Gate;
 use crate::hash::hash_types::{HashOut, RichField};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::iop::witness::{PartialWitness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
-use crate::plonk::config::GenericConfig;
+use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
 use crate::plonk::verifier::verify;
 use crate::util::{log2_ceil, transpose};
@@ -96,8 +96,8 @@ pub fn test_eval_fns<
     gate: G,
 ) -> Result<()>
 where
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     // Test that `eval_unfiltered` and `eval_unfiltered_base` are coherent.
     let wires_base = F::rand_vec(gate.num_wires());

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -14,35 +14,37 @@ pub trait RichField: PrimeField64 + Poseidon {}
 
 impl RichField for GoldilocksField {}
 
+pub const NUM_HASH_OUT_ELTS: usize = 4;
+
 /// Represents a ~256 bit hash output.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct HashOut<F: Field> {
-    pub elements: [F; 4],
+    pub elements: [F; NUM_HASH_OUT_ELTS],
 }
 
 impl<F: Field> HashOut<F> {
     pub const ZERO: Self = Self {
-        elements: [F::ZERO; 4],
+        elements: [F::ZERO; NUM_HASH_OUT_ELTS],
     };
 
     // TODO: Switch to a TryFrom impl.
     pub fn from_vec(elements: Vec<F>) -> Self {
-        debug_assert!(elements.len() == 4);
+        debug_assert!(elements.len() == NUM_HASH_OUT_ELTS);
         Self {
             elements: elements.try_into().unwrap(),
         }
     }
 
     pub fn from_partial(elements_in: &[F]) -> Self {
-        let mut elements = [F::ZERO; 4];
+        let mut elements = [F::ZERO; NUM_HASH_OUT_ELTS];
         elements[0..elements_in.len()].copy_from_slice(elements_in);
         Self { elements }
     }
 }
 
-impl<F: Field> From<[F; 4]> for HashOut<F> {
-    fn from(elements: [F; 4]) -> Self {
+impl<F: Field> From<[F; NUM_HASH_OUT_ELTS]> for HashOut<F> {
+    fn from(elements: [F; NUM_HASH_OUT_ELTS]) -> Self {
         Self { elements }
     }
 }
@@ -51,7 +53,7 @@ impl<F: Field> TryFrom<&[F]> for HashOut<F> {
     type Error = anyhow::Error;
 
     fn try_from(elements: &[F]) -> Result<Self, Self::Error> {
-        ensure!(elements.len() == 4);
+        ensure!(elements.len() == NUM_HASH_OUT_ELTS);
         Ok(Self {
             elements: elements.try_into().unwrap(),
         })
@@ -90,7 +92,7 @@ impl<F: RichField> GenericHashOut<F> for HashOut<F> {
         HashOut {
             elements: bytes
                 .chunks(8)
-                .take(4)
+                .take(NUM_HASH_OUT_ELTS)
                 .map(|x| F::from_canonical_u64(u64::from_le_bytes(x.try_into().unwrap())))
                 .collect::<Vec<_>>()
                 .try_into()
@@ -112,27 +114,27 @@ impl<F: Field> Default for HashOut<F> {
 /// Represents a ~256 bit hash output.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct HashOutTarget {
-    pub elements: [Target; 4],
+    pub elements: [Target; NUM_HASH_OUT_ELTS],
 }
 
 impl HashOutTarget {
     // TODO: Switch to a TryFrom impl.
     pub fn from_vec(elements: Vec<Target>) -> Self {
-        debug_assert!(elements.len() == 4);
+        debug_assert!(elements.len() == NUM_HASH_OUT_ELTS);
         Self {
             elements: elements.try_into().unwrap(),
         }
     }
 
     pub fn from_partial(elements_in: &[Target], zero: Target) -> Self {
-        let mut elements = [zero; 4];
+        let mut elements = [zero; NUM_HASH_OUT_ELTS];
         elements[0..elements_in.len()].copy_from_slice(elements_in);
         Self { elements }
     }
 }
 
-impl From<[Target; 4]> for HashOutTarget {
-    fn from(elements: [Target; 4]) -> Self {
+impl From<[Target; NUM_HASH_OUT_ELTS]> for HashOutTarget {
+    fn from(elements: [Target; NUM_HASH_OUT_ELTS]) -> Self {
         Self { elements }
     }
 }
@@ -141,7 +143,7 @@ impl TryFrom<&[Target]> for HashOutTarget {
     type Error = anyhow::Error;
 
     fn try_from(elements: &[Target]) -> Result<Self, Self::Error> {
-        ensure!(elements.len() == 4);
+        ensure!(elements.len() == NUM_HASH_OUT_ELTS);
         Ok(Self {
             elements: elements.try_into().unwrap(),
         })

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -12,10 +12,7 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::config::AlgebraicHasher;
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
-    pub fn hash_or_noop<H: AlgebraicHasher<F>>(&mut self, inputs: Vec<Target>) -> HashOutTarget
-    where
-        [(); H::Permutation::WIDTH]:,
-    {
+    pub fn hash_or_noop<H: AlgebraicHasher<F>>(&mut self, inputs: Vec<Target>) -> HashOutTarget {
         let zero = self.zero();
         if inputs.len() <= NUM_HASH_OUT_ELTS {
             HashOutTarget::from_partial(&inputs, zero)
@@ -27,10 +24,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn hash_n_to_hash_no_pad<H: AlgebraicHasher<F>>(
         &mut self,
         inputs: Vec<Target>,
-    ) -> HashOutTarget
-    where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) -> HashOutTarget {
         HashOutTarget::from_vec(self.hash_n_to_m_no_pad::<H>(inputs, NUM_HASH_OUT_ELTS))
     }
 
@@ -38,27 +32,24 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         &mut self,
         inputs: Vec<Target>,
         num_outputs: usize,
-    ) -> Vec<Target>
-    where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) -> Vec<Target> {
         let zero = self.zero();
-        let mut state = [zero; H::Permutation::WIDTH];
+        let mut state = H::AlgebraicPermutation::new(std::iter::repeat(zero));
 
         // Absorb all input chunks.
-        for input_chunk in inputs.chunks(H::Permutation::RATE) {
+        for input_chunk in inputs.chunks(H::AlgebraicPermutation::RATE) {
             // Overwrite the first r elements with the inputs. This differs from a standard sponge,
             // where we would xor or add in the inputs. This is a well-known variant, though,
             // sometimes called "overwrite mode".
-            state[..input_chunk.len()].copy_from_slice(input_chunk);
+            state.set_from_slice(input_chunk, 0);
             state = self.permute::<H>(state);
         }
 
         // Squeeze until we have the desired number of outputs.
         let mut outputs = Vec::with_capacity(num_outputs);
         loop {
-            for i in 0..H::Permutation::RATE {
-                outputs.push(state[i]);
+            for &s in state.squeeze() {
+                outputs.push(s);
                 if outputs.len() == num_outputs {
                     return outputs;
                 }
@@ -69,8 +60,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 /// Permutation that can be used in the sponge construction for an algebraic hash.
-pub trait PlonkyPermutation<F: Field>:
-    AsRef<[F]> + Clone + Debug + Default + Eq + Sync + Send
+pub trait PlonkyPermutation<T: Copy + Default>:
+    AsRef<[T]> + Copy + Debug + Default + Eq + Sync + Send
 {
     const RATE: usize;
     const WIDTH: usize;
@@ -78,29 +69,29 @@ pub trait PlonkyPermutation<F: Field>:
     /// Initialises internal state with values from `iter` until
     /// `iter` is exhausted or `Self::WIDTH` values have been
     /// received; remaining state (if any) initialised with
-    /// `F::default()`. To initialise remaining elements with a
+    /// `T::default()`. To initialise remaining elements with a
     /// different value, instead of your original `iter` pass
     /// `iter.chain(std::iter::repeat(F::from_canonical_u64(12345)))`
     /// or similar.
-    fn new<I: IntoIterator<Item = F>>(iter: I) -> Self;
+    fn new<I: IntoIterator<Item = T>>(iter: I) -> Self;
 
     /// Set idx-th state element to be `elt`. Panics if `idx >= WIDTH`.
-    fn set_elt(&mut self, elt: F, idx: usize);
+    fn set_elt(&mut self, elt: T, idx: usize);
 
     /// Set state element `i` to be `elts[i] for i =
     /// start_idx..start_idx + elts.len()`. Panics if `start_idx +
     /// elts.len() > WIDTH`.
-    fn set_from_iter<I: IntoIterator<Item = F>>(&mut self, elts: I, start_idx: usize);
+    fn set_from_iter<I: IntoIterator<Item = T>>(&mut self, elts: I, start_idx: usize);
 
     /// Same semantics as for `set_from_iter` but probably faster than
     /// just calling `set_from_iter(elts.iter())`.
-    fn set_from_slice(&mut self, elts: &[F], start_idx: usize);
+    fn set_from_slice(&mut self, elts: &[T], start_idx: usize);
 
     /// Apply permutation to internal state
     fn permute(&mut self);
 
     /// Return a slice of `RATE` elements
-    fn squeeze(&mut self) -> &[F];
+    fn squeeze(&self) -> &[T];
 }
 
 /// A one-way compression function which takes two ~256 bit inputs and returns a ~256 bit output.

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -79,8 +79,8 @@ pub trait PlonkyPermutation<T: Copy + Default>:
     fn set_elt(&mut self, elt: T, idx: usize);
 
     /// Set state element `i` to be `elts[i] for i =
-    /// start_idx..start_idx + elts.len()`. Panics if `start_idx +
-    /// elts.len() > WIDTH`.
+    /// start_idx..start_idx + n` where `n = min(elts.len(),
+    /// WIDTH-start_idx)`. Panics if `start_idx > WIDTH`.
     fn set_from_iter<I: IntoIterator<Item = T>>(&mut self, elts: I, start_idx: usize);
 
     /// Same semantics as for `set_from_iter` but probably faster than

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -8,7 +8,7 @@ use keccak_hash::keccak;
 
 use crate::hash::hash_types::{BytesHash, RichField};
 use crate::hash::hashing::PlonkyPermutation;
-use crate::plonk::config::{Hasher, KeccakHashConfig};
+use crate::plonk::config::Hasher;
 use crate::util::serialization::Write;
 
 pub const SPONGE_RATE: usize = 8;
@@ -21,6 +21,9 @@ pub const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 pub struct KeccakPermutation;
 
 impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation {
+    const RATE: usize = SPONGE_RATE;
+    const WIDTH: usize = SPONGE_WIDTH;
+
     type State = [F; SPONGE_WIDTH];
 
     fn permute(input: Self::State) -> Self::State {
@@ -60,7 +63,7 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation {
 /// Keccak-256 hash function.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct KeccakHash<const N: usize>;
-impl<F: RichField, const N: usize> Hasher<F, KeccakHashConfig> for KeccakHash<N> {
+impl<F: RichField, const N: usize> Hasher<F> for KeccakHash<N> {
     const HASH_SIZE: usize = N;
     type Hash = BytesHash<N>;
     type Permutation = KeccakPermutation;

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -19,11 +19,11 @@ pub const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 /// A state `input: [F; 12]` is sent to the field representation of `H(input) || H(H(input)) || H(H(H(input)))`
 /// where `H` is the Keccak-256 hash.
 pub struct KeccakPermutation;
-impl<F: RichField> PlonkyPermutation<F, KeccakHashConfig> for KeccakPermutation {
-    fn permute(input: [F; SPONGE_WIDTH]) -> [F; SPONGE_WIDTH]
-    where
-        [(); SPONGE_WIDTH]:,
-    {
+
+impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation {
+    type State = [F; SPONGE_WIDTH];
+
+    fn permute(input: Self::State) -> Self::State {
         let mut state = vec![0u8; SPONGE_WIDTH * size_of::<u64>()];
         for i in 0..SPONGE_WIDTH {
             state[i * size_of::<u64>()..(i + 1) * size_of::<u64>()]

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -18,7 +18,7 @@ pub const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 /// Keccak-256 pseudo-permutation (not necessarily one-to-one) used in the challenger.
 /// A state `input: [F; 12]` is sent to the field representation of `H(input) || H(H(input)) || H(H(H(input)))`
 /// where `H` is the Keccak-256 hash.
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Copy, Clone, Default, Debug, PartialEq)]
 pub struct KeccakPermutation<F: RichField> {
     state: [F; SPONGE_WIDTH],
 }
@@ -94,7 +94,7 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation<F> {
             .unwrap();
     }
 
-    fn squeeze(&mut self) -> &[F] {
+    fn squeeze(&self) -> &[F] {
         &self.state[..Self::RATE]
     }
 }

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField, NUM_HASH_OUT_ELTS};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
@@ -16,12 +16,12 @@ use crate::plonk::config::{AlgebraicHasher, Hasher};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(bound = "")]
-pub struct MerkleProof<F: RichField, HC: HashConfig, H: Hasher<F, HC>> {
+pub struct MerkleProof<F: RichField, H: Hasher<F>> {
     /// The Merkle digest of each sibling subtree, staying from the bottommost layer.
     pub siblings: Vec<H::Hash>,
 }
 
-impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleProof<F, HC, H> {
+impl<F: RichField, H: Hasher<F>> MerkleProof<F, H> {
     pub fn len(&self) -> usize {
         self.siblings.len()
     }
@@ -39,11 +39,11 @@ pub struct MerkleProofTarget {
 
 /// Verifies that the given leaf data is present at the given index in the Merkle tree with the
 /// given root.
-pub fn verify_merkle_proof<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+pub fn verify_merkle_proof<F: RichField, H: Hasher<F>>(
     leaf_data: Vec<F>,
     leaf_index: usize,
     merkle_root: H::Hash,
-    proof: &MerkleProof<F, HC, H>,
+    proof: &MerkleProof<F, H>,
 ) -> Result<()> {
     let merkle_cap = MerkleCap(vec![merkle_root]);
     verify_merkle_proof_to_cap(leaf_data, leaf_index, &merkle_cap, proof)
@@ -51,11 +51,11 @@ pub fn verify_merkle_proof<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
 
 /// Verifies that the given leaf data is present at the given index in the Merkle tree with the
 /// given cap.
-pub fn verify_merkle_proof_to_cap<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+pub fn verify_merkle_proof_to_cap<F: RichField, H: Hasher<F>>(
     leaf_data: Vec<F>,
     leaf_index: usize,
-    merkle_cap: &MerkleCap<F, HC, H>,
-    proof: &MerkleProof<F, HC, H>,
+    merkle_cap: &MerkleCap<F, H>,
+    proof: &MerkleProof<F, H>,
 ) -> Result<()> {
     let mut index = leaf_index;
     let mut current_digest = H::hash_or_noop(&leaf_data);
@@ -79,32 +79,32 @@ pub fn verify_merkle_proof_to_cap<F: RichField, HC: HashConfig, H: Hasher<F, HC>
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Verifies that the given leaf data is present at the given index in the Merkle tree with the
     /// given root. The index is given by its little-endian bits.
-    pub fn verify_merkle_proof<HC: HashConfig, H: AlgebraicHasher<F, HC>>(
+    pub fn verify_merkle_proof<H: AlgebraicHasher<F>>(
         &mut self,
         leaf_data: Vec<Target>,
         leaf_index_bits: &[BoolTarget],
         merkle_root: HashOutTarget,
         proof: &MerkleProofTarget,
     ) where
-        [(); HC::WIDTH]:,
+        [(); H::Permutation::WIDTH]:,
     {
         let merkle_cap = MerkleCapTarget(vec![merkle_root]);
-        self.verify_merkle_proof_to_cap::<HC, H>(leaf_data, leaf_index_bits, &merkle_cap, proof);
+        self.verify_merkle_proof_to_cap::<H>(leaf_data, leaf_index_bits, &merkle_cap, proof);
     }
 
     /// Verifies that the given leaf data is present at the given index in the Merkle tree with the
     /// given cap. The index is given by its little-endian bits.
-    pub fn verify_merkle_proof_to_cap<HC: HashConfig, H: AlgebraicHasher<F, HC>>(
+    pub fn verify_merkle_proof_to_cap<H: AlgebraicHasher<F>>(
         &mut self,
         leaf_data: Vec<Target>,
         leaf_index_bits: &[BoolTarget],
         merkle_cap: &MerkleCapTarget,
         proof: &MerkleProofTarget,
     ) where
-        [(); HC::WIDTH]:,
+        [(); H::Permutation::WIDTH]:,
     {
         let cap_index = self.le_sum(leaf_index_bits[proof.siblings.len()..].iter().copied());
-        self.verify_merkle_proof_to_cap_with_cap_index::<HC, H>(
+        self.verify_merkle_proof_to_cap_with_cap_index::<H>(
             leaf_data,
             leaf_index_bits,
             cap_index,
@@ -115,10 +115,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     /// Same as `verify_merkle_proof_to_cap`, except with the final "cap index" as separate parameter,
     /// rather than being contained in `leaf_index_bits`.
-    pub(crate) fn verify_merkle_proof_to_cap_with_cap_index<
-        HC: HashConfig,
-        H: AlgebraicHasher<F, HC>,
-    >(
+    pub(crate) fn verify_merkle_proof_to_cap_with_cap_index<H: AlgebraicHasher<F>>(
         &mut self,
         leaf_data: Vec<Target>,
         leaf_index_bits: &[BoolTarget],
@@ -126,17 +123,17 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         merkle_cap: &MerkleCapTarget,
         proof: &MerkleProofTarget,
     ) where
-        [(); HC::WIDTH]:,
+        [(); H::Permutation::WIDTH]:,
     {
         let zero = self.zero();
-        let mut state: HashOutTarget = self.hash_or_noop::<HC, H>(leaf_data);
+        let mut state: HashOutTarget = self.hash_or_noop::<H>(leaf_data);
 
         for (&bit, &sibling) in leaf_index_bits.iter().zip(&proof.siblings) {
-            let mut perm_inputs = [zero; HC::WIDTH];
+            let mut perm_inputs = [zero; H::Permutation::WIDTH];
             perm_inputs[..NUM_HASH_OUT_ELTS].copy_from_slice(&state.elements);
             perm_inputs[NUM_HASH_OUT_ELTS..2 * NUM_HASH_OUT_ELTS]
                 .copy_from_slice(&sibling.elements);
-            let perm_outs = self.permute_swapped::<HC, H>(perm_inputs, bit);
+            let perm_outs = self.permute_swapped::<H>(perm_inputs, bit);
             let hash_outs = perm_outs[0..NUM_HASH_OUT_ELTS].try_into().unwrap();
             state = HashOutTarget {
                 elements: hash_outs,
@@ -202,10 +199,7 @@ mod tests {
         let n = 1 << log_n;
         let cap_height = 1;
         let leaves = random_data::<F>(n, 7);
-        let tree =
-            MerkleTree::<F, <C as GenericConfig<D>>::HCO, <C as GenericConfig<D>>::Hasher>::new(
-                leaves, cap_height,
-            );
+        let tree = MerkleTree::<F, <C as GenericConfig<D>>::Hasher>::new(leaves, cap_height);
         let i: usize = OsRng.gen_range(0..n);
         let proof = tree.prove(i);
 
@@ -227,7 +221,7 @@ mod tests {
             pw.set_target(data[j], tree.leaves[i][j]);
         }
 
-        builder.verify_merkle_proof_to_cap::<<C as GenericConfig<D>>::HCI, <C as GenericConfig<D>>::InnerHasher>(
+        builder.verify_merkle_proof_to_cap::<<C as GenericConfig<D>>::InnerHasher>(
             data, &i_bits, &cap_t, &proof_t,
         );
 

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -122,19 +122,25 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         cap_index: Target,
         merkle_cap: &MerkleCapTarget,
         proof: &MerkleProofTarget,
-    ) where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) {
+        debug_assert!(H::AlgebraicPermutation::RATE >= NUM_HASH_OUT_ELTS);
+
         let zero = self.zero();
         let mut state: HashOutTarget = self.hash_or_noop::<H>(leaf_data);
+        debug_assert_eq!(state.elements.len(), NUM_HASH_OUT_ELTS);
 
         for (&bit, &sibling) in leaf_index_bits.iter().zip(&proof.siblings) {
-            let mut perm_inputs = [zero; H::Permutation::WIDTH];
-            perm_inputs[..NUM_HASH_OUT_ELTS].copy_from_slice(&state.elements);
-            perm_inputs[NUM_HASH_OUT_ELTS..2 * NUM_HASH_OUT_ELTS]
-                .copy_from_slice(&sibling.elements);
+            debug_assert_eq!(sibling.elements.len(), NUM_HASH_OUT_ELTS);
+
+            let mut perm_inputs = H::AlgebraicPermutation::default();
+            perm_inputs.set_from_slice(&state.elements, 0);
+            perm_inputs.set_from_slice(&sibling.elements, NUM_HASH_OUT_ELTS);
+            // Ensure the rest of the state, if any, is zero:
+            perm_inputs.set_from_iter(std::iter::repeat(zero), 2 * NUM_HASH_OUT_ELTS);
             let perm_outs = self.permute_swapped::<H>(perm_inputs, bit);
-            let hash_outs = perm_outs[0..NUM_HASH_OUT_ELTS].try_into().unwrap();
+            let hash_outs = perm_outs.squeeze()[0..NUM_HASH_OUT_ELTS]
+                .try_into()
+                .unwrap();
             state = HashOutTarget {
                 elements: hash_outs,
             };

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -85,9 +85,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         leaf_index_bits: &[BoolTarget],
         merkle_root: HashOutTarget,
         proof: &MerkleProofTarget,
-    ) where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) {
         let merkle_cap = MerkleCapTarget(vec![merkle_root]);
         self.verify_merkle_proof_to_cap::<H>(leaf_data, leaf_index_bits, &merkle_cap, proof);
     }
@@ -100,9 +98,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         leaf_index_bits: &[BoolTarget],
         merkle_cap: &MerkleCapTarget,
         proof: &MerkleProofTarget,
-    ) where
-        [(); H::Permutation::WIDTH]:,
-    {
+    ) {
         let cap_index = self.le_sum(leaf_index_bits[proof.siblings.len()..].iter().copied());
         self.verify_merkle_proof_to_cap_with_cap_index::<H>(
             leaf_data,

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -44,10 +44,7 @@ pub fn verify_merkle_proof<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     leaf_index: usize,
     merkle_root: H::Hash,
     proof: &MerkleProof<F, HC, H>,
-) -> Result<()>
-where
-    [(); HC::WIDTH]:,
-{
+) -> Result<()> {
     let merkle_cap = MerkleCap(vec![merkle_root]);
     verify_merkle_proof_to_cap(leaf_data, leaf_index, &merkle_cap, proof)
 }
@@ -59,10 +56,7 @@ pub fn verify_merkle_proof_to_cap<F: RichField, HC: HashConfig, H: Hasher<F, HC>
     leaf_index: usize,
     merkle_cap: &MerkleCap<F, HC, H>,
     proof: &MerkleProof<F, HC, H>,
-) -> Result<()>
-where
-    [(); HC::WIDTH]:,
-{
+) -> Result<()> {
     let mut index = leaf_index;
     let mut current_digest = H::hash_or_noop(&leaf_data);
     for &sibling_digest in proof.siblings.iter() {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -6,7 +6,6 @@ use plonky2_maybe_rayon::*;
 use serde::{Deserialize, Serialize};
 
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::{GenericHashOut, Hasher};
 use crate::util::log2_strict;
@@ -16,9 +15,9 @@ use crate::util::log2_strict;
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(bound = "")]
 // TODO: Change H to GenericHashOut<F>, since this only cares about the hash, not the hasher.
-pub struct MerkleCap<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(pub Vec<H::Hash>);
+pub struct MerkleCap<F: RichField, H: Hasher<F>>(pub Vec<H::Hash>);
 
-impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleCap<F, HC, H> {
+impl<F: RichField, H: Hasher<F>> MerkleCap<F, H> {
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -37,7 +36,7 @@ impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleCap<F, HC, H> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MerkleTree<F: RichField, HC: HashConfig, H: Hasher<F, HC>> {
+pub struct MerkleTree<F: RichField, H: Hasher<F>> {
     /// The data in the leaves of the Merkle tree.
     pub leaves: Vec<Vec<F>>,
 
@@ -52,7 +51,7 @@ pub struct MerkleTree<F: RichField, HC: HashConfig, H: Hasher<F, HC>> {
     pub digests: Vec<H::Hash>,
 
     /// The Merkle cap.
-    pub cap: MerkleCap<F, HC, H>,
+    pub cap: MerkleCap<F, H>,
 }
 
 fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {
@@ -67,7 +66,7 @@ fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {
     }
 }
 
-fn fill_subtree<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+fn fill_subtree<F: RichField, H: Hasher<F>>(
     digests_buf: &mut [MaybeUninit<H::Hash>],
     leaves: &[Vec<F>],
 ) -> H::Hash {
@@ -86,8 +85,8 @@ fn fill_subtree<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
         let (left_leaves, right_leaves) = leaves.split_at(leaves.len() / 2);
 
         let (left_digest, right_digest) = plonky2_maybe_rayon::join(
-            || fill_subtree::<F, HC, H>(left_digests_buf, left_leaves),
-            || fill_subtree::<F, HC, H>(right_digests_buf, right_leaves),
+            || fill_subtree::<F, H>(left_digests_buf, left_leaves),
+            || fill_subtree::<F, H>(right_digests_buf, right_leaves),
         );
 
         left_digest_mem.write(left_digest);
@@ -96,7 +95,7 @@ fn fill_subtree<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     }
 }
 
-fn fill_digests_buf<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+fn fill_digests_buf<F: RichField, H: Hasher<F>>(
     digests_buf: &mut [MaybeUninit<H::Hash>],
     cap_buf: &mut [MaybeUninit<H::Hash>],
     leaves: &[Vec<F>],
@@ -127,12 +126,12 @@ fn fill_digests_buf<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
             // We have `1 << cap_height` sub-trees, one for each entry in `cap`. They are totally
             // independent, so we schedule one task for each. `digests_buf` and `leaves` are split
             // into `1 << cap_height` slices, one for each sub-tree.
-            subtree_cap.write(fill_subtree::<F, HC, H>(subtree_digests, subtree_leaves));
+            subtree_cap.write(fill_subtree::<F, H>(subtree_digests, subtree_leaves));
         },
     );
 }
 
-impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleTree<F, HC, H> {
+impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
     pub fn new(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
         let log2_leaves_len = log2_strict(leaves.len());
         assert!(
@@ -150,7 +149,7 @@ impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleTree<F, HC, H> {
 
         let digests_buf = capacity_up_to_mut(&mut digests, num_digests);
         let cap_buf = capacity_up_to_mut(&mut cap, len_cap);
-        fill_digests_buf::<F, HC, H>(digests_buf, cap_buf, &leaves[..], cap_height);
+        fill_digests_buf::<F, H>(digests_buf, cap_buf, &leaves[..], cap_height);
 
         unsafe {
             // SAFETY: `fill_digests_buf` and `cap` initialized the spare capacity up to
@@ -171,7 +170,7 @@ impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleTree<F, HC, H> {
     }
 
     /// Create a Merkle proof from a leaf index.
-    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, HC, H> {
+    pub fn prove(&self, leaf_index: usize) -> MerkleProof<F, H> {
         let cap_height = log2_strict(self.cap.len());
         let num_layers = log2_strict(self.leaves.len()) - cap_height;
         debug_assert_eq!(leaf_index >> (cap_height + num_layers), 0);
@@ -221,14 +220,15 @@ mod tests {
         (0..n).map(|_| F::rand_vec(k)).collect()
     }
 
-    fn verify_all_leaves<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    fn verify_all_leaves<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+    >(
         leaves: Vec<Vec<F>>,
         cap_height: usize,
-    ) -> Result<()>
-    where
-        [(); C::HCO::WIDTH]:,
-    {
-        let tree = MerkleTree::<F, C::HCO, C::Hasher>::new(leaves.clone(), cap_height);
+    ) -> Result<()> {
+        let tree = MerkleTree::<F, C::Hasher>::new(leaves.clone(), cap_height);
         for (i, leaf) in leaves.into_iter().enumerate() {
             let proof = tree.prove(i);
             verify_merkle_proof_to_cap(leaf, i, &tree.cap, &proof)?;
@@ -247,9 +247,7 @@ mod tests {
         let cap_height = log_n + 1; // Should panic if `cap_height > len_n`.
 
         let leaves = random_data::<F>(1 << log_n, 7);
-        let _ = MerkleTree::<F, <C as GenericConfig<D>>::HCO, <C as GenericConfig<D>>::Hasher>::new(
-            leaves, cap_height,
-        );
+        let _ = MerkleTree::<F, <C as GenericConfig<D>>::Hasher>::new(leaves, cap_height);
     }
 
     #[test]

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -70,10 +70,7 @@ fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {
 fn fill_subtree<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     digests_buf: &mut [MaybeUninit<H::Hash>],
     leaves: &[Vec<F>],
-) -> H::Hash
-where
-    [(); HC::WIDTH]:,
-{
+) -> H::Hash {
     assert_eq!(leaves.len(), digests_buf.len() / 2 + 1);
     if digests_buf.is_empty() {
         H::hash_or_noop(&leaves[0])
@@ -104,9 +101,7 @@ fn fill_digests_buf<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     cap_buf: &mut [MaybeUninit<H::Hash>],
     leaves: &[Vec<F>],
     cap_height: usize,
-) where
-    [(); HC::WIDTH]:,
-{
+) {
     // Special case of a tree that's all cap. The usual case will panic because we'll try to split
     // an empty slice into chunks of `0`. (We would not need this if there was a way to split into
     // `blah` chunks as opposed to chunks _of_ `blah`.)
@@ -137,10 +132,7 @@ fn fill_digests_buf<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
     );
 }
 
-impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleTree<F, HC, H>
-where
-    [(); HC::WIDTH]:,
-{
+impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> MerkleTree<F, HC, H> {
     pub fn new(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
         let log2_leaves_len = log2_strict(leaves.len());
         assert!(

--- a/plonky2/src/hash/path_compression.rs
+++ b/plonky2/src/hash/path_compression.rs
@@ -5,7 +5,6 @@ use hashbrown::HashMap;
 use num::Integer;
 
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::Hasher;
 
@@ -60,10 +59,7 @@ pub(crate) fn decompress_merkle_proofs<F: RichField, H: Hasher<F>>(
     compressed_proofs: &[MerkleProof<F, H>],
     height: usize,
     cap_height: usize,
-) -> Vec<MerkleProof<F, H>>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> Vec<MerkleProof<F, H>> {
     let num_leaves = 1 << height;
     let compressed_proofs = compressed_proofs.to_vec();
     let mut decompressed_proofs = Vec::with_capacity(compressed_proofs.len());

--- a/plonky2/src/hash/path_compression.rs
+++ b/plonky2/src/hash/path_compression.rs
@@ -5,16 +5,16 @@ use hashbrown::HashMap;
 use num::Integer;
 
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::Hasher;
 
 /// Compress multiple Merkle proofs on the same tree by removing redundancy in the Merkle paths.
-pub(crate) fn compress_merkle_proofs<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+pub(crate) fn compress_merkle_proofs<F: RichField, H: Hasher<F>>(
     cap_height: usize,
     indices: &[usize],
-    proofs: &[MerkleProof<F, HC, H>],
-) -> Vec<MerkleProof<F, HC, H>> {
+    proofs: &[MerkleProof<F, H>],
+) -> Vec<MerkleProof<F, H>> {
     assert!(!proofs.is_empty());
     let height = cap_height + proofs[0].siblings.len();
     let num_leaves = 1 << height;
@@ -54,15 +54,15 @@ pub(crate) fn compress_merkle_proofs<F: RichField, HC: HashConfig, H: Hasher<F, 
 
 /// Decompress compressed Merkle proofs.
 /// Note: The data and indices must be in the same order as in `compress_merkle_proofs`.
-pub(crate) fn decompress_merkle_proofs<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
+pub(crate) fn decompress_merkle_proofs<F: RichField, H: Hasher<F>>(
     leaves_data: &[Vec<F>],
     leaves_indices: &[usize],
-    compressed_proofs: &[MerkleProof<F, HC, H>],
+    compressed_proofs: &[MerkleProof<F, H>],
     height: usize,
     cap_height: usize,
-) -> Vec<MerkleProof<F, HC, H>>
+) -> Vec<MerkleProof<F, H>>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let num_leaves = 1 << height;
     let compressed_proofs = compressed_proofs.to_vec();
@@ -134,11 +134,7 @@ mod tests {
         let h = 10;
         let cap_height = 3;
         let vs = (0..1 << h).map(|_| vec![F::rand()]).collect::<Vec<_>>();
-        let mt =
-            MerkleTree::<F, <C as GenericConfig<D>>::HCO, <C as GenericConfig<D>>::Hasher>::new(
-                vs.clone(),
-                cap_height,
-            );
+        let mt = MerkleTree::<F, <C as GenericConfig<D>>::Hasher>::new(vs.clone(), cap_height);
 
         let mut rng = OsRng;
         let k = rng.gen_range(1..=1 << h);

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -633,8 +633,11 @@ pub trait Poseidon: PrimeField64 {
 }
 
 pub struct PoseidonPermutation;
-impl<F: RichField> PlonkyPermutation<F, PoseidonHashConfig> for PoseidonPermutation {
-    fn permute(input: [F; SPONGE_WIDTH]) -> [F; SPONGE_WIDTH] {
+
+impl<F: RichField> PlonkyPermutation<F> for PoseidonPermutation {
+    type State = [F; SPONGE_WIDTH];
+
+    fn permute(input: Self::State) -> Self::State {
         F::poseidon(input)
     }
 }
@@ -652,7 +655,7 @@ impl<F: RichField> Hasher<F, PoseidonHashConfig> for PoseidonHash {
     }
 
     fn two_to_one(left: Self::Hash, right: Self::Hash) -> Self::Hash {
-        compress::<F, PoseidonHashConfig, Self::Permutation>(left, right)
+        compress::<F, Self::Permutation>(left, right)
     }
 }
 

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -160,10 +160,7 @@ impl<F: RichField, HC: HashConfig, H: Hasher<F, HC>> Challenger<F, HC, H> {
     }
 }
 
-impl<F: RichField, HC: HashConfig, H: AlgebraicHasher<F, HC>> Default for Challenger<F, HC, H>
-where
-    [(); HC::WIDTH]:,
-{
+impl<F: RichField, HC: HashConfig, H: AlgebraicHasher<F, HC>> Default for Challenger<F, HC, H> {
     fn default() -> Self {
         Self::new()
     }

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -148,7 +148,7 @@ impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
             self.duplexing();
         }
         self.output_buffer.clear();
-        self.sponge_state.clone()
+        self.sponge_state
     }
 }
 
@@ -287,7 +287,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
     pub fn compact(&mut self, builder: &mut CircuitBuilder<F, D>) -> H::AlgebraicPermutation {
         self.absorb_buffered_inputs(builder);
         self.output_buffer.clear();
-        self.sponge_state.clone()
+        self.sponge_state
     }
 }
 

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use hashbrown::HashMap;
-use itertools::Itertools;
+use itertools::{zip_eq, Itertools};
 
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::field::types::Field;
@@ -43,14 +43,11 @@ pub trait WitnessWrite<F: Field> {
     where
         F: RichField + Extendable<D>,
     {
-        self.set_target_arr(et.0, &value.to_basefield_array());
+        self.set_target_arr(&et.0, &value.to_basefield_array());
     }
 
-    fn set_target_arr<const N: usize>(&mut self, targets: [Target; N], values: &[F]) {
-        assert_eq!(values.len(), N);
-        (0..N).for_each(|i| {
-            self.set_target(targets[i], values[i]);
-        });
+    fn set_target_arr(&mut self, targets: &[Target], values: &[F]) {
+        zip_eq(targets, values).for_each(|(&target, &value)| self.set_target(target, value));
     }
 
     fn set_extension_targets<const D: usize>(

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -9,7 +9,6 @@ use crate::field::types::Field;
 use crate::fri::structure::{FriOpenings, FriOpeningsTarget};
 use crate::fri::witness_util::set_fri_proof_target;
 use crate::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::HashConfig;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::target::{BoolTarget, Target};
@@ -28,10 +27,10 @@ pub trait WitnessWrite<F: Field> {
             .for_each(|(&t, x)| self.set_target(t, x));
     }
 
-    fn set_cap_target<HC: HashConfig, H: AlgebraicHasher<F, HC>>(
+    fn set_cap_target<H: AlgebraicHasher<F>>(
         &mut self,
         ct: &MerkleCapTarget,
-        value: &MerkleCap<F, HC, H>,
+        value: &MerkleCap<F, H>,
     ) where
         F: RichField,
     {
@@ -79,7 +78,7 @@ pub trait WitnessWrite<F: Field> {
         proof_with_pis: &ProofWithPublicInputs<F, C, D>,
     ) where
         F: RichField + Extendable<D>,
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
+        C::Hasher: AlgebraicHasher<F>,
     {
         let ProofWithPublicInputs {
             proof,
@@ -105,7 +104,7 @@ pub trait WitnessWrite<F: Field> {
         proof: &Proof<F, C, D>,
     ) where
         F: RichField + Extendable<D>,
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
+        C::Hasher: AlgebraicHasher<F>,
     {
         self.set_cap_target(&proof_target.wires_cap, &proof.wires_cap);
         self.set_cap_target(
@@ -144,7 +143,7 @@ pub trait WitnessWrite<F: Field> {
         vd: &VerifierOnlyCircuitData<C, D>,
     ) where
         F: RichField + Extendable<D>,
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
+        C::Hasher: AlgebraicHasher<F>,
     {
         self.set_cap_target(&vdt.constants_sigmas_cap, &vd.constants_sigmas_cap);
         self.set_hash_target(vdt.circuit_digest, vd.circuit_digest);
@@ -226,14 +225,10 @@ pub trait Witness<F: Field>: WitnessWrite<F> {
         }
     }
 
-    fn get_merkle_cap_target<HC, H: Hasher<F, HC>>(
-        &self,
-        cap_target: MerkleCapTarget,
-    ) -> MerkleCap<F, HC, H>
+    fn get_merkle_cap_target<H: Hasher<F>>(&self, cap_target: MerkleCapTarget) -> MerkleCap<F, H>
     where
         F: RichField,
-        HC: HashConfig,
-        H: AlgebraicHasher<F, HC>,
+        H: AlgebraicHasher<F>,
     {
         let cap = cap_target
             .0

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -44,10 +44,11 @@ pub trait WitnessWrite<F: Field> {
     where
         F: RichField + Extendable<D>,
     {
-        self.set_target_arr(et.0, value.to_basefield_array());
+        self.set_target_arr(et.0, &value.to_basefield_array());
     }
 
-    fn set_target_arr<const N: usize>(&mut self, targets: [Target; N], values: [F; N]) {
+    fn set_target_arr<const N: usize>(&mut self, targets: [Target; N], values: &[F]) {
+        assert_eq!(values.len(), N);
         (0..N).for_each(|i| {
             self.set_target(targets[i], values[i]);
         });

--- a/plonky2/src/lib.rs
+++ b/plonky2/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::upper_case_acronyms)]
-#![allow(incomplete_features)]
-#![feature(generic_const_exprs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -27,7 +27,7 @@ use crate::gates::noop::NoopGate;
 use crate::gates::public_input::PublicInputGate;
 use crate::gates::selectors::selector_polynomials;
 use crate::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProofTarget;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::ext_target::ExtensionTarget;
@@ -435,9 +435,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
 
-    pub fn constant_merkle_cap<HC: HashConfig, H: Hasher<F, HC, Hash = HashOut<F>>>(
+    pub fn constant_merkle_cap<H: Hasher<F, Hash = HashOut<F>>>(
         &mut self,
-        cap: &MerkleCap<F, HC, H>,
+        cap: &MerkleCap<F, H>,
     ) -> MerkleCapTarget {
         MerkleCapTarget(cap.0.iter().map(|h| self.constant_hash(*h)).collect())
     }
@@ -447,7 +447,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         verifier_data: &VerifierOnlyCircuitData<C, D>,
     ) -> VerifierCircuitTarget
     where
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
+        C::Hasher: AlgebraicHasher<F>,
     {
         VerifierCircuitTarget {
             constants_sigmas_cap: self.constant_merkle_cap(&verifier_data.constants_sigmas_cap),
@@ -740,8 +740,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Builds a "full circuit", with both prover and verifier data.
     pub fn build<C: GenericConfig<D, F = F>>(mut self) -> CircuitData<F, C, D>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let mut timing = TimingTree::new("preprocess", Level::Trace);
         #[cfg(feature = "std")]
@@ -753,7 +753,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         // those hash wires match the claimed public inputs.
         let num_public_inputs = self.public_inputs.len();
         let public_inputs_hash =
-            self.hash_n_to_hash_no_pad::<C::HCI, C::InnerHasher>(self.public_inputs.clone());
+            self.hash_n_to_hash_no_pad::<C::InnerHasher>(self.public_inputs.clone());
         let pi_gate = self.add_gate(PublicInputGate, vec![]);
         for (&hash_part, wire) in public_inputs_hash
             .elements
@@ -948,8 +948,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Builds a "prover circuit", with data needed to generate proofs but not verify them.
     pub fn build_prover<C: GenericConfig<D, F = F>>(self) -> ProverCircuitData<F, C, D>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();
@@ -959,8 +959,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Builds a "verifier circuit", with data needed to verify proofs but not generate them.
     pub fn build_verifier<C: GenericConfig<D, F = F>>(self) -> VerifierCircuitData<F, C, D>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -738,11 +738,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// Builds a "full circuit", with both prover and verifier data.
-    pub fn build<C: GenericConfig<D, F = F>>(mut self) -> CircuitData<F, C, D>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn build<C: GenericConfig<D, F = F>>(mut self) -> CircuitData<F, C, D> {
         let mut timing = TimingTree::new("preprocess", Level::Trace);
         #[cfg(feature = "std")]
         let start = Instant::now();

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -27,7 +27,6 @@ use crate::gates::noop::NoopGate;
 use crate::gates::public_input::PublicInputGate;
 use crate::gates::selectors::selector_polynomials;
 use crate::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProofTarget;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::ext_target::ExtensionTarget;
@@ -942,22 +941,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// Builds a "prover circuit", with data needed to generate proofs but not verify them.
-    pub fn build_prover<C: GenericConfig<D, F = F>>(self) -> ProverCircuitData<F, C, D>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn build_prover<C: GenericConfig<D, F = F>>(self) -> ProverCircuitData<F, C, D> {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();
         circuit_data.prover_data()
     }
 
     /// Builds a "verifier circuit", with data needed to verify proofs but not generate them.
-    pub fn build_verifier<C: GenericConfig<D, F = F>>(self) -> VerifierCircuitData<F, C, D>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn build_verifier<C: GenericConfig<D, F = F>>(self) -> VerifierCircuitData<F, C, D> {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();
         circuit_data.verifier_data()

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -19,7 +19,6 @@ use crate::fri::{FriConfig, FriParams};
 use crate::gates::gate::GateRef;
 use crate::gates::selectors::SelectorsInfo;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::generator::WitnessGeneratorRef;
@@ -139,11 +138,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         buffer.read_circuit_data(gate_serializer, generator_serializer)
     }
 
-    pub fn prove(&self, inputs: PartialWitness<F>) -> Result<ProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn prove(&self, inputs: PartialWitness<F>) -> Result<ProofWithPublicInputs<F, C, D>> {
         prove::<F, C, D>(
             &self.prover_only,
             &self.common,
@@ -152,44 +147,28 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         )
     }
 
-    pub fn verify(&self, proof_with_pis: ProofWithPublicInputs<F, C, D>) -> Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn verify(&self, proof_with_pis: ProofWithPublicInputs<F, C, D>) -> Result<()> {
         verify::<F, C, D>(proof_with_pis, &self.verifier_only, &self.common)
     }
 
     pub fn verify_compressed(
         &self,
         compressed_proof_with_pis: CompressedProofWithPublicInputs<F, C, D>,
-    ) -> Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<()> {
         compressed_proof_with_pis.verify(&self.verifier_only, &self.common)
     }
 
     pub fn compress(
         &self,
         proof: ProofWithPublicInputs<F, C, D>,
-    ) -> Result<CompressedProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<CompressedProofWithPublicInputs<F, C, D>> {
         proof.compress(&self.verifier_only.circuit_digest, &self.common)
     }
 
     pub fn decompress(
         &self,
         proof: CompressedProofWithPublicInputs<F, C, D>,
-    ) -> Result<ProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
         proof.decompress(&self.verifier_only.circuit_digest, &self.common)
     }
 
@@ -256,11 +235,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         buffer.read_prover_circuit_data(gate_serializer, generator_serializer)
     }
 
-    pub fn prove(&self, inputs: PartialWitness<F>) -> Result<ProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn prove(&self, inputs: PartialWitness<F>) -> Result<ProofWithPublicInputs<F, C, D>> {
         prove::<F, C, D>(
             &self.prover_only,
             &self.common,
@@ -298,22 +273,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         buffer.read_verifier_circuit_data(gate_serializer)
     }
 
-    pub fn verify(&self, proof_with_pis: ProofWithPublicInputs<F, C, D>) -> Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    pub fn verify(&self, proof_with_pis: ProofWithPublicInputs<F, C, D>) -> Result<()> {
         verify::<F, C, D>(proof_with_pis, &self.verifier_only, &self.common)
     }
 
     pub fn verify_compressed(
         &self,
         compressed_proof_with_pis: CompressedProofWithPublicInputs<F, C, D>,
-    ) -> Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<()> {
         compressed_proof_with_pis.verify(&self.verifier_only, &self.common)
     }
 }

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -25,7 +25,7 @@ pub trait GenericHashOut<F: RichField>:
 }
 
 /// Trait for hash functions.
-pub trait Hasher<F: RichField>: Sized + Clone + Debug + Eq + PartialEq {
+pub trait Hasher<F: RichField>: Sized + Copy + Debug + Eq + PartialEq {
     /// Size of `Hash` in bytes.
     const HASH_SIZE: usize;
 
@@ -70,15 +70,16 @@ pub trait Hasher<F: RichField>: Sized + Clone + Debug + Eq + PartialEq {
 
 /// Trait for algebraic hash functions, built from a permutation using the sponge construction.
 pub trait AlgebraicHasher<F: RichField>: Hasher<F, Hash = HashOut<F>> {
+    type AlgebraicPermutation: PlonkyPermutation<Target>;
+
     /// Circuit to conditionally swap two chunks of the inputs (useful in verifying Merkle proofs),
     /// then apply the permutation.
     fn permute_swapped<const D: usize>(
-        inputs: [Target; <Self as Hasher<F>>::Permutation::WIDTH],
+        inputs: Self::AlgebraicPermutation,
         swap: BoolTarget,
         builder: &mut CircuitBuilder<F, D>,
-    ) -> [Target; <Self as Hasher<F>>::Permutation::WIDTH]
+    ) -> Self::AlgebraicPermutation
     where
-        [(); <Self as Hasher<F>>::Permutation::WIDTH]:,
         F: RichField + Extendable<D>;
 }
 

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -37,15 +37,10 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
 
     /// Hash a message without any padding step. Note that this can enable length-extension attacks.
     /// However, it is still collision-resistant in cases where the input has a fixed length.
-    fn hash_no_pad(input: &[F]) -> Self::Hash
-    where
-        [(); HC::WIDTH]:;
+    fn hash_no_pad(input: &[F]) -> Self::Hash;
 
     /// Pad the message using the `pad10*1` rule, then hash it.
-    fn hash_pad(input: &[F]) -> Self::Hash
-    where
-        [(); HC::WIDTH]:,
-    {
+    fn hash_pad(input: &[F]) -> Self::Hash {
         let mut padded_input = input.to_vec();
         padded_input.push(F::ONE);
         while (padded_input.len() + 1) % HC::WIDTH != 0 {
@@ -57,10 +52,7 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
 
     /// Hash the slice if necessary to reduce its length to ~256 bits. If it already fits, this is a
     /// no-op.
-    fn hash_or_noop(inputs: &[F]) -> Self::Hash
-    where
-        [(); HC::WIDTH]:,
-    {
+    fn hash_or_noop(inputs: &[F]) -> Self::Hash {
         if inputs.len() * 8 <= Self::HASH_SIZE {
             let mut inputs_bytes = vec![0u8; Self::HASH_SIZE];
             for i in 0..inputs.len() {
@@ -73,9 +65,7 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
         }
     }
 
-    fn two_to_one(left: Self::Hash, right: Self::Hash) -> Self::Hash
-    where
-        [(); HC::WIDTH]:;
+    fn two_to_one(left: Self::Hash, right: Self::Hash) -> Self::Hash;
 }
 
 /// Trait for algebraic hash functions, built from a permutation using the sponge construction.

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -9,7 +9,7 @@ use crate::field::extension::quadratic::QuadraticExtension;
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::field::goldilocks_field::GoldilocksField;
 use crate::hash::hash_types::{HashOut, RichField};
-use crate::hash::hashing::{HashConfig, PlonkyPermutation};
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::keccak::KeccakHash;
 use crate::hash::poseidon::PoseidonHash;
 use crate::iop::target::{BoolTarget, Target};
@@ -25,7 +25,7 @@ pub trait GenericHashOut<F: RichField>:
 }
 
 /// Trait for hash functions.
-pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + PartialEq {
+pub trait Hasher<F: RichField>: Sized + Clone + Debug + Eq + PartialEq {
     /// Size of `Hash` in bytes.
     const HASH_SIZE: usize;
 
@@ -43,7 +43,7 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
     fn hash_pad(input: &[F]) -> Self::Hash {
         let mut padded_input = input.to_vec();
         padded_input.push(F::ONE);
-        while (padded_input.len() + 1) % HC::WIDTH != 0 {
+        while (padded_input.len() + 1) % Self::Permutation::WIDTH != 0 {
             padded_input.push(F::ZERO);
         }
         padded_input.push(F::ONE);
@@ -69,16 +69,16 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
 }
 
 /// Trait for algebraic hash functions, built from a permutation using the sponge construction.
-pub trait AlgebraicHasher<F: RichField, HC: HashConfig>: Hasher<F, HC, Hash = HashOut<F>> {
+pub trait AlgebraicHasher<F: RichField>: Hasher<F, Hash = HashOut<F>> {
     /// Circuit to conditionally swap two chunks of the inputs (useful in verifying Merkle proofs),
     /// then apply the permutation.
     fn permute_swapped<const D: usize>(
-        inputs: [Target; HC::WIDTH],
+        inputs: [Target; <Self as Hasher<F>>::Permutation::WIDTH],
         swap: BoolTarget,
         builder: &mut CircuitBuilder<F, D>,
-    ) -> [Target; HC::WIDTH]
+    ) -> [Target; <Self as Hasher<F>>::Permutation::WIDTH]
     where
-        [(); HC::WIDTH]:,
+        [(); <Self as Hasher<F>>::Permutation::WIDTH]:,
         F: RichField + Extendable<D>;
 }
 
@@ -90,48 +90,28 @@ pub trait GenericConfig<const D: usize>:
     type F: RichField + Extendable<D, Extension = Self::FE>;
     /// Field extension of degree D of the main field.
     type FE: FieldExtension<D, BaseField = Self::F>;
-    /// Hash configuration for this GenericConfig's `Hasher`.
-    type HCO: HashConfig;
-    /// Hash configuration for this GenericConfig's `InnerHasher`.
-    type HCI: HashConfig;
     /// Hash function used for building Merkle trees.
-    type Hasher: Hasher<Self::F, Self::HCO>;
+    type Hasher: Hasher<Self::F>;
     /// Algebraic hash function used for the challenger and hashing public inputs.
-    type InnerHasher: AlgebraicHasher<Self::F, Self::HCI>;
+    type InnerHasher: AlgebraicHasher<Self::F>;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PoseidonHashConfig;
-impl HashConfig for PoseidonHashConfig {
-    const RATE: usize = 8;
-    const WIDTH: usize = 12;
-}
 /// Configuration using Poseidon over the Goldilocks field.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
 pub struct PoseidonGoldilocksConfig;
 impl GenericConfig<2> for PoseidonGoldilocksConfig {
     type F = GoldilocksField;
     type FE = QuadraticExtension<Self::F>;
-    type HCO = PoseidonHashConfig;
-    type HCI = PoseidonHashConfig;
     type Hasher = PoseidonHash;
     type InnerHasher = PoseidonHash;
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct KeccakHashConfig;
-impl HashConfig for KeccakHashConfig {
-    const RATE: usize = 8;
-    const WIDTH: usize = 12;
-}
 /// Configuration using truncated Keccak over the Goldilocks field.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct KeccakGoldilocksConfig;
 impl GenericConfig<2> for KeccakGoldilocksConfig {
     type F = GoldilocksField;
     type FE = QuadraticExtension<Self::F>;
-    type HCO = KeccakHashConfig;
-    type HCI = PoseidonHashConfig;
     type Hasher = KeccakHash<25>;
     type InnerHasher = PoseidonHash;
 }

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -33,7 +33,7 @@ pub trait Hasher<F: RichField, HC: HashConfig>: Sized + Clone + Debug + Eq + Par
     type Hash: GenericHashOut<F>;
 
     /// Permutation used in the sponge construction.
-    type Permutation: PlonkyPermutation<F, HC>;
+    type Permutation: PlonkyPermutation<F>;
 
     /// Hash a message without any padding step. Note that this can enable length-extension attacks.
     /// However, it is still collision-resistant in cases where the input has a fixed length.

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -9,7 +9,6 @@ use crate::fri::proof::{CompressedFriProof, FriChallenges, FriProof, FriProofTar
 use crate::fri::verifier::{compute_evaluation, fri_combine_initial, PrecomputedReducedOpenings};
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::challenger::{Challenger, RecursiveChallenger};
 use crate::iop::target::Target;
@@ -130,11 +129,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<ProofChallenges<F, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<ProofChallenges<F, D>> {
         let CompressedProof {
             wires_cap,
             plonk_zs_partial_products_cap,
@@ -255,8 +250,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> ProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let config = &inner_common_data.config;
         let num_challenges = config.num_challenges;
@@ -305,8 +298,6 @@ impl<const D: usize> ProofWithPublicInputsTarget<D> {
     ) -> ProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let ProofTarget {
             wires_cap,

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -9,7 +9,7 @@ use crate::fri::proof::{CompressedFriProof, FriChallenges, FriProof, FriProofTar
 use crate::fri::verifier::{compute_evaluation, fri_combine_initial, PrecomputedReducedOpenings};
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::challenger::{Challenger, RecursiveChallenger};
 use crate::iop::target::Target;
@@ -24,38 +24,38 @@ use crate::plonk::proof::{
 use crate::util::reverse_bits;
 
 fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
-    public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F, C::HCI>>::Hash,
-    wires_cap: &MerkleCap<F, C::HCO, C::Hasher>,
-    plonk_zs_partial_products_cap: &MerkleCap<F, C::HCO, C::Hasher>,
-    quotient_polys_cap: &MerkleCap<F, C::HCO, C::Hasher>,
+    public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
+    wires_cap: &MerkleCap<F, C::Hasher>,
+    plonk_zs_partial_products_cap: &MerkleCap<F, C::Hasher>,
+    quotient_polys_cap: &MerkleCap<F, C::Hasher>,
     openings: &OpeningSet<F, D>,
-    commit_phase_merkle_caps: &[MerkleCap<F, C::HCO, C::Hasher>],
+    commit_phase_merkle_caps: &[MerkleCap<F, C::Hasher>],
     final_poly: &PolynomialCoeffs<F::Extension>,
     pow_witness: F,
-    circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F, C::HCO>>::Hash,
+    circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
     common_data: &CommonCircuitData<F, D>,
 ) -> anyhow::Result<ProofChallenges<F, D>>
 where
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let config = &common_data.config;
     let num_challenges = config.num_challenges;
 
-    let mut challenger = Challenger::<F, C::HCO, C::Hasher>::new();
+    let mut challenger = Challenger::<F, C::Hasher>::new();
 
     // Observe the instance.
-    challenger.observe_hash::<C::HCO, C::Hasher>(*circuit_digest);
-    challenger.observe_hash::<C::HCI, C::InnerHasher>(public_inputs_hash);
+    challenger.observe_hash::<C::Hasher>(*circuit_digest);
+    challenger.observe_hash::<C::InnerHasher>(public_inputs_hash);
 
-    challenger.observe_cap::<C::HCO, C::Hasher>(wires_cap);
+    challenger.observe_cap::<C::Hasher>(wires_cap);
     let plonk_betas = challenger.get_n_challenges(num_challenges);
     let plonk_gammas = challenger.get_n_challenges(num_challenges);
 
-    challenger.observe_cap::<C::HCO, C::Hasher>(plonk_zs_partial_products_cap);
+    challenger.observe_cap::<C::Hasher>(plonk_zs_partial_products_cap);
     let plonk_alphas = challenger.get_n_challenges(num_challenges);
 
-    challenger.observe_cap::<C::HCO, C::Hasher>(quotient_polys_cap);
+    challenger.observe_cap::<C::Hasher>(quotient_polys_cap);
     let plonk_zeta = challenger.get_extension_challenge::<D>();
 
     challenger.observe_openings(&openings.to_fri_openings());
@@ -80,12 +80,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 {
     pub(crate) fn fri_query_indices(
         &self,
-        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F, C::HCO>>::Hash,
+        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Vec<usize>>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         Ok(self
             .get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?
@@ -96,13 +96,13 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     /// Computes all Fiat-Shamir challenges used in the Plonk proof.
     pub fn get_challenges(
         &self,
-        public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F, C::HCI>>::Hash,
-        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F, C::HCO>>::Hash,
+        public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
+        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<ProofChallenges<F, D>>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let Proof {
             wires_cap,
@@ -139,13 +139,13 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     /// Computes all Fiat-Shamir challenges used in the Plonk proof.
     pub(crate) fn get_challenges(
         &self,
-        public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F, C::HCI>>::Hash,
-        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F, C::HCO>>::Hash,
+        public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
+        circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<ProofChallenges<F, D>>
     where
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let CompressedProof {
             wires_cap,
@@ -266,14 +266,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) -> ProofChallengesTarget<D>
     where
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        C::Hasher: AlgebraicHasher<F>,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let config = &inner_common_data.config;
         let num_challenges = config.num_challenges;
 
-        let mut challenger = RecursiveChallenger::<F, C::HCO, C::Hasher, D>::new(self);
+        let mut challenger = RecursiveChallenger::<F, C::Hasher, D>::new(self);
 
         // Observe the instance.
         challenger.observe_hash(&inner_circuit_digest);
@@ -316,9 +316,9 @@ impl<const D: usize> ProofWithPublicInputsTarget<D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) -> ProofChallengesTarget<D>
     where
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        C::Hasher: AlgebraicHasher<F>,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let ProofTarget {
             wires_cap,

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -34,11 +34,7 @@ fn get_challenges<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, cons
     pow_witness: F,
     circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
     common_data: &CommonCircuitData<F, D>,
-) -> anyhow::Result<ProofChallenges<F, D>>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> anyhow::Result<ProofChallenges<F, D>> {
     let config = &common_data.config;
     let num_challenges = config.num_challenges;
 
@@ -82,11 +78,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         &self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<Vec<usize>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<Vec<usize>> {
         Ok(self
             .get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?
             .fri_challenges
@@ -99,11 +91,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<ProofChallenges<F, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<ProofChallenges<F, D>> {
         let Proof {
             wires_cap,
             plonk_zs_partial_products_cap,

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -89,11 +89,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<CompressedProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<CompressedProofWithPublicInputs<F, C, D>> {
         let indices = self.fri_query_indices(circuit_digest, common_data)?;
         let compressed_proof = self.proof.compress(&indices, &common_data.fri_params);
         Ok(CompressedProofWithPublicInputs {
@@ -104,10 +100,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
     pub fn get_public_inputs_hash(
         &self,
-    ) -> <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash
-    where
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash {
         C::InnerHasher::hash_no_pad(&self.public_inputs)
     }
 
@@ -157,10 +150,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         challenges: &ProofChallenges<F, D>,
         fri_inferred_elements: FriInferredElements<F, D>,
         params: &FriParams,
-    ) -> Proof<F, C, D>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Proof<F, C, D> {
         let CompressedProof {
             wires_cap,
             plonk_zs_partial_products_cap,

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -15,7 +15,6 @@ use crate::fri::structure::{
 };
 use crate::fri::FriParams;
 use crate::hash::hash_types::{MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::target::Target;
@@ -187,11 +186,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         self,
         circuit_digest: &<<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
         let challenges =
             self.get_challenges(self.get_public_inputs_hash(), circuit_digest, common_data)?;
         let fri_inferred_elements = self.get_inferred_elements(&challenges, common_data);
@@ -208,11 +203,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         self,
         verifier_data: &VerifierOnlyCircuitData<C, D>,
         common_data: &CommonCircuitData<F, D>,
-    ) -> anyhow::Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> anyhow::Result<()> {
         ensure!(
             self.public_inputs.len() == common_data.num_public_inputs,
             "Number of public inputs doesn't match circuit data."
@@ -238,10 +229,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 
     pub(crate) fn get_public_inputs_hash(
         &self,
-    ) -> <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash
-    where
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash {
         C::InnerHasher::hash_no_pad(&self.public_inputs)
     }
 

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -11,7 +11,6 @@ use crate::field::types::Field;
 use crate::field::zero_poly_coset::ZeroPolyOnCoset;
 use crate::fri::oracle::PolynomialBatch;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::PlonkyPermutation;
 use crate::iop::challenger::Challenger;
 use crate::iop::generator::generate_partial_witness;
 use crate::iop::witness::{MatrixWitness, PartialWitness, Witness};
@@ -35,8 +34,6 @@ pub fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: 
 where
     C::Hasher: Hasher<F>,
     C::InnerHasher: Hasher<F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let config = &common_data.config;
     let num_challenges = config.num_challenges;

--- a/plonky2/src/plonk/verifier.rs
+++ b/plonky2/src/plonk/verifier.rs
@@ -4,7 +4,6 @@ use crate::field::extension::Extendable;
 use crate::field::types::Field;
 use crate::fri::verifier::verify_fri_proof;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::PlonkyPermutation;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierOnlyCircuitData};
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::plonk_common::reduce_with_powers;
@@ -17,11 +16,7 @@ pub(crate) fn verify<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     proof_with_pis: ProofWithPublicInputs<F, C, D>,
     verifier_data: &VerifierOnlyCircuitData<C, D>,
     common_data: &CommonCircuitData<F, D>,
-) -> Result<()>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> Result<()> {
     validate_proof_with_pis_shape(&proof_with_pis, common_data)?;
 
     let public_inputs_hash = proof_with_pis.get_public_inputs_hash();
@@ -50,10 +45,7 @@ pub(crate) fn verify_with_challenges<
     challenges: ProofChallenges<F, D>,
     verifier_data: &VerifierOnlyCircuitData<C, D>,
     common_data: &CommonCircuitData<F, D>,
-) -> Result<()>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> Result<()> {
     let local_constants = &proof.openings.constants;
     let local_wires = &proof.openings.wires;
     let vars = EvaluationVars {

--- a/plonky2/src/plonk/verifier.rs
+++ b/plonky2/src/plonk/verifier.rs
@@ -4,7 +4,7 @@ use crate::field::extension::Extendable;
 use crate::field::types::Field;
 use crate::fri::verifier::verify_fri_proof;
 use crate::hash::hash_types::RichField;
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierOnlyCircuitData};
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::plonk_common::reduce_with_powers;
@@ -19,8 +19,8 @@ pub(crate) fn verify<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     common_data: &CommonCircuitData<F, D>,
 ) -> Result<()>
 where
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     validate_proof_with_pis_shape(&proof_with_pis, common_data)?;
 
@@ -46,13 +46,13 @@ pub(crate) fn verify_with_challenges<
     const D: usize,
 >(
     proof: Proof<F, C, D>,
-    public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F, C::HCI>>::Hash,
+    public_inputs_hash: <<C as GenericConfig<D>>::InnerHasher as Hasher<F>>::Hash,
     challenges: ProofChallenges<F, D>,
     verifier_data: &VerifierOnlyCircuitData<C, D>,
     common_data: &CommonCircuitData<F, D>,
 ) -> Result<()>
 where
-    [(); C::HCO::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let local_constants = &proof.openings.constants;
     let local_wires = &proof.openings.wires;

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -8,13 +8,12 @@ use crate::fri::proof::{
 };
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProofTarget;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierCircuitTarget};
-use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::plonk::proof::{OpeningSetTarget, ProofTarget, ProofWithPublicInputsTarget};
 use crate::with_context;
 
@@ -31,8 +30,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let selected_proof =
             self.select_proof_with_pis(condition, proof_with_pis0, proof_with_pis1);
@@ -62,8 +59,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> anyhow::Result<()>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let (dummy_proof_with_pis_target, dummy_verifier_data_target) =
             self.dummy_proof_and_vk::<C>(inner_common_data)?;

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -8,13 +8,13 @@ use crate::fri::proof::{
 };
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::HashConfig;
+use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_proofs::MerkleProofTarget;
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierCircuitTarget};
-use crate::plonk::config::{AlgebraicHasher, GenericConfig};
+use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
 use crate::plonk::proof::{OpeningSetTarget, ProofTarget, ProofWithPublicInputsTarget};
 use crate::with_context;
 
@@ -30,9 +30,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_verifier_data1: &VerifierCircuitTarget,
         inner_common_data: &CommonCircuitData<F, D>,
     ) where
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        C::Hasher: AlgebraicHasher<F>,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let selected_proof =
             self.select_proof_with_pis(condition, proof_with_pis0, proof_with_pis1);
@@ -61,9 +61,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<()>
     where
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
+        C::Hasher: AlgebraicHasher<F>,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let (dummy_proof_with_pis_target, dummy_verifier_data_target) =
             self.dummy_proof_and_vk::<C>(inner_common_data)?;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -374,7 +374,7 @@ mod tests {
     fn iterate_poseidon<F: RichField>(initial_state: [F; 4], n: usize) -> [F; 4] {
         let mut current = initial_state;
         for _ in 0..n {
-            current = hash_n_to_hash_no_pad::<F, PoseidonPermutation>(&current).elements;
+            current = hash_n_to_hash_no_pad::<F, PoseidonPermutation<F>>(&current).elements;
         }
         current
     }

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -4,14 +4,13 @@ use anyhow::{ensure, Result};
 
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::{HashOut, HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::target::{BoolTarget, Target};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{
     CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
 };
-use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 use crate::util::serialization::{Buffer, IoResult, Read, Write};
 
@@ -108,8 +107,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> Result<()>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let verifier_data = self
             .verifier_data_public_input
@@ -162,8 +159,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> Result<()>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let (dummy_proof_with_pis_target, dummy_verifier_data_target) =
             self.dummy_proof_and_vk::<C>(common_data)?;
@@ -191,8 +186,6 @@ pub fn check_cyclic_proof_verifier_data<
 ) -> Result<()>
 where
     C::Hasher: AlgebraicHasher<F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let pis = VerifierOnlyCircuitData::<C, D>::from_slice(&proof.public_inputs, common_data)?;
     ensure!(verifier_data.constants_sigmas_cap == pis.constants_sigmas_cap);
@@ -209,12 +202,12 @@ mod tests {
     use crate::field::types::{Field, PrimeField64};
     use crate::gates::noop::NoopGate;
     use crate::hash::hash_types::{HashOutTarget, RichField};
-    use crate::hash::hashing::{hash_n_to_hash_no_pad, PlonkyPermutation};
+    use crate::hash::hashing::hash_n_to_hash_no_pad;
     use crate::hash::poseidon::{PoseidonHash, PoseidonPermutation};
     use crate::iop::witness::{PartialWitness, WitnessWrite};
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
-    use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
+    use crate::plonk::config::{AlgebraicHasher, GenericConfig, PoseidonGoldilocksConfig};
     use crate::recursion::cyclic_recursion::check_cyclic_proof_verifier_data;
     use crate::recursion::dummy_circuit::cyclic_base_proof;
 
@@ -226,8 +219,6 @@ mod tests {
     >() -> CommonCircuitData<F, D>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let config = CircuitConfig::standard_recursion_config();
         let builder = CircuitBuilder::<F, D>::new(config);

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -10,7 +10,6 @@ use crate::fri::proof::{FriProof, FriProofTarget};
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::gates::noop::NoopGate;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator};
 use crate::iop::target::Target;
@@ -40,8 +39,6 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     C::Hasher: AlgebraicHasher<C::F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let pis_len = common_data.num_public_inputs;
     let cap_elements = common_data.config.fri_config.num_cap_elements();
@@ -76,8 +73,6 @@ pub(crate) fn dummy_proof<
     nonzero_public_inputs: HashMap<usize, F>,
 ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>>
 where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let mut pw = PartialWitness::new();
     for i in 0..circuit.common.num_public_inputs {
@@ -94,11 +89,7 @@ pub(crate) fn dummy_circuit<
     const D: usize,
 >(
     common_data: &CommonCircuitData<F, D>,
-) -> CircuitData<F, C, D>
-where
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-{
+) -> CircuitData<F, C, D> {
     let config = common_data.config.clone();
     assert!(
         !common_data.config.zero_knowledge,
@@ -133,8 +124,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let dummy_circuit = dummy_circuit::<F, C, D>(common_data);
         let dummy_proof_with_pis = dummy_proof::<F, C, D>(&dummy_circuit, HashMap::new())?;

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -1,9 +1,8 @@
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::{HashOutTarget, RichField};
-use crate::hash::hashing::PlonkyPermutation;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierCircuitTarget};
-use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::plonk::plonk_common::salt_size;
 use crate::plonk::proof::{
     OpeningSetTarget, ProofChallengesTarget, ProofTarget, ProofWithPublicInputsTarget,
@@ -22,8 +21,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         assert_eq!(
             proof_with_pis.public_inputs.len(),
@@ -57,7 +54,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         inner_common_data: &CommonCircuitData<F, D>,
     ) where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let one = self.one_extension();
 
@@ -329,11 +325,7 @@ mod tests {
     fn dummy_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
         config: &CircuitConfig,
         num_dummy_gates: u64,
-    ) -> Result<Proof<F, C, D>>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<Proof<F, C, D>> {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         for _ in 0..num_dummy_gates {
             builder.add_gate(NoopGate, vec![]);
@@ -363,10 +355,6 @@ mod tests {
     ) -> Result<Proof<F, C, D>>
     where
         InnerC::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <InnerC::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <InnerC::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
@@ -418,11 +406,7 @@ mod tests {
         proof: &ProofWithPublicInputs<F, C, D>,
         vd: &VerifierOnlyCircuitData<C, D>,
         cd: &CommonCircuitData<F, D>,
-    ) -> Result<()>
-    where
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-    {
+    ) -> Result<()> {
         let proof_bytes = proof.to_bytes();
         info!("Proof length: {} bytes", proof_bytes.len());
         let proof_from_bytes = ProofWithPublicInputs::from_bytes(proof_bytes, cd)?;

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -133,7 +133,7 @@ pub mod default {
     where
         F: RichField + Extendable<D>,
         C: GenericConfig<D, F = F> + 'static,
-        C::Hasher: AlgebraicHasher<F, C::HCO>,
+        C::Hasher: AlgebraicHasher<F>,
     {
         impl_generator_serializer! {
             DefaultGeneratorSerializer,

--- a/starky/src/fibonacci_stark.rs
+++ b/starky/src/fibonacci_stark.rs
@@ -127,13 +127,10 @@ mod tests {
     use plonky2::field::extension::Extendable;
     use plonky2::field::types::Field;
     use plonky2::hash::hash_types::RichField;
-    use plonky2::hash::hashing::PlonkyPermutation;
     use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_builder::CircuitBuilder;
     use plonky2::plonk::circuit_data::CircuitConfig;
-    use plonky2::plonk::config::{
-        AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig,
-    };
+    use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, PoseidonGoldilocksConfig};
     use plonky2::util::timing::TimingTree;
 
     use crate::config::StarkConfig;
@@ -240,10 +237,6 @@ mod tests {
         InnerC::Hasher: AlgebraicHasher<F>,
         [(); S::COLUMNS]:,
         [(); S::PUBLIC_INPUTS]:,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <InnerC::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <InnerC::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let circuit_config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(circuit_config);

--- a/starky/src/fibonacci_stark.rs
+++ b/starky/src/fibonacci_stark.rs
@@ -127,11 +127,13 @@ mod tests {
     use plonky2::field::extension::Extendable;
     use plonky2::field::types::Field;
     use plonky2::hash::hash_types::RichField;
-    use plonky2::hash::hashing::HashConfig;
+    use plonky2::hash::hashing::PlonkyPermutation;
     use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_builder::CircuitBuilder;
     use plonky2::plonk::circuit_data::CircuitConfig;
-    use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, PoseidonGoldilocksConfig};
+    use plonky2::plonk::config::{
+        AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig,
+    };
     use plonky2::util::timing::TimingTree;
 
     use crate::config::StarkConfig;
@@ -235,13 +237,13 @@ mod tests {
         print_gate_counts: bool,
     ) -> Result<()>
     where
-        InnerC::Hasher: AlgebraicHasher<F, InnerC::HCO>,
+        InnerC::Hasher: AlgebraicHasher<F>,
         [(); S::COLUMNS]:,
         [(); S::PUBLIC_INPUTS]:,
-        [(); C::HCO::WIDTH]:,
-        [(); C::HCI::WIDTH]:,
-        [(); InnerC::HCO::WIDTH]:,
-        [(); InnerC::HCI::WIDTH]:,
+        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <InnerC::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+        [(); <InnerC::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let circuit_config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(circuit_config);

--- a/starky/src/get_challenges.rs
+++ b/starky/src/get_challenges.rs
@@ -5,12 +5,11 @@ use plonky2::field::polynomial::PolynomialCoeffs;
 use plonky2::fri::proof::{FriProof, FriProofTarget};
 use plonky2::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 
 use crate::config::StarkConfig;
 use crate::permutation::{
@@ -35,8 +34,6 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     S: Stark<F, D>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let num_challenges = config.num_challenges;
 
@@ -79,8 +76,6 @@ impl<F, C, const D: usize> StarkProofWithPublicInputs<F, C, D>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     // TODO: Should be used later in compression?
     #![allow(dead_code)]
@@ -151,8 +146,6 @@ pub(crate) fn get_challenges_target<
 ) -> StarkProofChallengesTarget<D>
 where
     C::Hasher: AlgebraicHasher<F>,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let num_challenges = config.num_challenges;
 
@@ -205,8 +198,6 @@ impl<const D: usize> StarkProofWithPublicInputsTarget<D> {
     ) -> StarkProofChallengesTarget<D>
     where
         C::Hasher: AlgebraicHasher<F>,
-        [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-        [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
     {
         let StarkProofTarget {
             trace_cap,

--- a/starky/src/permutation.rs
+++ b/starky/src/permutation.rs
@@ -10,7 +10,6 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -152,10 +151,7 @@ fn poly_product_elementwise<F: Field>(
 
 fn get_permutation_challenge<F: RichField, H: Hasher<F>>(
     challenger: &mut Challenger<F, H>,
-) -> PermutationChallenge<F>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> PermutationChallenge<F> {
     let beta = challenger.get_challenge();
     let gamma = challenger.get_challenge();
     PermutationChallenge { beta, gamma }
@@ -164,10 +160,7 @@ where
 fn get_permutation_challenge_set<F: RichField, H: Hasher<F>>(
     challenger: &mut Challenger<F, H>,
     num_challenges: usize,
-) -> PermutationChallengeSet<F>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> PermutationChallengeSet<F> {
     let challenges = (0..num_challenges)
         .map(|_| get_permutation_challenge(challenger))
         .collect();
@@ -178,10 +171,7 @@ pub(crate) fn get_n_permutation_challenge_sets<F: RichField, H: Hasher<F>>(
     challenger: &mut Challenger<F, H>,
     num_challenges: usize,
     num_sets: usize,
-) -> Vec<PermutationChallengeSet<F>>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> Vec<PermutationChallengeSet<F>> {
     (0..num_sets)
         .map(|_| get_permutation_challenge_set(challenger, num_challenges))
         .collect()
@@ -194,10 +184,7 @@ fn get_permutation_challenge_target<
 >(
     builder: &mut CircuitBuilder<F, D>,
     challenger: &mut RecursiveChallenger<F, H, D>,
-) -> PermutationChallenge<Target>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> PermutationChallenge<Target> {
     let beta = challenger.get_challenge(builder);
     let gamma = challenger.get_challenge(builder);
     PermutationChallenge { beta, gamma }
@@ -211,10 +198,7 @@ fn get_permutation_challenge_set_target<
     builder: &mut CircuitBuilder<F, D>,
     challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
-) -> PermutationChallengeSet<Target>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> PermutationChallengeSet<Target> {
     let challenges = (0..num_challenges)
         .map(|_| get_permutation_challenge_target(builder, challenger))
         .collect();
@@ -230,10 +214,7 @@ pub(crate) fn get_n_permutation_challenge_sets_target<
     challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
     num_sets: usize,
-) -> Vec<PermutationChallengeSet<Target>>
-where
-    [(); H::Permutation::WIDTH]:,
-{
+) -> Vec<PermutationChallengeSet<Target>> {
     (0..num_sets)
         .map(|_| get_permutation_challenge_set_target(builder, challenger, num_challenges))
         .collect()

--- a/starky/src/permutation.rs
+++ b/starky/src/permutation.rs
@@ -10,7 +10,7 @@ use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
 use plonky2::field::types::Field;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::{Challenger, RecursiveChallenger};
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
@@ -150,23 +150,23 @@ fn poly_product_elementwise<F: Field>(
     product
 }
 
-fn get_permutation_challenge<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+fn get_permutation_challenge<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
 ) -> PermutationChallenge<F>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let beta = challenger.get_challenge();
     let gamma = challenger.get_challenge();
     PermutationChallenge { beta, gamma }
 }
 
-fn get_permutation_challenge_set<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+fn get_permutation_challenge_set<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
     num_challenges: usize,
 ) -> PermutationChallengeSet<F>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let challenges = (0..num_challenges)
         .map(|_| get_permutation_challenge(challenger))
@@ -174,13 +174,13 @@ where
     PermutationChallengeSet { challenges }
 }
 
-pub(crate) fn get_n_permutation_challenge_sets<F: RichField, HC: HashConfig, H: Hasher<F, HC>>(
-    challenger: &mut Challenger<F, HC, H>,
+pub(crate) fn get_n_permutation_challenge_sets<F: RichField, H: Hasher<F>>(
+    challenger: &mut Challenger<F, H>,
     num_challenges: usize,
     num_sets: usize,
 ) -> Vec<PermutationChallengeSet<F>>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     (0..num_sets)
         .map(|_| get_permutation_challenge_set(challenger, num_challenges))
@@ -189,15 +189,14 @@ where
 
 fn get_permutation_challenge_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
 ) -> PermutationChallenge<Target>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let beta = challenger.get_challenge(builder);
     let gamma = challenger.get_challenge(builder);
@@ -206,16 +205,15 @@ where
 
 fn get_permutation_challenge_set_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
 ) -> PermutationChallengeSet<Target>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     let challenges = (0..num_challenges)
         .map(|_| get_permutation_challenge_target(builder, challenger))
@@ -225,17 +223,16 @@ where
 
 pub(crate) fn get_n_permutation_challenge_sets_target<
     F: RichField + Extendable<D>,
-    HC: HashConfig,
-    H: AlgebraicHasher<F, HC>,
+    H: AlgebraicHasher<F>,
     const D: usize,
 >(
     builder: &mut CircuitBuilder<F, D>,
-    challenger: &mut RecursiveChallenger<F, HC, H, D>,
+    challenger: &mut RecursiveChallenger<F, H, D>,
     num_challenges: usize,
     num_sets: usize,
 ) -> Vec<PermutationChallengeSet<Target>>
 where
-    [(); HC::WIDTH]:,
+    [(); H::Permutation::WIDTH]:,
 {
     (0..num_sets)
         .map(|_| get_permutation_challenge_set_target(builder, challenger, num_challenges))

--- a/starky/src/proof.rs
+++ b/starky/src/proof.rs
@@ -23,15 +23,15 @@ use crate::permutation::PermutationChallengeSet;
 #[derive(Debug, Clone)]
 pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     /// Merkle cap of LDEs of trace values.
-    pub trace_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub trace_cap: MerkleCap<F, C::Hasher>,
     /// Merkle cap of LDEs of permutation Z values.
-    pub permutation_zs_cap: Option<MerkleCap<F, C::HCO, C::Hasher>>,
+    pub permutation_zs_cap: Option<MerkleCap<F, C::Hasher>>,
     /// Merkle cap of LDEs of trace values.
-    pub quotient_polys_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub quotient_polys_cap: MerkleCap<F, C::Hasher>,
     /// Purported values of each polynomial at the challenge point.
     pub openings: StarkOpeningSet<F, D>,
     /// A batch FRI argument for all openings.
-    pub opening_proof: FriProof<F, C::HCO, C::Hasher, D>,
+    pub opening_proof: FriProof<F, C::Hasher, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> StarkProof<F, C, D> {
@@ -88,11 +88,11 @@ pub struct CompressedStarkProof<
     const D: usize,
 > {
     /// Merkle cap of LDEs of trace values.
-    pub trace_cap: MerkleCap<F, C::HCO, C::Hasher>,
+    pub trace_cap: MerkleCap<F, C::Hasher>,
     /// Purported values of each polynomial at the challenge point.
     pub openings: StarkOpeningSet<F, D>,
     /// A batch FRI argument for all openings.
-    pub opening_proof: CompressedFriProof<F, C::HCO, C::Hasher, D>,
+    pub opening_proof: CompressedFriProof<F, C::Hasher, D>,
 }
 
 pub struct CompressedStarkProofWithPublicInputs<

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -11,9 +11,9 @@ use plonky2::field::types::Field;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
 use plonky2::fri::oracle::PolynomialBatch;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::Challenger;
-use plonky2::plonk::config::GenericConfig;
+use plonky2::plonk::config::{GenericConfig, Hasher};
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use plonky2::util::{log2_ceil, log2_strict, transpose};
@@ -43,8 +43,8 @@ where
     S: Stark<F, D>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let degree = trace_poly_values[0].len();
     let degree_bits = log2_strict(degree);

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -11,9 +11,8 @@ use plonky2::field::types::Field;
 use plonky2::field::zero_poly_coset::ZeroPolyOnCoset;
 use plonky2::fri::oracle::PolynomialBatch;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::challenger::Challenger;
-use plonky2::plonk::config::{GenericConfig, Hasher};
+use plonky2::plonk::config::GenericConfig;
 use plonky2::timed;
 use plonky2::util::timing::TimingTree;
 use plonky2::util::{log2_ceil, log2_strict, transpose};
@@ -43,8 +42,6 @@ where
     S: Stark<F, D>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     let degree = trace_poly_values[0].len();
     let degree_bits = log2_strict(degree);

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -7,11 +7,10 @@ use plonky2::field::extension::Extendable;
 use plonky2::field::types::Field;
 use plonky2::fri::witness_util::set_fri_proof_target;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::witness::Witness;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::with_context;
 
@@ -40,8 +39,6 @@ pub fn verify_stark_proof_circuit<
     C::Hasher: AlgebraicHasher<F>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     assert_eq!(proof_with_pis.public_inputs.len(), S::PUBLIC_INPUTS);
     let degree_bits = proof_with_pis.proof.recover_degree_bits(inner_config);
@@ -78,7 +75,6 @@ fn verify_stark_proof_with_challenges_circuit<
     C::Hasher: AlgebraicHasher<F>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     check_permutation_options(&stark, &proof_with_pis, &challenges).unwrap();
     let one = builder.one_extension();

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -7,11 +7,11 @@ use plonky2::field::extension::Extendable;
 use plonky2::field::types::Field;
 use plonky2::fri::witness_util::set_fri_proof_target;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::witness::Witness;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
-use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
 use plonky2::util::reducing::ReducingFactorTarget;
 use plonky2::with_context;
 
@@ -37,11 +37,11 @@ pub fn verify_stark_proof_circuit<
     proof_with_pis: StarkProofWithPublicInputsTarget<D>,
     inner_config: &StarkConfig,
 ) where
-    C::Hasher: AlgebraicHasher<F, C::HCO>,
+    C::Hasher: AlgebraicHasher<F>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     assert_eq!(proof_with_pis.public_inputs.len(), S::PUBLIC_INPUTS);
     let degree_bits = proof_with_pis.proof.recover_degree_bits(inner_config);
@@ -75,10 +75,10 @@ fn verify_stark_proof_with_challenges_circuit<
     inner_config: &StarkConfig,
     degree_bits: usize,
 ) where
-    C::Hasher: AlgebraicHasher<F, C::HCO>,
+    C::Hasher: AlgebraicHasher<F>,
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     check_permutation_options(&stark, &proof_with_pis, &challenges).unwrap();
     let one = builder.one_extension();
@@ -269,7 +269,7 @@ pub fn set_stark_proof_with_pis_target<F, C: GenericConfig<D, F = F>, W, const D
     stark_proof_with_pis: &StarkProofWithPublicInputs<F, C, D>,
 ) where
     F: RichField + Extendable<D>,
-    C::Hasher: AlgebraicHasher<F, C::HCO>,
+    C::Hasher: AlgebraicHasher<F>,
     W: Witness<F>,
 {
     let StarkProofWithPublicInputs {
@@ -295,7 +295,7 @@ pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
     proof: &StarkProof<F, C, D>,
 ) where
     F: RichField + Extendable<D>,
-    C::Hasher: AlgebraicHasher<F, C::HCO>,
+    C::Hasher: AlgebraicHasher<F>,
     W: Witness<F>,
 {
     witness.set_cap_target(&proof_target.trace_cap, &proof.trace_cap);

--- a/starky/src/stark_testing.rs
+++ b/starky/src/stark_testing.rs
@@ -6,11 +6,11 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use plonky2::field::types::{Field, Sample};
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
-use plonky2::plonk::config::GenericConfig;
+use plonky2::plonk::config::{GenericConfig, Hasher};
 use plonky2::util::{log2_ceil, log2_strict, transpose};
 
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
@@ -90,8 +90,8 @@ pub fn test_stark_circuit_constraints<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     // Compute native constraint evaluation on random values.
     let vars = StarkEvaluationVars {

--- a/starky/src/stark_testing.rs
+++ b/starky/src/stark_testing.rs
@@ -6,11 +6,10 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use plonky2::field::types::{Field, Sample};
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::circuit_data::CircuitConfig;
-use plonky2::plonk::config::{GenericConfig, Hasher};
+use plonky2::plonk::config::GenericConfig;
 use plonky2::util::{log2_ceil, log2_strict, transpose};
 
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
@@ -90,8 +89,6 @@ pub fn test_stark_circuit_constraints<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     // Compute native constraint evaluation on random values.
     let vars = StarkEvaluationVars {

--- a/starky/src/verifier.rs
+++ b/starky/src/verifier.rs
@@ -7,8 +7,7 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::types::Field;
 use plonky2::fri::verifier::verify_fri_proof;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::PlonkyPermutation;
-use plonky2::plonk::config::{GenericConfig, Hasher};
+use plonky2::plonk::config::GenericConfig;
 use plonky2::plonk::plonk_common::reduce_with_powers;
 
 use crate::config::StarkConfig;
@@ -32,8 +31,6 @@ pub fn verify_stark_proof<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
-    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     ensure!(proof_with_pis.public_inputs.len() == S::PUBLIC_INPUTS);
     let degree_bits = proof_with_pis.proof.recover_degree_bits(config);
@@ -56,7 +53,6 @@ pub(crate) fn verify_stark_proof_with_challenges<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     validate_proof_shape(&stark, &proof_with_pis, config)?;
     check_permutation_options(&stark, &proof_with_pis, &challenges)?;

--- a/starky/src/verifier.rs
+++ b/starky/src/verifier.rs
@@ -7,8 +7,8 @@ use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::types::Field;
 use plonky2::fri::verifier::verify_fri_proof;
 use plonky2::hash::hash_types::RichField;
-use plonky2::hash::hashing::HashConfig;
-use plonky2::plonk::config::GenericConfig;
+use plonky2::hash::hashing::PlonkyPermutation;
+use plonky2::plonk::config::{GenericConfig, Hasher};
 use plonky2::plonk::plonk_common::reduce_with_powers;
 
 use crate::config::StarkConfig;
@@ -32,8 +32,8 @@ pub fn verify_stark_proof<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
-    [(); C::HCI::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
+    [(); <C::InnerHasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     ensure!(proof_with_pis.public_inputs.len() == S::PUBLIC_INPUTS);
     let degree_bits = proof_with_pis.proof.recover_degree_bits(config);
@@ -56,7 +56,7 @@ pub(crate) fn verify_stark_proof_with_challenges<
 where
     [(); S::COLUMNS]:,
     [(); S::PUBLIC_INPUTS]:,
-    [(); C::HCO::WIDTH]:,
+    [(); <C::Hasher as Hasher<F>>::Permutation::WIDTH]:,
 {
     validate_proof_shape(&stark, &proof_with_pis, config)?;
     check_permutation_options(&stark, &proof_with_pis, &challenges)?;


### PR DESCRIPTION
This PR fixes the problem of dramatically increased compile times which started with #873 with the re-introduction and extensive use of the unstable `generic_const_exprs` feature into `plonky2_evm` to provide more generic support for hash functions. This triggered particularly bad compile times of up to an hour in #905, which has been blocked since.

The problem with the "generic" hash function code was the proliferation of declarations of primitive array types whose sizes were specified in a generic parameter (usually `HashConfig`). This triggered some kind of edge case in the `generic_const_exprs` type checking code, specifically in the `eval_obligation` compiler phase when analysing the `where` clauses to a couple of functions in the prover that had comically large collections of const generic constraints.

This PR applies a kind of "dependency inversion" to the hash/permutation code to hide the implementation details of permutation state inside traits, achieving the same (or better) genericity as the previous PR while limiting the visibility of the implementation details to only the places that need it. In particular, it was clear that the separate `HashConfig` trait is redundant since its data is intrinsically linked to the permutation created in the first place because it cannot vary independently of said permutation; folding `HashConfig` into `PlonkyPermutation` was a simple but big step towards the solution.

Overall, the new design allows removal of practically all of the syntactic ugliness introduced in #873 (including the use of `HashConfig` and the associated proliferation of `where` clauses) in favour of augmenting the `PlonkyPermutation` trait with a richer interface. The vast majority of uses of `generic_const_exprs` have been removed, although some remain (primarily relating to `Stark::COLUMNS` and `Stark::PUBLIC_INPUTS`) which will be dealt with in a future PR. In my opinion the overwhelming majority of the changes make the code more clear and readable, though there are a couple of exceptions that will be obvious; ideas and suggestions for clearer expressions are always welcome!

Most of this PR is just removing the `HashConfig` stuff from #873 and so easy to check; but I'd like to request special attention from the reviewers in those places where I've replaced existing logic with a sequence of calls to the expanded `PlonkyPermutation` trait. This occurs in multiple locations, but `plonky2/src/fri/prover.rs` is a typical example.

Some minor issues remain, but they are fairly trivial and can be left to future PRs, as this one is already much longer than any PR ever should be. These known issues include a cleaner definition of the `Permuter` trait, rethinking/possible removal of `RichField`, removing `plonky2_evm` dependency on `generic_const_exprs`, etc. Please feel free to note other issues to follow up as well.

The main uncertainty I had with the implementation was my use of `AsRef<[T]>` to allow "slice" access to the hash state (where previous code just accessed the array directly). I think it's fairly clean, but maybe providing `IntoIterator<Item=T>` might be more appropriate. I'd welcome PR reviewer's thoughts on this.

@Nashtare As the author of #873 I'd be particularly keen to hear your thoughts on this PR, especially to confirm that it is indeed sufficiently generic to satisfy your requirements for instantiating with different hash functions. Thanks!