### PR TITLE
Revert #1074

### DIFF
--- a/evm/src/cpu/kernel/asm/core/create_contract_account.asm
+++ b/evm/src/cpu/kernel/asm/core/create_contract_account.asm
@@ -19,14 +19,11 @@
     // Check that the code is empty.
     %add_const(3)
     // stack: existing_codehash_ptr, address
-    %mload_trie_data // codehash = account[3]
+    DUP1 %mload_trie_data // codehash = account[3]
     %eq_const(@EMPTY_STRING_HASH) ISZERO %jumpi(%%error_collision)
-    // stack: address
-    PUSH 0 DUP2 %journal_add_nonce_change
-    // stack: address
-    %increment_nonce
-    PUSH 0 // success
-    %jump(%%end)
+    // stack: existing_codehash_ptr, address
+    %sub_const(2) %mload_trie_data // balance = account[1]
+    %jump(%%do_insert)
 
 %%add_account:
     // stack: existing_balance, address


### PR DESCRIPTION
Previous version was fine actually. Turns out some tests are really stupid and include empty accounts with non-empty storage. This can never happen in practice, so I think it can safely be ignored.