### PR TITLE
Fix to hash precompile so EVM tests pass

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint = "0.4.3"
 once_cell = "1.13.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-plonky2 = { version = "0.1.2", default-features = false, features = ["timing"] }
+plonky2 = { path = "../plonky2", default-features = false, features = ["timing"] }
 plonky2_util = { version = "0.1.0" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -26,7 +26,7 @@ num-bigint = "0.4.3"
 once_cell = "1.13.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-plonky2 = { path = "../plonky2", default-features = false, features = ["timing"] }
+plonky2 = { version = "0.1.2", default-features = false, features = ["timing"] }
 plonky2_util = { version = "0.1.0" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"

--- a/evm/src/cpu/kernel/asm/core/precompiles/rip160.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/rip160.asm
@@ -27,7 +27,7 @@ global precompile_rip160:
     //
     //    %stack (ctx, size) ->
     //        (
-    //        0, @SEGMENT_KERNEL_GENERAL, 200, // DST
+    //        ctx, @SEGMENT_KERNEL_GENERAL, 200, // DST
     //        ctx, @SEGMENT_CALLDATA, 0,       // SRC
     //        size, ripemd,                    // count, retdest
     //        200, size, rip160_contd          // ripemd input: virt, num_bytes, retdest
@@ -42,7 +42,7 @@ global precompile_rip160:
     SWAP6
     PUSH 200
     PUSH @SEGMENT_KERNEL_GENERAL
-    PUSH 0
+    DUP3
 
     %jump(memcpy)
 

--- a/evm/src/cpu/kernel/asm/core/precompiles/sha256.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/sha256.asm
@@ -31,7 +31,7 @@ global precompile_sha256:
     //
     //    %stack (ctx, size) ->
     //        (
-    //        0, @SEGMENT_KERNEL_GENERAL, 1, // DST
+    //        ctx, @SEGMENT_KERNEL_GENERAL, 1, // DST
     //        ctx, @SEGMENT_CALLDATA, 0,     // SRC
     //        size, sha2,                    // count, retdest
     //        0, size, sha256_contd          // sha2 input: virt, num_bytes, retdest
@@ -47,7 +47,7 @@ global precompile_sha256:
     SWAP6
     PUSH 1
     PUSH @SEGMENT_KERNEL_GENERAL
-    PUSH 0
+    DUP3
 
     %jump(memcpy)
 

--- a/evm/src/cpu/kernel/asm/hash/ripemd/update.asm
+++ b/evm/src/cpu/kernel/asm/hash/ripemd/update.asm
@@ -117,7 +117,7 @@ buffer_update:
     DUP2
     DUP2
     // stack: get, set, get  , set  , times  , retdest
-    %mupdate_kernel_general
+    %mupdate_current_general
     // stack:           get  , set  , times  , retdest
     %increment
     SWAP1 

--- a/evm/src/cpu/kernel/asm/memory/core.asm
+++ b/evm/src/cpu/kernel/asm/memory/core.asm
@@ -194,6 +194,16 @@
     // stack: (empty)
 %endmacro
 
+// set offset i to offset j in kernel general
+%macro mupdate_current_general
+    // stack: j, i
+    %mload_current_general
+    // stack: x, i
+    SWAP1
+    %mstore_current_general
+    // stack: (empty)
+%endmacro
+
 // Load a single value from the given segment of kernel (context 0) memory.
 %macro mload_kernel(segment)
     // stack: offset
@@ -407,16 +417,6 @@
 %macro mstore_kernel_general_u32
     // stack: offset, value
     %mstore_kernel_u32(@SEGMENT_KERNEL_GENERAL)
-%endmacro
-
-// set offset i to offset j in kernel general
-%macro mupdate_kernel_general
-    // stack: j, i
-    %mload_kernel_general
-    // stack: x, i
-    SWAP1
-    %mstore_kernel_general
-    // stack: (empty)
 %endmacro
 
 // Load a single value from kernel general 2 memory.


### PR DESCRIPTION
#1029 broke some sha2 and ripemd EVM tests, this fixes them! (I think, I couldn't run the biggest tests on my machine)