### PR TITLE
Fix arithmetic stark padding

### DIFF
--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -138,8 +138,10 @@ impl<F: RichField, const D: usize> ArithmeticStark<F, D> {
         }
 
         // Pad the trace with zero rows if it doesn't have enough rows
-        // to accommodate the range check columns.
-        for _ in trace_rows.len()..RANGE_MAX {
+        // to accommodate the range check columns. Also make sure the
+        // trace length is a power of two.
+        let padded_len = trace_rows.len().next_power_of_two();
+        for _ in trace_rows.len()..std::cmp::max(padded_len, RANGE_MAX) {
             trace_rows.push(vec![F::ZERO; columns::NUM_ARITH_COLUMNS]);
         }
 


### PR DESCRIPTION
The current padding only applies up to 65536 rows. For some ethereum tests of the test suite (for instance `GeneralStateTests/stSpecialTest/deploymentError`), the ArithmeticStark trace becomes larger and a panic arises.
This handles proper padding in those cases.