### PR TITLE
Make serializer work with slices

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -297,7 +297,7 @@ where
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes.to_vec());
+        let mut buffer = Buffer::new(bytes);
         let root =
             RootCircuitData::from_buffer(&mut buffer, gate_serializer, generator_serializer)?;
         let aggregation = AggregationCircuitData::from_buffer(

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -134,7 +134,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes.to_vec());
+        let mut buffer = Buffer::new(bytes);
         buffer.read_circuit_data(gate_serializer, generator_serializer)
     }
 
@@ -231,7 +231,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes.to_vec());
+        let mut buffer = Buffer::new(bytes);
         buffer.read_prover_circuit_data(gate_serializer, generator_serializer)
     }
 
@@ -269,7 +269,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         bytes: Vec<u8>,
         gate_serializer: &dyn GateSerializer<F, D>,
     ) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         buffer.read_verifier_circuit_data(gate_serializer)
     }
 
@@ -332,7 +332,7 @@ impl<C: GenericConfig<D>, const D: usize> VerifierOnlyCircuitData<C, D> {
     }
 
     pub fn from_bytes(bytes: Vec<u8>) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         buffer.read_verifier_only_circuit_data()
     }
 }
@@ -379,7 +379,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CommonCircuitData<F, D> {
         bytes: Vec<u8>,
         gate_serializer: &dyn GateSerializer<F, D>,
     ) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         buffer.read_common_circuit_data(gate_serializer)
     }
 

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -21,9 +21,7 @@ use crate::iop::target::Target;
 use crate::plonk::circuit_data::{CommonCircuitData, VerifierOnlyCircuitData};
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::verifier::verify_with_challenges;
-use crate::util::serialization::Write;
-#[cfg(feature = "std")]
-use crate::util::serialization::{Buffer, Read};
+use crate::util::serialization::{Buffer, Read, Write};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(bound = "")]
@@ -111,7 +109,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         buffer
     }
 
-    #[cfg(feature = "std")]
     pub fn from_bytes(
         bytes: Vec<u8>,
         common_data: &CommonCircuitData<F, D>,
@@ -241,7 +238,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         buffer
     }
 
-    #[cfg(feature = "std")]
     pub fn from_bytes(
         bytes: Vec<u8>,
         common_data: &CommonCircuitData<F, D>,

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -116,7 +116,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         bytes: Vec<u8>,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         let proof = buffer
             .read_proof_with_public_inputs(common_data)
             .map_err(anyhow::Error::msg)?;
@@ -246,7 +246,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         bytes: Vec<u8>,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         let proof = buffer
             .read_compressed_proof_with_public_inputs(common_data)
             .map_err(anyhow::Error::msg)?;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -49,7 +49,7 @@ impl VerifierCircuitTarget {
     }
 
     pub fn from_bytes(bytes: Vec<u8>) -> IoResult<Self> {
-        let mut buffer = Buffer::new(bytes);
+        let mut buffer = Buffer::new(&bytes);
         let constants_sigmas_cap = buffer.read_target_merkle_cap()?;
         let circuit_digest = buffer.read_target_hash()?;
         Ok(Self {

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -1993,16 +1993,16 @@ impl Write for Vec<u8> {
 /// Buffer
 #[cfg(feature = "std")]
 #[derive(Debug)]
-pub struct Buffer {
-    bytes: Vec<u8>,
+pub struct Buffer<'a> {
+    bytes: &'a [u8],
     pos: usize,
 }
 
 #[cfg(feature = "std")]
-impl Buffer {
+impl<'a> Buffer<'a> {
     /// Builds a new [`Buffer`] over `buffer`.
     #[inline]
-    pub fn new(bytes: Vec<u8>) -> Self {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes, pos: 0 }
     }
 
@@ -2014,26 +2014,24 @@ impl Buffer {
 
     /// Returns the inner buffer.
     #[inline]
-    pub fn bytes(&self) -> Vec<u8> {
-        self.bytes.clone()
+    pub fn bytes(&self) -> &'a [u8] {
+        self.bytes
     }
 
     /// Returns the inner unread buffer.
     #[inline]
-    pub fn unread_bytes(&self) -> Vec<u8> {
-        self.bytes[self.pos..].to_vec()
+    pub fn unread_bytes(&self) -> &'a [u8] {
+        &self.bytes()[self.pos()..]
     }
 }
 
-#[cfg(feature = "std")]
-impl Remaining for Buffer {
+impl<'a> Remaining for Buffer<'a> {
     fn remaining(&self) -> usize {
-        self.bytes.len() - self.pos
+        self.bytes.len() - self.pos()
     }
 }
 
-#[cfg(feature = "std")]
-impl Read for Buffer {
+impl<'a> Read for Buffer<'a> {
     #[inline]
     fn read_exact(&mut self, bytes: &mut [u8]) -> IoResult<()> {
         let n = bytes.len();

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -1991,14 +1991,12 @@ impl Write for Vec<u8> {
 }
 
 /// Buffer
-#[cfg(feature = "std")]
 #[derive(Debug)]
 pub struct Buffer<'a> {
     bytes: &'a [u8],
     pos: usize,
 }
 
-#[cfg(feature = "std")]
 impl<'a> Buffer<'a> {
     /// Builds a new [`Buffer`] over `buffer`.
     #[inline]


### PR DESCRIPTION
Deserializing (especially large objects like `AllRecursiveCircuits`)  can get expensive when copying the bytes into a new `Buffer`.
Also removes the conditional attribute with `std` (I'm not sure why it was to begin with, as `Vec` is imported from `alloc`?).