### PR TITLE
clippy fixes

### DIFF
--- a/evm/src/cpu/gas.rs
+++ b/evm/src/cpu/gas.rs
@@ -60,6 +60,7 @@ const SIMPLE_OPCODES: OpsColumnsView<Option<u32>> = OpsColumnsView {
     exception: None,
 };
 
+#[allow(clippy::useless_conversion)] // For izip! macro.
 fn eval_packed_accumulate<P: PackedField>(
     lv: &CpuColumnsView<P>,
     nv: &CpuColumnsView<P>,
@@ -118,6 +119,7 @@ pub fn eval_packed<P: PackedField>(
     eval_packed_init(lv, nv, yield_constr);
 }
 
+#[allow(clippy::useless_conversion)] // For izip! macro.
 fn eval_ext_circuit_accumulate<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
     lv: &CpuColumnsView<ExtensionTarget<D>>,

--- a/evm/src/cpu/kernel/tests/bignum/mod.rs
+++ b/evm/src/cpu/kernel/tests/bignum/mod.rs
@@ -188,7 +188,7 @@ fn test_add_bignum(a: BigUint, b: BigUint, expected_output: BigUint) -> Result<(
 fn test_addmul_bignum(a: BigUint, b: BigUint, c: u128, expected_output: BigUint) -> Result<()> {
     let len = bignum_len(&a).max(bignum_len(&b));
     let mut memory = pad_bignums(&[a, b], len);
-    memory.splice(len..len, vec![0.into(); 2].iter().cloned());
+    memory.splice(len..len, [0.into(); 2].iter().cloned());
 
     let a_start_loc = 0;
     let b_start_loc = len + 2;

--- a/evm/src/cpu/memio.rs
+++ b/evm/src/cpu/memio.rs
@@ -40,6 +40,7 @@ fn eval_packed_load<P: PackedField>(
     }
 }
 
+#[allow(clippy::tuple_array_conversions)] // For izip! macro.
 fn eval_ext_circuit_load<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
     lv: &CpuColumnsView<ExtensionTarget<D>>,
@@ -109,6 +110,7 @@ fn eval_packed_store<P: PackedField>(
     }
 }
 
+#[allow(clippy::tuple_array_conversions)] // For izip! macro.
 fn eval_ext_circuit_store<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
     lv: &CpuColumnsView<ExtensionTarget<D>>,

--- a/evm/src/cpu/stack.rs
+++ b/evm/src/cpu/stack.rs
@@ -187,6 +187,7 @@ fn eval_packed_one<P: PackedField>(
     }
 }
 
+#[allow(clippy::useless_conversion)] // For izip! macro.
 pub fn eval_packed<P: PackedField>(
     lv: &CpuColumnsView<P>,
     yield_constr: &mut ConstraintConsumer<P>,
@@ -301,6 +302,7 @@ fn eval_ext_circuit_one<F: RichField + Extendable<D>, const D: usize>(
     }
 }
 
+#[allow(clippy::useless_conversion)] // For izip! macro.
 pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
     lv: &CpuColumnsView<ExtensionTarget<D>>,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -188,7 +188,7 @@ where
         let circuit = buffer.read_circuit_data(gate_serializer, generator_serializer)?;
         let target_vec = buffer.read_target_vec()?;
         let init_challenger_state_target =
-            <C::Hasher as AlgebraicHasher<F>>::AlgebraicPermutation::new(target_vec.into_iter());
+            <C::Hasher as AlgebraicHasher<F>>::AlgebraicPermutation::new(target_vec);
         let zero_target = buffer.read_target()?;
         let stark_proof_target = StarkProofTarget::from_buffer(buffer)?;
         let ctl_challenges_target = GrandProductChallengeSet::from_buffer(buffer)?;

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
-itertools = { version = "0.10.0", default-features = false, features = ["use_alloc"] }
+itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "rand"] }
 plonky2_util = { version = "0.1.0", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -21,7 +21,7 @@ timing = ["std"]
 ahash = { version = "0.7.6", default-features = false, features = ["compile-time-rng"] } # NOTE: Be sure to keep this version the same as the dependency in `hashbrown`.
 anyhow = { version = "1.0.40", default-features = false }
 hashbrown = { version = "0.12.3", default-features = false, features = ["ahash", "serde"] } # NOTE: When upgrading, see `ahash` dependency.
-itertools = { version = "0.10.0", default-features = false }
+itertools = { version = "0.11.0", default-features = false }
 keccak-hash = { version = "0.8.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -136,7 +136,7 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     // obtaining our duplex's post-state which contains the PoW response.
     let mut duplex_intermediate_state = challenger.sponge_state;
     let witness_input_pos = challenger.input_buffer.len();
-    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone().into_iter(), 0);
+    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone(), 0);
 
     let pow_witness = (0..=F::NEG_ONE.to_canonical_u64())
         .into_par_iter()

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -58,6 +58,7 @@ pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>
             )],
             SelectorsInfo {
                 selector_indices: vec![0; num_gates],
+                #[allow(clippy::single_range_in_vec_init)]
                 groups: vec![0..num_gates],
             },
         );

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -36,6 +36,7 @@ impl SelectorsInfo {
 ///         k
 ///     else
 ///         UNUSED_SELECTOR
+#[allow(clippy::single_range_in_vec_init)] // `groups` is a Vec of Ranges.
 pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>(
     gates: &[GateRef<F, D>],
     instances: &[GateInstance<F, D>],
@@ -48,7 +49,6 @@ pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>
     let index = |id| gates.iter().position(|g| g.0.id() == id).unwrap();
 
     // Special case if we can use only one selector polynomial.
-    #[allow(clippy::single_range_in_vec_init)]
     if max_gate_degree + num_gates - 1 <= max_degree {
         return (
             vec![PolynomialValues::new(

--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -48,6 +48,7 @@ pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>
     let index = |id| gates.iter().position(|g| g.0.id() == id).unwrap();
 
     // Special case if we can use only one selector polynomial.
+    #[allow(clippy::single_range_in_vec_init)]
     if max_gate_degree + num_gates - 1 <= max_degree {
         return (
             vec![PolynomialValues::new(
@@ -58,7 +59,6 @@ pub(crate) fn selector_polynomials<F: RichField + Extendable<D>, const D: usize>
             )],
             SelectorsInfo {
                 selector_indices: vec![0; num_gates],
-                #[allow(clippy::single_range_in_vec_init)]
                 groups: vec![0..num_gates],
             },
         );

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -332,8 +332,8 @@ mod tests {
 
         // These are mostly arbitrary, but we want to test some rounds with enough inputs/outputs to
         // trigger multiple absorptions/squeezes.
-        let num_inputs_per_round = vec![2, 5, 3];
-        let num_outputs_per_round = vec![1, 2, 4];
+        let num_inputs_per_round = [2, 5, 3];
+        let num_outputs_per_round = [1, 2, 4];
 
         // Generate random input messages.
         let inputs_per_round: Vec<Vec<F>> = num_inputs_per_round

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -18,7 +18,7 @@ timing = ["plonky2/timing"]
 
 [dependencies]
 anyhow = { version = "1.0.40", default-features = false }
-itertools = { version = "0.10.0", default-features = false }
+itertools = { version = "0.11.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
 plonky2_maybe_rayon = { version = "0.1.0", default-features = false }
 plonky2 = { version = "0.1.2", default-features = false }


### PR DESCRIPTION
Fixes for updated clippy. Mostly following its suggestions, except for two kinds of errors where it's wrong about arguments to the `izip!` macro (I bumped the itertools version, but seems like it hasn't been updated); so in those cases I just use an `allow`