### PR TITLE
Remove parts of the copy-on-write logic

### DIFF
--- a/evm/src/cpu/kernel/asm/core/create.asm
+++ b/evm/src/cpu/kernel/asm/core/create.asm
@@ -239,7 +239,6 @@ create_too_deep:
 
 // Pre stack: addr, codehash, redest
 // Post stack: (empty)
-// TODO: Should it be copy-on-write (with make_account_copy) instead of mutating the trie?
 global set_codehash:
     // stack: addr, codehash, retdest
     DUP1 %insert_touched_addresses

--- a/evm/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm/src/cpu/kernel/asm/core/terminate.asm
@@ -89,7 +89,7 @@ global sys_selfdestruct:
     // stack: account_ptr, 0, balance, address, recipient, kexit_info
     %add_const(1)
     // stack: balance_ptr, 0, balance, address, recipient, kexit_info
-    %mstore_trie_data // TODO: This should be a copy-on-write operation.
+    %mstore_trie_data
 
     %stack (balance, address, recipient, kexit_info) ->
         (address, recipient, balance, address, recipient, recipient, balance, kexit_info)

--- a/evm/src/cpu/kernel/asm/core/transfer.asm
+++ b/evm/src/cpu/kernel/asm/core/transfer.asm
@@ -26,7 +26,6 @@ global transfer_eth_failure:
 // Returns 0 on success, or 1 if addr has insufficient balance. Panics if addr isn't found in the trie.
 // Pre stack: addr, amount, retdest
 // Post stack: status (0 indicates success)
-// TODO: Should it be copy-on-write (with make_account_copy) instead of mutating the trie?
 global deduct_eth:
     // stack: addr, amount, retdest
     DUP1 %insert_touched_addresses
@@ -63,7 +62,6 @@ global deduct_eth_insufficient_balance:
 
 // Pre stack: addr, amount, redest
 // Post stack: (empty)
-// TODO: Should it be copy-on-write (with make_account_copy) instead of mutating the trie?
 global add_eth:
     // stack: addr, amount, retdest
     DUP1 %insert_touched_addresses

--- a/evm/src/cpu/kernel/asm/journal/storage_change.asm
+++ b/evm/src/cpu/kernel/asm/journal/storage_change.asm
@@ -47,17 +47,11 @@ delete:
 new_storage_root:
     // stack: new_storage_root_ptr, address, retdest
     DUP2 %mpt_read_state_trie
-    // stack: old_account_ptr, new_storage_root_ptr, address, retdest
-    %make_account_copy
-    // stack: new_account_ptr, new_storage_root_ptr, address, retdest
+    // stack: account_ptr, new_storage_root_ptr, address, retdest
 
-    // Update the copied account with our new storage root pointer.
-    %stack (new_account_ptr, new_storage_root_ptr) -> (new_account_ptr, new_storage_root_ptr, new_account_ptr)
+    // Update account with our new storage root pointer.
     %add_const(2)
-    // stack: new_account_storage_root_ptr_ptr, new_storage_root_ptr, new_account_ptr, address, retdest
+    // stack: account_storage_root_ptr_ptr, new_storage_root_ptr, address, retdest
     %mstore_trie_data
-    // stack: new_account_ptr, address, retdest
-
-    DUP2 %addr_to_state_key
-    %stack (state_key, new_account_ptr, address, retdest) -> (state_key, new_account_ptr, retdest)
-    %jump(mpt_insert_state_trie)
+    // stack: address, retdest
+    POP JUMP

--- a/evm/src/cpu/kernel/asm/mpt/accounts.asm
+++ b/evm/src/cpu/kernel/asm/mpt/accounts.asm
@@ -19,35 +19,3 @@
     %mload_trie_data
     // stack: storage_root_ptr
 %endmacro
-
-global make_default_account:
-    PANIC // TODO
-
-// Create a copy of the given account. The copy can then safely be mutated as
-// needed, while leaving the original account data untouched.
-//
-// This writes the new account's data to MPT data, but does not register the new
-// account in the state trie.
-//
-// Pre stack: old_account_ptr, retdest
-// Post stack: new_account_ptr
-global make_account_copy:
-    // stack: old_account_ptr, retdest
-    %get_trie_data_size // pointer to new account we're about to create
-    // stack: new_account_ptr, old_account_ptr, retdest
-
-    DUP2                %mload_trie_data %append_to_trie_data
-    DUP2  %add_const(1) %mload_trie_data %append_to_trie_data
-    DUP2  %add_const(2) %mload_trie_data %append_to_trie_data
-    SWAP1 %add_const(3) %mload_trie_data %append_to_trie_data
-
-    // stack: new_account_ptr, retdest
-    SWAP1
-    JUMP
-
-// Convenience macro to call make_account_copy and return where we left off.
-%macro make_account_copy
-    %stack (old_account_ptr) -> (old_account_ptr, %%after)
-    %jump(make_account_copy)
-%%after:
-%endmacro

--- a/evm/src/cpu/kernel/asm/mpt/delete/delete.asm
+++ b/evm/src/cpu/kernel/asm/mpt/delete/delete.asm
@@ -3,6 +3,7 @@
 //
 // Pre stack: node_ptr, num_nibbles, key, retdest
 // Post stack: updated_node_ptr
+// TODO: Optimize this by removing the copy-on-write logic.
 global mpt_delete:
     // stack: node_ptr, num_nibbles, key, retdest
     DUP1 %mload_trie_data

