### PR TITLE
Store gas in two limbs to prevent overflow errors

### DIFF
--- a/evm/src/cpu/columns/mod.rs
+++ b/evm/src/cpu/columns/mod.rs
@@ -62,8 +62,8 @@ pub struct CpuColumnsView<T: Copy> {
     /// If CPU cycle: We're in kernel (privileged) mode.
     pub is_kernel_mode: T,
 
-    /// If CPU cycle: Gas counter.
-    pub gas: T,
+    /// If CPU cycle: Gas counter, split in two 32-bit limbs in little-endian order.
+    pub gas: [T; 2],
 
     /// If CPU cycle: flags for EVM instructions (a few cannot be shared; see the comments in
     /// `OpsColumnsView`).

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -511,10 +511,6 @@ pub(crate) fn generate_syscall<F: Field>(
     state: &mut GenerationState<F>,
     mut row: CpuColumnsView<F>,
 ) -> Result<(), ProgramError> {
-    if TryInto::<u32>::try_into(state.registers.gas_used).is_err() {
-        return Err(ProgramError::GasLimitError);
-    }
-
     if state.registers.stack_len < stack_values_read {
         return Err(ProgramError::StackUnderflow);
     }
@@ -604,9 +600,6 @@ pub(crate) fn generate_exit_kernel<F: Field>(
     assert!(is_kernel_mode_val == 0 || is_kernel_mode_val == 1);
     let is_kernel_mode = is_kernel_mode_val != 0;
     let gas_used_val = kexit_info.0[3];
-    if TryInto::<u32>::try_into(gas_used_val).is_err() {
-        panic!();
-    }
 
     if is_kernel_mode {
         row.general.exit_kernel_mut().stack_len_check_aux = F::ZERO;

--- a/evm/src/witness/transition.rs
+++ b/evm/src/witness/transition.rs
@@ -251,7 +251,10 @@ fn base_row<F: Field>(state: &mut GenerationState<F>) -> (CpuColumnsView<F>, u8)
     row.context = F::from_canonical_usize(state.registers.context);
     row.program_counter = F::from_canonical_usize(state.registers.program_counter);
     row.is_kernel_mode = F::from_bool(state.registers.is_kernel);
-    row.gas = F::from_canonical_u64(state.registers.gas_used);
+    row.gas = [
+        F::from_canonical_u32(state.registers.gas_used as u32),
+        F::from_canonical_u64(state.registers.gas_used >> 32),
+    ];
     row.stack_len = F::from_canonical_usize(state.registers.stack_len);
 
     let opcode = read_code_memory(state, &mut row);


### PR DESCRIPTION
The gas value stored in kernel exit info can sometimes be greater than the current u32 limit, causing overflows with the existing config. See `stCreate2/returndatacopy_following_create` for a related failing test, where the CALL uses a (too) large amount of gas to send to the subcontext.