### PR TITLE
Fix the memory CTL and implement the verifier memory bus

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -10,7 +10,7 @@ use crate::config::StarkConfig;
 use crate::cpu::cpu_stark;
 use crate::cpu::cpu_stark::CpuStark;
 use crate::cpu::membus::NUM_GP_CHANNELS;
-use crate::cross_table_lookup::{Column, CrossTableLookup, TableWithColumns};
+use crate::cross_table_lookup::{CrossTableLookup, TableWithColumns};
 use crate::keccak::keccak_stark;
 use crate::keccak::keccak_stark::KeccakStark;
 use crate::keccak_sponge::columns::KECCAK_RATE_BYTES;
@@ -97,23 +97,13 @@ impl Table {
 }
 
 pub(crate) fn all_cross_table_lookups<F: Field>() -> Vec<CrossTableLookup<F>> {
-    let mut ctls = vec![
+    vec![
         ctl_arithmetic(),
         ctl_keccak_sponge(),
         ctl_keccak(),
         ctl_logic(),
         ctl_memory(),
-    ];
-    // TODO: Some CTLs temporarily disabled while we get them working.
-    disable_ctl(&mut ctls[4]);
-    ctls
-}
-
-fn disable_ctl<F: Field>(ctl: &mut CrossTableLookup<F>) {
-    for table in &mut ctl.looking_tables {
-        table.filter_column = Some(Column::zero());
-    }
-    ctl.looked_table.filter_column = Some(Column::zero());
+    ]
 }
 
 fn ctl_arithmetic<F: Field>() -> CrossTableLookup<F> {

--- a/evm/src/cpu/bootstrap_kernel.rs
+++ b/evm/src/cpu/bootstrap_kernel.rs
@@ -48,6 +48,7 @@ pub(crate) fn generate_bootstrap_kernel<F: Field>(state: &mut GenerationState<F>
     final_cpu_row.mem_channels[2].value[0] = F::ZERO; // virt
     final_cpu_row.mem_channels[3].value[0] = F::from_canonical_usize(KERNEL.code.len()); // len
     final_cpu_row.mem_channels[4].value = KERNEL.code_hash.map(F::from_canonical_u32);
+    final_cpu_row.mem_channels[4].value.reverse();
     keccak_sponge_log(
         state,
         MemoryAddress::new(0, Segment::Code, 0),
@@ -93,6 +94,7 @@ pub(crate) fn eval_bootstrap_kernel<F: Field, P: PackedField<Scalar = F>>(
     for (&expected, actual) in KERNEL
         .code_hash
         .iter()
+        .rev()
         .zip(local_values.mem_channels.last().unwrap().value)
     {
         let expected = P::from(F::from_canonical_u32(expected));
@@ -153,6 +155,7 @@ pub(crate) fn eval_bootstrap_kernel_circuit<F: RichField + Extendable<D>, const 
     for (&expected, actual) in KERNEL
         .code_hash
         .iter()
+        .rev()
         .zip(local_values.mem_channels.last().unwrap().value)
     {
         let expected = builder.constant_extension(F::Extension::from_canonical_u32(expected));

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -44,9 +44,10 @@ impl Kernel {
         prover_inputs: HashMap<usize, ProverInputFn>,
     ) -> Self {
         let code_hash_bytes = keccak(&code).0;
-        let code_hash = core::array::from_fn(|i| {
+        let code_hash_be = core::array::from_fn(|i| {
             u32::from_le_bytes(core::array::from_fn(|j| code_hash_bytes[i * 4 + j]))
         });
+        let code_hash = code_hash_be.map(u32::from_be);
         let ordered_labels = global_labels
             .keys()
             .cloned()

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -542,21 +542,29 @@ pub(crate) fn eval_cross_table_lookup_checks_circuit<
 pub(crate) fn verify_cross_table_lookups<F: RichField + Extendable<D>, const D: usize>(
     cross_table_lookups: &[CrossTableLookup<F>],
     ctl_zs_lasts: [Vec<F>; NUM_TABLES],
+    ctl_extra_looking_products: Vec<Vec<F>>,
     config: &StarkConfig,
 ) -> Result<()> {
     let mut ctl_zs_openings = ctl_zs_lasts.iter().map(|v| v.iter()).collect::<Vec<_>>();
-    for CrossTableLookup {
-        looking_tables,
-        looked_table,
-    } in cross_table_lookups.iter()
+    for (
+        CrossTableLookup {
+            looking_tables,
+            looked_table,
+        },
+        extra_product_vec,
+    ) in cross_table_lookups
+        .iter()
+        .zip(ctl_extra_looking_products.iter())
     {
-        for _ in 0..config.num_challenges {
-            let looking_zs_prod = looking_tables
+        for c in 0..config.num_challenges {
+            let mut looking_zs_prod = looking_tables
                 .iter()
                 .map(|table| *ctl_zs_openings[table.table as usize].next().unwrap())
                 .product::<F>();
-            let looked_z = *ctl_zs_openings[looked_table.table as usize].next().unwrap();
 
+            looking_zs_prod *= extra_product_vec[c];
+
+            let looked_z = *ctl_zs_openings[looked_table.table as usize].next().unwrap();
             ensure!(
                 looking_zs_prod == looked_z,
                 "Cross-table lookup verification failed."
@@ -572,22 +580,31 @@ pub(crate) fn verify_cross_table_lookups_circuit<F: RichField + Extendable<D>, c
     builder: &mut CircuitBuilder<F, D>,
     cross_table_lookups: Vec<CrossTableLookup<F>>,
     ctl_zs_lasts: [Vec<Target>; NUM_TABLES],
+    ctl_extra_looking_products: Vec<Vec<Target>>,
     inner_config: &StarkConfig,
 ) {
     let mut ctl_zs_openings = ctl_zs_lasts.iter().map(|v| v.iter()).collect::<Vec<_>>();
-    for CrossTableLookup {
-        looking_tables,
-        looked_table,
-    } in cross_table_lookups.into_iter()
+    for (
+        CrossTableLookup {
+            looking_tables,
+            looked_table,
+        },
+        extra_product_vec,
+    ) in cross_table_lookups
+        .into_iter()
+        .zip(ctl_extra_looking_products.iter())
     {
-        for _ in 0..inner_config.num_challenges {
-            let looking_zs_prod = builder.mul_many(
+        for c in 0..inner_config.num_challenges {
+            let mut looking_zs_prod = builder.mul_many(
                 looking_tables
                     .iter()
                     .map(|table| *ctl_zs_openings[table.table as usize].next().unwrap()),
             );
+
+            looking_zs_prod = builder.mul(looking_zs_prod, extra_product_vec[c]);
+
             let looked_z = *ctl_zs_openings[looked_table.table as usize].next().unwrap();
-            builder.connect(looking_zs_prod, looked_z);
+            builder.connect(looked_z, looking_zs_prod);
         }
     }
     debug_assert!(ctl_zs_openings.iter_mut().all(|iter| iter.next().is_none()));

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -544,12 +544,11 @@ pub(crate) fn verify_cross_table_lookups<F: RichField + Extendable<D>, const D: 
     {
         let extra_product_vec = &ctl_extra_looking_products[looked_table.table as usize];
         for c in 0..config.num_challenges {
-            let mut looking_zs_prod = looking_tables
+            let looking_zs_prod = looking_tables
                 .iter()
                 .map(|table| *ctl_zs_openings[table.table as usize].next().unwrap())
-                .product::<F>();
-
-            looking_zs_prod *= extra_product_vec[c];
+                .product::<F>()
+                * extra_product_vec[c];
 
             let looked_z = *ctl_zs_openings[looked_table.table as usize].next().unwrap();
             ensure!(

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -244,15 +244,6 @@ pub(crate) fn cross_table_lookup_data<F: RichField, const D: usize>(
                 &looked_table.filter_column,
                 challenge,
             );
-
-            debug_assert_eq!(
-                zs_looking
-                    .clone()
-                    .map(|z| *z.values.last().unwrap())
-                    .product::<F>(),
-                *z_looked.values.last().unwrap()
-            );
-
             for (table, z) in looking_tables.iter().zip(zs_looking) {
                 ctl_data_per_table[table.table as usize]
                     .zs_columns

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -537,16 +537,12 @@ pub(crate) fn verify_cross_table_lookups<F: RichField + Extendable<D>, const D: 
     config: &StarkConfig,
 ) -> Result<()> {
     let mut ctl_zs_openings = ctl_zs_lasts.iter().map(|v| v.iter()).collect::<Vec<_>>();
-    for (
-        CrossTableLookup {
-            looking_tables,
-            looked_table,
-        },
-        extra_product_vec,
-    ) in cross_table_lookups
-        .iter()
-        .zip(ctl_extra_looking_products.iter())
+    for CrossTableLookup {
+        looking_tables,
+        looked_table,
+    } in cross_table_lookups.iter()
     {
+        let extra_product_vec = &ctl_extra_looking_products[looked_table.table as usize];
         for c in 0..config.num_challenges {
             let mut looking_zs_prod = looking_tables
                 .iter()
@@ -575,16 +571,12 @@ pub(crate) fn verify_cross_table_lookups_circuit<F: RichField + Extendable<D>, c
     inner_config: &StarkConfig,
 ) {
     let mut ctl_zs_openings = ctl_zs_lasts.iter().map(|v| v.iter()).collect::<Vec<_>>();
-    for (
-        CrossTableLookup {
-            looking_tables,
-            looked_table,
-        },
-        extra_product_vec,
-    ) in cross_table_lookups
-        .into_iter()
-        .zip(ctl_extra_looking_products.iter())
+    for CrossTableLookup {
+        looking_tables,
+        looked_table,
+    } in cross_table_lookups.into_iter()
     {
+        let extra_product_vec = &ctl_extra_looking_products[looked_table.table as usize];
         for c in 0..inner_config.num_challenges {
             let mut looking_zs_prod = builder.mul_many(
                 looking_tables

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -466,32 +466,12 @@ where
         }
 
         // Extra products to add to the looked last value
-        let mut extra_looking_products = Vec::new();
-        for _ in 0..NUM_TABLES {
-            extra_looking_products.push(Vec::new());
-        }
-
-        // Arithmetic
-        for _ in 0..stark_config.num_challenges {
-            extra_looking_products[Table::Arithmetic as usize].push(builder.constant(F::ONE));
-        }
-
-        // KeccakSponge
-        for _ in 0..stark_config.num_challenges {
-            extra_looking_products[Table::KeccakSponge as usize].push(builder.constant(F::ONE));
-        }
-
-        // Keccak
-        for _ in 0..stark_config.num_challenges {
-            extra_looking_products[Table::Keccak as usize].push(builder.constant(F::ONE));
-        }
-
-        // Logic
-        for _ in 0..stark_config.num_challenges {
-            extra_looking_products[Table::Logic as usize].push(builder.constant(F::ONE));
-        }
+        // Arithmetic, KeccakSponge, Keccak, Logic
+        let mut extra_looking_products =
+            vec![vec![builder.constant(F::ONE); stark_config.num_challenges]; NUM_TABLES - 1];
 
         // Memory
+        extra_looking_products.push(Vec::new());
         for c in 0..stark_config.num_challenges {
             extra_looking_products[Table::Memory as usize].push(
                 Self::get_memory_extra_looking_products_circuit(
@@ -746,7 +726,7 @@ where
             builder.connect(row[3], field_target);
             // values
             for j in 0..VALUE_LIMBS {
-                builder.connect(row[j + 4], targets[j]);
+                builder.connect(row[4 + j], targets[j]);
             }
             // timestamp
             builder.connect(row[12], timestamp_target);

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -467,40 +467,40 @@ where
 
         // Extra products to add to the looked last value
         let mut extra_looking_products = Vec::new();
+        for _ in 0..NUM_TABLES {
+            extra_looking_products.push(Vec::new());
+        }
 
         // Arithmetic
-        extra_looking_products.push(Vec::new());
         for _ in 0..stark_config.num_challenges {
-            extra_looking_products[0].push(builder.constant(F::ONE));
+            extra_looking_products[Table::Arithmetic as usize].push(builder.constant(F::ONE));
         }
 
         // KeccakSponge
-        extra_looking_products.push(Vec::new());
         for _ in 0..stark_config.num_challenges {
-            extra_looking_products[1].push(builder.constant(F::ONE));
+            extra_looking_products[Table::KeccakSponge as usize].push(builder.constant(F::ONE));
         }
 
         // Keccak
-        extra_looking_products.push(Vec::new());
         for _ in 0..stark_config.num_challenges {
-            extra_looking_products[2].push(builder.constant(F::ONE));
+            extra_looking_products[Table::Keccak as usize].push(builder.constant(F::ONE));
         }
 
         // Logic
-        extra_looking_products.push(Vec::new());
         for _ in 0..stark_config.num_challenges {
-            extra_looking_products[3].push(builder.constant(F::ONE));
+            extra_looking_products[Table::Logic as usize].push(builder.constant(F::ONE));
         }
 
         // Memory
-        extra_looking_products.push(Vec::new());
         for c in 0..stark_config.num_challenges {
-            extra_looking_products[4].push(Self::get_memory_extra_looking_products_circuit(
-                &mut builder,
-                public_values,
-                cpu_trace_len,
-                ctl_challenges.challenges[c],
-            ));
+            extra_looking_products[Table::Memory as usize].push(
+                Self::get_memory_extra_looking_products_circuit(
+                    &mut builder,
+                    public_values,
+                    cpu_trace_len,
+                    ctl_challenges.challenges[c],
+                ),
+            );
         }
 
         // Verify the CTL checks.

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -32,7 +32,7 @@ use crate::config::StarkConfig;
 use crate::cpu::cpu_stark::CpuStark;
 use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cross_table_lookup::{verify_cross_table_lookups_circuit, CrossTableLookup};
-use crate::generation::{self, GenerationInputs};
+use crate::generation::GenerationInputs;
 use crate::keccak::keccak_stark::KeccakStark;
 use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
 use crate::logic::LogicStark;
@@ -42,18 +42,14 @@ use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
 use crate::permutation::{
     get_grand_product_challenge_set_target, GrandProductChallenge, GrandProductChallengeSet,
 };
-use crate::proof::{
-    BlockMetadata, BlockMetadataTarget, PublicValues, PublicValuesTarget, StarkProofWithMetadata,
-    TrieRootsTarget,
-};
+use crate::proof::{PublicValues, PublicValuesTarget, StarkProofWithMetadata};
 use crate::prover::prove;
 use crate::recursive_verifier::{
-    add_common_recursion_gates, add_virtual_public_values, add_virtual_trie_roots,
-    recursive_stark_circuit, set_block_metadata_target, set_trie_roots_target, PlonkWrapperCircuit,
-    PublicInputs, StarkWrapperCircuit,
+    add_common_recursion_gates, add_virtual_public_values, recursive_stark_circuit,
+    set_block_metadata_target, set_trie_roots_target, PlonkWrapperCircuit, PublicInputs,
+    StarkWrapperCircuit,
 };
 use crate::stark::Stark;
-use crate::util::h160_limbs;
 
 /// The recursion threshold. We end a chain of recursive proofs once we reach this size.
 const THRESHOLD_DEGREE_BITS: usize = 13;

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -38,7 +38,6 @@ use crate::witness::util::mem_write_log;
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct GenerationInputs {
     pub signed_txns: Vec<Vec<u8>>,
-
     pub tries: TrieInputs,
 
     /// Mapping between smart contract code hashes and the contract byte code.
@@ -153,7 +152,7 @@ fn apply_trie_memops<F: RichField + Extendable<D>, const D: usize>(
     state.traces.memory_ops.extend(ops);
 }
 
-pub(crate) fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
+pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     all_stark: &AllStark<F, D>,
     inputs: GenerationInputs,
     config: &StarkConfig,
@@ -201,6 +200,7 @@ pub(crate) fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         trie_roots_before,
         trie_roots_after,
         block_metadata: inputs.block_metadata,
+        cpu_trace_len: state.traces.clock(),
     };
 
     let tables = timed!(

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -164,6 +164,7 @@ pub(crate) fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     GenerationOutputs,
 )> {
     let mut state = GenerationState::<F>::new(inputs.clone(), &KERNEL.code);
+
     apply_metadata_memops(&mut state, &inputs.block_metadata);
 
     generate_bootstrap_kernel::<F>(&mut state);

--- a/evm/src/keccak_sponge/columns.rs
+++ b/evm/src/keccak_sponge/columns.rs
@@ -9,6 +9,7 @@ pub(crate) const KECCAK_RATE_BYTES: usize = 136;
 pub(crate) const KECCAK_RATE_U32S: usize = KECCAK_RATE_BYTES / 4;
 pub(crate) const KECCAK_CAPACITY_BYTES: usize = 64;
 pub(crate) const KECCAK_CAPACITY_U32S: usize = KECCAK_CAPACITY_BYTES / 4;
+pub(crate) const KECCAK_DIGEST_BYTES: usize = 32;
 
 #[repr(C)]
 #[derive(Eq, PartialEq, Debug)]
@@ -53,6 +54,8 @@ pub(crate) struct KeccakSpongeColumnsView<T: Copy> {
     /// The entire state (rate + capacity) of the sponge, encoded as 32-bit chunks, after the
     /// permutation is applied.
     pub updated_state_u32s: [T; KECCAK_WIDTH_U32S],
+
+    pub updated_state_bytes: [T; KECCAK_DIGEST_BYTES],
 }
 
 // `u8` is guaranteed to have a `size_of` of 1.

--- a/evm/src/permutation.rs
+++ b/evm/src/permutation.rs
@@ -14,7 +14,9 @@ use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, Hasher};
-use plonky2::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_circuit};
+use plonky2::plonk::plonk_common::{
+    reduce_with_powers, reduce_with_powers_circuit, reduce_with_powers_ext_circuit,
+};
 use plonky2::util::reducing::{ReducingFactor, ReducingFactorTarget};
 use plonky2::util::serialization::{Buffer, IoResult, Read, Write};
 use plonky2_maybe_rayon::*;
@@ -80,6 +82,17 @@ impl GrandProductChallenge<Target> {
         let reduced = reduce_with_powers_ext_circuit(builder, terms, self.beta);
         let gamma = builder.convert_to_ext(self.gamma);
         builder.add_extension(reduced, gamma)
+    }
+}
+
+impl GrandProductChallenge<Target> {
+    pub(crate) fn combine_base_circuit<F: RichField + Extendable<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        terms: &[Target],
+    ) -> Target {
+        let reduced = reduce_with_powers_circuit(builder, terms, self.beta);
+        builder.add(reduced, self.gamma)
     }
 }
 

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -119,7 +119,8 @@ where
     C: GenericConfig<D, F = F>,
 {
     pub(crate) init_challenger_state: <C::Hasher as Hasher<F>>::Permutation,
-    pub(crate) proof: StarkProof<F, C, D>,
+    // TODO: set it back to pub(crate) when cpu trace len is a public input
+    pub proof: StarkProof<F, C, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> StarkProof<F, C, D> {

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -52,9 +52,10 @@ pub struct PublicValues {
     pub trie_roots_before: TrieRoots,
     pub trie_roots_after: TrieRoots,
     pub block_metadata: BlockMetadata,
+    pub cpu_trace_len: usize,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TrieRoots {
     pub state_root: H256,
     pub transactions_root: H256,
@@ -74,18 +75,101 @@ pub struct BlockMetadata {
 
 /// Memory values which are public.
 /// Note: All the larger integers are encoded with 32-bit limbs in little-endian order.
+#[derive(Eq, PartialEq, Debug)]
 pub struct PublicValuesTarget {
     pub trie_roots_before: TrieRootsTarget,
     pub trie_roots_after: TrieRootsTarget,
     pub block_metadata: BlockMetadataTarget,
+    pub cpu_trace_len: Target,
 }
 
+impl PublicValuesTarget {
+    pub fn to_buffer(&self, buffer: &mut Vec<u8>) -> IoResult<()> {
+        let TrieRootsTarget {
+            state_root: state_root_before,
+            transactions_root: transactions_root_before,
+            receipts_root: receipts_root_before,
+        } = self.trie_roots_before;
+
+        buffer.write_target_vec(&state_root_before)?;
+        buffer.write_target_vec(&transactions_root_before)?;
+        buffer.write_target_vec(&receipts_root_before)?;
+
+        let TrieRootsTarget {
+            state_root: state_root_after,
+            transactions_root: transactions_root_after,
+            receipts_root: receipts_root_after,
+        } = self.trie_roots_after;
+
+        buffer.write_target_vec(&state_root_after)?;
+        buffer.write_target_vec(&transactions_root_after)?;
+        buffer.write_target_vec(&receipts_root_after)?;
+
+        let BlockMetadataTarget {
+            block_beneficiary,
+            block_timestamp,
+            block_number,
+            block_difficulty,
+            block_gaslimit,
+            block_chain_id,
+            block_base_fee,
+        } = self.block_metadata;
+
+        buffer.write_target_vec(&block_beneficiary)?;
+        buffer.write_target(block_timestamp)?;
+        buffer.write_target(block_number)?;
+        buffer.write_target(block_difficulty)?;
+        buffer.write_target(block_gaslimit)?;
+        buffer.write_target(block_chain_id)?;
+        buffer.write_target(block_base_fee)?;
+
+        buffer.write_target(self.cpu_trace_len)?;
+
+        Ok(())
+    }
+
+    pub fn from_buffer(buffer: &mut Buffer) -> IoResult<Self> {
+        let trie_roots_before = TrieRootsTarget {
+            state_root: buffer.read_target_vec()?.try_into().unwrap(),
+            transactions_root: buffer.read_target_vec()?.try_into().unwrap(),
+            receipts_root: buffer.read_target_vec()?.try_into().unwrap(),
+        };
+
+        let trie_roots_after = TrieRootsTarget {
+            state_root: buffer.read_target_vec()?.try_into().unwrap(),
+            transactions_root: buffer.read_target_vec()?.try_into().unwrap(),
+            receipts_root: buffer.read_target_vec()?.try_into().unwrap(),
+        };
+
+        let block_metadata = BlockMetadataTarget {
+            block_beneficiary: buffer.read_target_vec()?.try_into().unwrap(),
+            block_timestamp: buffer.read_target()?,
+            block_number: buffer.read_target()?,
+            block_difficulty: buffer.read_target()?,
+            block_gaslimit: buffer.read_target()?,
+            block_chain_id: buffer.read_target()?,
+            block_base_fee: buffer.read_target()?,
+        };
+
+        let cpu_trace_len = buffer.read_target()?;
+
+        Ok(Self {
+            trie_roots_before,
+            trie_roots_after,
+            block_metadata,
+            cpu_trace_len,
+        })
+    }
+}
+
+#[derive(Eq, PartialEq, Debug)]
 pub struct TrieRootsTarget {
     pub state_root: [Target; 8],
     pub transactions_root: [Target; 8],
     pub receipts_root: [Target; 8],
 }
 
+#[derive(Eq, PartialEq, Debug)]
 pub struct BlockMetadataTarget {
     pub block_beneficiary: [Target; 5],
     pub block_timestamp: Target,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -129,10 +129,21 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             ensure!(pis[i].challenger_state_before == pis[i - 1].challenger_state_after);
         }
 
+        // Dummy values which will make the check fail.
+        // TODO: Fix this if the code isn't deprecated.
+        let mut extra_looking_products = Vec::new();
+        for i in 0..NUM_TABLES {
+            extra_looking_products.push(Vec::new());
+            for _ in 0..inner_config.num_challenges {
+                extra_looking_products[i].push(F::ONE);
+            }
+        }
+
         // Verify the CTL checks.
         verify_cross_table_lookups::<F, D>(
             &cross_table_lookups,
             pis.map(|p| p.ctl_zs_last),
+            extra_looking_products,
             inner_config,
         )?;
 

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -39,7 +39,7 @@ use crate::proof::{
     TrieRootsTarget,
 };
 use crate::stark::Stark;
-use crate::util::{h160_limbs, h256_limbs};
+use crate::util::h160_limbs;
 use crate::vanishing_poly::eval_vanishing_poly_circuit;
 use crate::vars::StarkEvaluationTargets;
 

--- a/evm/src/util.rs
+++ b/evm/src/util.rs
@@ -61,6 +61,7 @@ pub(crate) fn u256_limbs<F: Field>(u256: U256) -> [F; 8] {
         .unwrap()
 }
 
+#[allow(unused)]
 /// Returns the 32-bit little-endian limbs of a `H256`.
 pub(crate) fn h256_limbs<F: Field>(h256: H256) -> [F; 8] {
     h256.0

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -9,7 +9,7 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::plonk::config::GenericConfig;
 use plonky2::plonk::plonk_common::reduce_with_powers;
 
-use crate::all_stark::{AllStark, Table};
+use crate::all_stark::{AllStark, Table, NUM_TABLES};
 use crate::arithmetic::arithmetic_stark::ArithmeticStark;
 use crate::config::StarkConfig;
 use crate::constraint_consumer::ConstraintConsumer;
@@ -114,30 +114,34 @@ where
 
     // Extra products to add to the looked last value.
     let mut extra_looking_products = Vec::new();
+    for _ in 0..NUM_TABLES {
+        extra_looking_products.push(Vec::new());
+    }
+
+    // Arithmetic
+    for _ in 0..config.num_challenges {
+        extra_looking_products[Table::Arithmetic as usize].push(F::ONE);
+    }
 
     // KeccakSponge
-    extra_looking_products.push(Vec::new());
     for _ in 0..config.num_challenges {
-        extra_looking_products[0].push(F::ONE);
+        extra_looking_products[Table::KeccakSponge as usize].push(F::ONE);
     }
 
     // Keccak
-    extra_looking_products.push(Vec::new());
     for _ in 0..config.num_challenges {
-        extra_looking_products[1].push(F::ONE);
+        extra_looking_products[Table::Keccak as usize].push(F::ONE);
     }
 
     // Logic
-    extra_looking_products.push(Vec::new());
     for _ in 0..config.num_challenges {
-        extra_looking_products[2].push(F::ONE);
+        extra_looking_products[Table::Logic as usize].push(F::ONE);
     }
 
     // Memory
-    extra_looking_products.push(Vec::new());
-    let cpu_trace_len = 1 << all_proof.stark_proofs[0].proof.recover_degree_bits(config);
+    let cpu_trace_len = 1 << all_proof.stark_proofs[1].proof.recover_degree_bits(config);
     for c in 0..config.num_challenges {
-        extra_looking_products[3].push(get_memory_extra_looking_products(
+        extra_looking_products[Table::Memory as usize].push(get_memory_extra_looking_products(
             &public_values,
             cpu_trace_len,
             ctl_challenges.challenges[c],

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -112,33 +112,12 @@ where
 
     let public_values = all_proof.public_values;
 
-    // Extra products to add to the looked last value.
-    let mut extra_looking_products = Vec::new();
-    for _ in 0..NUM_TABLES {
-        extra_looking_products.push(Vec::new());
-    }
-
-    // Arithmetic
-    for _ in 0..config.num_challenges {
-        extra_looking_products[Table::Arithmetic as usize].push(F::ONE);
-    }
-
-    // KeccakSponge
-    for _ in 0..config.num_challenges {
-        extra_looking_products[Table::KeccakSponge as usize].push(F::ONE);
-    }
-
-    // Keccak
-    for _ in 0..config.num_challenges {
-        extra_looking_products[Table::Keccak as usize].push(F::ONE);
-    }
-
-    // Logic
-    for _ in 0..config.num_challenges {
-        extra_looking_products[Table::Logic as usize].push(F::ONE);
-    }
+    // Extra products to add to the looked last value
+    // Arithmetic, KeccakSponge, Keccak, Logic
+    let mut extra_looking_products = vec![vec![F::ONE; config.num_challenges]; NUM_TABLES - 1];
 
     // Memory
+    extra_looking_products.push(Vec::new());
     let cpu_trace_len = 1 << all_proof.stark_proofs[1].proof.recover_degree_bits(config);
     for c in 0..config.num_challenges {
         extra_looking_products[Table::Memory as usize].push(get_memory_extra_looking_products(

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -1,6 +1,7 @@
 use std::any::type_name;
 
 use anyhow::{ensure, Result};
+use ethereum_types::{BigEndianHash, U256};
 use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::types::Field;
 use plonky2::fri::verifier::verify_fri_proof;
@@ -13,14 +14,17 @@ use crate::arithmetic::arithmetic_stark::ArithmeticStark;
 use crate::config::StarkConfig;
 use crate::constraint_consumer::ConstraintConsumer;
 use crate::cpu::cpu_stark::CpuStark;
+use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cross_table_lookup::{verify_cross_table_lookups, CtlCheckVars};
 use crate::keccak::keccak_stark::KeccakStark;
 use crate::keccak_sponge::keccak_sponge_stark::KeccakSpongeStark;
 use crate::logic::LogicStark;
 use crate::memory::memory_stark::MemoryStark;
-use crate::permutation::PermutationCheckVars;
+use crate::memory::segments::Segment;
+use crate::memory::{NUM_CHANNELS, VALUE_LIMBS};
+use crate::permutation::{GrandProductChallenge, PermutationCheckVars};
 use crate::proof::{
-    AllProof, AllProofChallenges, StarkOpeningSet, StarkProof, StarkProofChallenges,
+    AllProof, AllProofChallenges, PublicValues, StarkOpeningSet, StarkProof, StarkProofChallenges,
 };
 use crate::stark::Stark;
 use crate::vanishing_poly::eval_vanishing_poly;
@@ -106,11 +110,157 @@ where
         config,
     )?;
 
+    let public_values = all_proof.public_values;
+
+    // Extra products to add to the looked last value.
+    let mut extra_looking_products = Vec::new();
+
+    // KeccakSponge
+    extra_looking_products.push(Vec::new());
+    for _ in 0..config.num_challenges {
+        extra_looking_products[0].push(F::ONE);
+    }
+
+    // Keccak
+    extra_looking_products.push(Vec::new());
+    for _ in 0..config.num_challenges {
+        extra_looking_products[1].push(F::ONE);
+    }
+
+    // Logic
+    extra_looking_products.push(Vec::new());
+    for _ in 0..config.num_challenges {
+        extra_looking_products[2].push(F::ONE);
+    }
+
+    // Memory
+    extra_looking_products.push(Vec::new());
+    let cpu_trace_len = 1 << all_proof.stark_proofs[0].proof.recover_degree_bits(config);
+    for c in 0..config.num_challenges {
+        extra_looking_products[3].push(get_memory_extra_looking_products(
+            &public_values,
+            cpu_trace_len,
+            ctl_challenges.challenges[c],
+        ));
+    }
+
     verify_cross_table_lookups::<F, D>(
         cross_table_lookups,
         all_proof.stark_proofs.map(|p| p.proof.openings.ctl_zs_last),
+        extra_looking_products,
         config,
     )
+}
+
+/// Computes the extra product to multiply to the looked value. It contains memory operations not in the CPU trace:
+/// - block metadata writes before kernel bootstrapping,
+/// - public values reads at the end of the execution.
+pub(crate) fn get_memory_extra_looking_products<F, const D: usize>(
+    public_values: &PublicValues,
+    cpu_trace_len: usize,
+    challenge: GrandProductChallenge<F>,
+) -> F
+where
+    F: RichField + Extendable<D>,
+{
+    let mut prod = F::ONE;
+
+    // Add metadata writes.
+    let block_fields = [
+        (
+            GlobalMetadata::BlockBeneficiary,
+            U256::from_big_endian(&public_values.block_metadata.block_beneficiary.0),
+        ),
+        (
+            GlobalMetadata::BlockTimestamp,
+            public_values.block_metadata.block_timestamp,
+        ),
+        (
+            GlobalMetadata::BlockNumber,
+            public_values.block_metadata.block_number,
+        ),
+        (
+            GlobalMetadata::BlockDifficulty,
+            public_values.block_metadata.block_difficulty,
+        ),
+        (
+            GlobalMetadata::BlockGasLimit,
+            public_values.block_metadata.block_gaslimit,
+        ),
+        (
+            GlobalMetadata::BlockChainId,
+            public_values.block_metadata.block_chain_id,
+        ),
+        (
+            GlobalMetadata::BlockBaseFee,
+            public_values.block_metadata.block_base_fee,
+        ),
+    ];
+    let is_read = F::ZERO;
+    let context = F::ZERO;
+    let segment = F::from_canonical_u32(Segment::GlobalMetadata as u32);
+    let timestamp = F::ONE;
+
+    block_fields.map(|(field, val)| {
+        let mut row = vec![F::ZERO; 13];
+        row[0] = is_read;
+        row[1] = context;
+        row[2] = segment;
+        row[3] = F::from_canonical_usize(field as usize);
+
+        for j in 0..VALUE_LIMBS {
+            row[j + 4] = F::from_canonical_u32((val >> (j * 32)).low_u32());
+        }
+        row[12] = timestamp;
+        prod *= challenge.combine(row.iter());
+    });
+
+    // Add public values reads.
+    let trie_fields = [
+        (
+            GlobalMetadata::StateTrieRootDigestBefore,
+            public_values.trie_roots_before.state_root,
+        ),
+        (
+            GlobalMetadata::TransactionTrieRootDigestBefore,
+            public_values.trie_roots_before.transactions_root,
+        ),
+        (
+            GlobalMetadata::ReceiptTrieRootDigestBefore,
+            public_values.trie_roots_before.receipts_root,
+        ),
+        (
+            GlobalMetadata::StateTrieRootDigestAfter,
+            public_values.trie_roots_after.state_root,
+        ),
+        (
+            GlobalMetadata::TransactionTrieRootDigestAfter,
+            public_values.trie_roots_after.transactions_root,
+        ),
+        (
+            GlobalMetadata::ReceiptTrieRootDigestAfter,
+            public_values.trie_roots_after.receipts_root,
+        ),
+    ];
+    let is_read = F::ONE;
+    let timestamp = F::from_canonical_usize(cpu_trace_len * NUM_CHANNELS + 1);
+
+    trie_fields.map(|(field, hash)| {
+        let mut row = vec![F::ZERO; 13];
+        row[0] = is_read;
+        row[1] = context;
+        row[2] = segment;
+        row[3] = F::from_canonical_usize(field as usize);
+
+        let val = hash.into_uint();
+
+        for j in 0..VALUE_LIMBS {
+            row[j + 4] = F::from_canonical_u32((val >> (j * 32)).low_u32());
+        }
+        row[12] = timestamp;
+        prod *= challenge.combine(row.iter());
+    });
+    prod
 }
 
 pub(crate) fn verify_stark_proof_with_challenges<

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -141,12 +141,7 @@ pub(crate) fn generate_keccak_general<F: Field>(
     log::debug!("Hashing {:?}", input);
 
     let hash = keccak(&input);
-    let val_u64s: [u64; 4] =
-        core::array::from_fn(|i| u64::from_le_bytes(core::array::from_fn(|j| hash.0[i * 8 + j])));
-    let hash_int = U256(val_u64s);
-
-    let mut log_push = stack_push_log_and_fill(state, &mut row, hash_int)?;
-    log_push.value = hash.into_uint();
+    let log_push = stack_push_log_and_fill(state, &mut row, hash.into_uint())?;
 
     keccak_sponge_log(state, base_address, input);
 

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
-use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
+use eth_trie_utils::partial_trie::HashedPartialTrie;
 use keccak_hash::keccak;
 use log::info;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -15,10 +15,8 @@ use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
-use plonky2_evm::generation::{generate_traces, GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
-use plonky2_evm::prover::prove;
-use plonky2_evm::verifier::verify_proof;
+use plonky2_evm::generation::{GenerationInputs, TrieInputs};
+use plonky2_evm::proof::BlockMetadata;
 use plonky2_evm::Node;
 
 type F = GoldilocksField;
@@ -27,7 +25,7 @@ type C = PoseidonGoldilocksConfig;
 
 /// Execute the empty list of transactions, i.e. a no-op.
 #[test]
-//#[ignore] // Too slow to run on CI.
+#[ignore] // Too slow to run on CI.
 fn test_empty_txn_list() -> anyhow::Result<()> {
     init_logger();
 

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -93,11 +93,14 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         receipts_trie_root
     );
 
-    verify_proof(&all_stark, proof, &config)?;
+    verify_proof(&all_stark, proof.clone(), &config)?;
 
+    let cpu_trace_len = 1 << proof.stark_proofs[0].proof.recover_degree_bits(&config);
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
         &[16..17, 14..15, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list
+        &proof.public_values,
+        cpu_trace_len,
         &config,
     );
 

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -95,7 +95,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     verify_proof(&all_stark, proof.clone(), &config)?;
 
-    let cpu_trace_len = 1 << proof.stark_proofs[0].proof.recover_degree_bits(&config);
+    let cpu_trace_len = 1 << proof.stark_proofs[1].proof.recover_degree_bits(&config);
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
         &[16..17, 14..15, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -15,8 +15,8 @@ use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
-use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::BlockMetadata;
+use plonky2_evm::generation::{generate_traces, GenerationInputs, TrieInputs};
+use plonky2_evm::proof::{BlockMetadata, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -27,7 +27,7 @@ type C = PoseidonGoldilocksConfig;
 
 /// Execute the empty list of transactions, i.e. a no-op.
 #[test]
-#[ignore] // Too slow to run on CI.
+//#[ignore] // Too slow to run on CI.
 fn test_empty_txn_list() -> anyhow::Result<()> {
     init_logger();
 
@@ -40,10 +40,6 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
     let transactions_trie = HashedPartialTrie::from(Node::Empty);
     let receipts_trie = HashedPartialTrie::from(Node::Empty);
     let storage_tries = vec![];
-
-    let state_trie_root = state_trie.hash();
-    let txns_trie_root = transactions_trie.hash();
-    let receipts_trie_root = receipts_trie.hash();
 
     let mut contract_code = HashMap::new();
     contract_code.insert(keccak(vec![]), vec![]);
@@ -61,46 +57,9 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         addresses: vec![],
     };
 
-    let mut timing = TimingTree::new("prove", log::Level::Debug);
-    // TODO: This is redundant; prove_root below calls this prove method internally.
-    // Just keeping it for now because the root proof returned by prove_root doesn't contain public
-    // values yet, and we want those for the assertions below.
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs.clone(), &mut timing)?;
-    timing.filter(Duration::from_millis(100)).print();
-
-    assert_eq!(
-        proof.public_values.trie_roots_before.state_root,
-        state_trie_root
-    );
-    assert_eq!(
-        proof.public_values.trie_roots_after.state_root,
-        state_trie_root
-    );
-    assert_eq!(
-        proof.public_values.trie_roots_before.transactions_root,
-        txns_trie_root
-    );
-    assert_eq!(
-        proof.public_values.trie_roots_after.transactions_root,
-        txns_trie_root
-    );
-    assert_eq!(
-        proof.public_values.trie_roots_before.receipts_root,
-        receipts_trie_root
-    );
-    assert_eq!(
-        proof.public_values.trie_roots_after.receipts_root,
-        receipts_trie_root
-    );
-
-    verify_proof(&all_stark, proof.clone(), &config)?;
-
-    let cpu_trace_len = 1 << proof.stark_proofs[1].proof.recover_degree_bits(&config);
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
         &[16..17, 14..15, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list
-        &proof.public_values,
-        cpu_trace_len,
         &config,
     );
 
@@ -133,12 +92,18 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
     }
 
     let mut timing = TimingTree::new("prove", log::Level::Info);
-    let root_proof = all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
+    let (root_proof, public_values) =
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
     timing.filter(Duration::from_millis(100)).print();
     all_circuits.verify_root(root_proof.clone())?;
 
-    let agg_proof = all_circuits.prove_aggregation(false, &root_proof, false, &root_proof)?;
-    all_circuits.verify_aggregation(&agg_proof)
+    // We can duplicate the proofs here because the state hasn't mutated.
+    let (agg_proof, public_values) =
+        all_circuits.prove_aggregation(false, &root_proof, false, &root_proof, public_values)?;
+    all_circuits.verify_aggregation(&agg_proof)?;
+
+    let (block_proof, _) = all_circuits.prove_block(None, &agg_proof, public_values)?;
+    all_circuits.verify_block(&block_proof)
 }
 
 fn init_logger() {

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -323,6 +323,12 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         t
     }
 
+    pub fn add_virtual_public_input_arr<const N: usize>(&mut self) -> [Target; N] {
+        let ts = [0; N].map(|_| self.add_virtual_target());
+        self.register_public_inputs(&ts);
+        ts
+    }
+
     pub fn add_virtual_verifier_data(&mut self, cap_height: usize) -> VerifierCircuitTarget {
         VerifierCircuitTarget {
             constants_sigmas_cap: self.add_virtual_cap(cap_height),


### PR DESCRIPTION
This pull request fixes the memory CTL so that it doesn't have to be disabled anymore.
It also introduces a verifier-only memory bus to check a small set of memory operations.

## `KeccakSponge` endianness
Related issue: https://github.com/mir-protocol/plonky2/issues/1004
In the `KeccakSponge` STARK, the output of the hash is stored in `u32` columns written in big endian format. This introduces a discrepancy with how the columns are written in the `Memory` STARK, and makes the CTL check fail. The easiest solution to implement we found was to add columns in `KeccakSponge` for individual bytes of the output, which can be recombined in little endian format.

## Verifier-only memory bus
Following Daniel's advice [here](https://github.com/mir-protocol/plonky2/issues/988#issuecomment-1512002282), we introduced a set of memory operations which can be directly checked by the verifier by multiplying their contribution to the looked product. For the sake of generality, these extra values can be added to any CTL product though we only need it for memory.
For now, the operations checked by the verifier are the block metadata writes before kernel bootstrapping and the trie hash roots reads at the end of the execution.


Further work:
- To make sure they are consistent, the trie hash roots should be public inputs of the SNARK wrapper. I believe this is not the case yet.
- For the trie hash roots reads, we need the CPU trace length of the underlying CPU STARK. For now it's provided manually, but it should be propagated from the base CPU STARK to its SNARK wrapper, and all the way through the SNARK recursion chain to the root circuit. It could be handled with public inputs, or maybe with another verifier-only read of a global variable keeping track of the number of steps of the CPU?