--- a/evm/src/cpu/kernel/asm/mpt/insert/insert.asm
+++ b/evm/src/cpu/kernel/asm/mpt/insert/insert.asm
@@ -2,6 +2,7 @@
 //
 // Pre stack: node_ptr, num_nibbles, key, value_ptr, retdest
 // Post stack: updated_node_ptr
+// TODO: Optimize this by removing the copy-on-write logic.
 global mpt_insert:
     // stack: node_ptr, num_nibbles, key, value_ptr, retdest
     DUP1 %mload_trie_data

--- a/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
+++ b/evm/src/cpu/kernel/asm/mpt/storage/storage_write.asm
@@ -116,24 +116,12 @@ sstore_after_refund:
 after_storage_insert:
     // stack: new_storage_root_ptr, kexit_info
     %current_account_data
-    // stack: old_account_ptr, new_storage_root_ptr, kexit_info
-    %make_account_copy
-    // stack: new_account_ptr, new_storage_root_ptr, kexit_info
+    // stack: account_ptr, new_storage_root_ptr, kexit_info
 
     // Update the copied account with our new storage root pointer.
-    %stack (new_account_ptr, new_storage_root_ptr) -> (new_account_ptr, new_storage_root_ptr, new_account_ptr)
     %add_const(2)
-    // stack: new_account_storage_root_ptr_ptr, new_storage_root_ptr, new_account_ptr, kexit_info
+    // stack: account_storage_root_ptr_ptr, new_storage_root_ptr, kexit_info
     %mstore_trie_data
-    // stack: new_account_ptr, kexit_info
-
-    // Save this updated account to the state trie.
-    %stack (new_account_ptr) -> (new_account_ptr, after_state_insert)
-    %address %addr_to_state_key
-    // stack: state_key, new_account_ptr, after_state_insert, kexit_info
-    %jump(mpt_insert_state_trie)
-
-after_state_insert:
     // stack: kexit_info
     EXIT_KERNEL
 

--- a/evm/src/memory/segments.rs
+++ b/evm/src/memory/segments.rs
@@ -28,8 +28,7 @@ pub enum Segment {
     TxnData = 11,
     /// A buffer used to hold raw RLP data.
     RlpRaw = 12,
-    /// Contains all trie data. Tries are stored as immutable, copy-on-write trees, so this is an
-    /// append-only buffer. It is owned by the kernel, so it only lives on context 0.
+    /// Contains all trie data. It is owned by the kernel, so it only lives on context 0.
     TrieData = 13,
     /// A buffer used to store the encodings of a branch node's children.
     TrieEncodedChild = 14,

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -64,6 +64,33 @@ where
 
 /// Generate traces, then create all STARK proofs. Returns information about the post-state,
 /// intended for debugging, in addition to the proof.
+pub fn dont_prove_with_outputs<F, C, const D: usize>(
+    all_stark: &AllStark<F, D>,
+    config: &StarkConfig,
+    inputs: GenerationInputs,
+    timing: &mut TimingTree,
+) -> Result<(PublicValues, GenerationOutputs)>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    [(); ArithmeticStark::<F, D>::COLUMNS]:,
+    [(); CpuStark::<F, D>::COLUMNS]:,
+    [(); KeccakStark::<F, D>::COLUMNS]:,
+    [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
+    [(); LogicStark::<F, D>::COLUMNS]:,
+    [(); MemoryStark::<F, D>::COLUMNS]:,
+{
+    timed!(timing, "build kernel", Lazy::force(&KERNEL));
+    let (_traces, public_values, outputs) = timed!(
+        timing,
+        "generate all traces",
+        generate_traces(all_stark, inputs, config, timing)?
+    );
+    Ok((public_values, outputs))
+}
+
+/// Generate traces, then create all STARK proofs. Returns information about the post-state,
+/// intended for debugging, in addition to the proof.
 pub fn prove_with_outputs<F, C, const D: usize>(
     all_stark: &AllStark<F, D>,
     config: &StarkConfig,

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -64,33 +64,6 @@ where
 
 /// Generate traces, then create all STARK proofs. Returns information about the post-state,
 /// intended for debugging, in addition to the proof.
-pub fn dont_prove_with_outputs<F, C, const D: usize>(
-    all_stark: &AllStark<F, D>,
-    config: &StarkConfig,
-    inputs: GenerationInputs,
-    timing: &mut TimingTree,
-) -> Result<(PublicValues, GenerationOutputs)>
-where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    [(); ArithmeticStark::<F, D>::COLUMNS]:,
-    [(); CpuStark::<F, D>::COLUMNS]:,
-    [(); KeccakStark::<F, D>::COLUMNS]:,
-    [(); KeccakSpongeStark::<F, D>::COLUMNS]:,
-    [(); LogicStark::<F, D>::COLUMNS]:,
-    [(); MemoryStark::<F, D>::COLUMNS]:,
-{
-    timed!(timing, "build kernel", Lazy::force(&KERNEL));
-    let (_traces, public_values, outputs) = timed!(
-        timing,
-        "generate all traces",
-        generate_traces(all_stark, inputs, config, timing)?
-    );
-    Ok((public_values, outputs))
-}
-
-/// Generate traces, then create all STARK proofs. Returns information about the post-state,
-/// intended for debugging, in addition to the proof.
 pub fn prove_with_outputs<F, C, const D: usize>(
     all_stark: &AllStark<F, D>,
     config: &StarkConfig,


### PR DESCRIPTION
With the journal-based approach to state reversion, we don't need the tries to be copy-on-write.
MPT insertion and deletion can also be optimized a lot by removing the copying logic. Left that as a TODO.