### PR TITLE
`TrieInputs` now uses `H256` for storage account addresses

### DIFF
--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -71,7 +71,7 @@ pub struct TrieInputs {
 
     /// A partial version of each storage trie prior to these transactions. It should include all
     /// storage tries, and nodes therein, that will be accessed by these transactions.
-    pub storage_tries: Vec<(Address, HashedPartialTrie)>,
+    pub storage_tries: Vec<(H256, HashedPartialTrie)>,
 }
 
 fn apply_metadata_memops<F: RichField + Extendable<D>, const D: usize>(

--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -43,8 +43,8 @@ pub(crate) fn all_mpt_prover_inputs(trie_inputs: &TrieInputs) -> Vec<U256> {
     let storage_tries_by_state_key = trie_inputs
         .storage_tries
         .iter()
-        .map(|(address, storage_trie)| {
-            let key = Nibbles::from_bytes_be(keccak(address).as_bytes()).unwrap();
+        .map(|(hashed_address, storage_trie)| {
+            let key = Nibbles::from_bytes_be(hashed_address.as_bytes()).unwrap();
             (key, storage_trie)
         })
         .collect();

--- a/evm/tests/add11_yml.rs
+++ b/evm/tests/add11_yml.rs
@@ -39,11 +39,11 @@ fn add11_yml() -> anyhow::Result<()> {
 
     let beneficiary_state_key = keccak(beneficiary);
     let sender_state_key = keccak(sender);
-    let to_state_key = keccak(to);
+    let to_hashed = keccak(to);
 
     let beneficiary_nibbles = Nibbles::from_bytes_be(beneficiary_state_key.as_bytes()).unwrap();
     let sender_nibbles = Nibbles::from_bytes_be(sender_state_key.as_bytes()).unwrap();
-    let to_nibbles = Nibbles::from_bytes_be(to_state_key.as_bytes()).unwrap();
+    let to_nibbles = Nibbles::from_bytes_be(to_hashed.as_bytes()).unwrap();
 
     let code = [0x60, 0x01, 0x60, 0x01, 0x01, 0x60, 0x00, 0x55, 0x00];
     let code_hash = keccak(code);
@@ -74,7 +74,7 @@ fn add11_yml() -> anyhow::Result<()> {
         state_trie: state_trie_before,
         transactions_trie: Node::Empty.into(),
         receipts_trie: Node::Empty.into(),
-        storage_tries: vec![(Address::from_slice(&to), Node::Empty.into())],
+        storage_tries: vec![(to_hashed, Node::Empty.into())],
     };
 
     let txn = hex!("f863800a83061a8094095e7baea6a6c7c4c2dfeb977efac326af552d87830186a0801ba0ffb600e63115a7362e7811894a91d8ba4330e526f22121c994c4692035dfdfd5a06198379fcac8de3dbfac48b165df4bf88e2088f294b61efb9a65fe2281c76e16");

--- a/evm/tests/self_balance_gas_cost.rs
+++ b/evm/tests/self_balance_gas_cost.rs
@@ -39,11 +39,11 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
 
     let beneficiary_state_key = keccak(beneficiary);
     let sender_state_key = keccak(sender);
-    let to_state_key = keccak(to);
+    let to_hashed = keccak(to);
 
     let beneficiary_nibbles = Nibbles::from_bytes_be(beneficiary_state_key.as_bytes()).unwrap();
     let sender_nibbles = Nibbles::from_bytes_be(sender_state_key.as_bytes()).unwrap();
-    let to_nibbles = Nibbles::from_bytes_be(to_state_key.as_bytes()).unwrap();
+    let to_nibbles = Nibbles::from_bytes_be(to_hashed.as_bytes()).unwrap();
 
     let code = [
         0x5a, 0x47, 0x5a, 0x90, 0x50, 0x90, 0x03, 0x60, 0x02, 0x90, 0x03, 0x60, 0x01, 0x55, 0x00,
@@ -72,7 +72,7 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
         state_trie: state_trie_before,
         transactions_trie: Node::Empty.into(),
         receipts_trie: Node::Empty.into(),
-        storage_tries: vec![(Address::from_slice(&to), Node::Empty.into())],
+        storage_tries: vec![(to_hashed, Node::Empty.into())],
     };
 
     let txn = hex!("f861800a8405f5e10094100000000000000000000000000000000000000080801ba07e09e26678ed4fac08a249ebe8ed680bf9051a5e14ad223e4b2b9d26e0208f37a05f6e3f188e3e6eab7d7d3b6568f5eac7d687b08d307d3154ccd8c87b4630509b");


### PR DESCRIPTION
Slightly easier for us if we use `H256` instead of `H160`.