### PR TITLE
RIPEMD doesn't get untouched

### DIFF
--- a/evm/src/cpu/kernel/asm/journal/account_loaded.asm
+++ b/evm/src/cpu/kernel/asm/journal/account_loaded.asm
@@ -9,4 +9,11 @@ global revert_account_loaded:
     POP
     %journal_load_1
     // stack: address, retdest
+    DUP1 %eq_const(@RIP160) %jumpi(ripemd)
     %jump(remove_accessed_addresses)
+
+// The address 0x3 shouldn't become unloaded.
+// See https://github.com/ethereum/EIPs/issues/716.
+ripemd:
+    // stack: address, retdest
+    POP JUMP

--- a/evm/src/cpu/kernel/asm/journal/account_touched.asm
+++ b/evm/src/cpu/kernel/asm/journal/account_touched.asm
@@ -9,4 +9,11 @@ global revert_account_touched:
     POP
     %journal_load_1
     // stack: address, retdest
+    DUP1 %eq_const(@RIP160) %jumpi(ripemd)
     %jump(remove_touched_addresses)
+
+// The address 0x3 shouldn't become untouched.
+// See https://github.com/ethereum/EIPs/issues/716.
+ripemd:
+    // stack: address, retdest
+    POP JUMP


### PR DESCRIPTION
Yet another weird Ethereum quirk 