### PR TITLE
Fix jump operation generation

### DIFF
--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -185,13 +185,14 @@ pub(crate) fn generate_jump<F: Field>(
         state,
         &mut row,
     );
+
+    row.mem_channels[1].value[0] = F::ONE;
+
     if state.registers.is_kernel {
         // Don't actually do the read, just set the address, etc.
         let channel = &mut row.mem_channels[NUM_GP_CHANNELS - 1];
         channel.used = F::ZERO;
         channel.value[0] = F::ONE;
-
-        row.mem_channels[1].value[0] = F::ONE;
     } else {
         if jumpdest_bit != U256::one() {
             return Err(ProgramError::InvalidJumpDestination);


### PR DESCRIPTION
We noticed that some proof verifications were failing due to a constraint in `jump.rs`: `lv.op.jump * (cond[0] - P::ONES)` (l. 76). 
This is due to the fact that in `generate_jump`, `row.mem_channels[1].value[0]` was only set to 1 if it was a kernel operation. However, the comment in `jump.rs` explains that `row.mem_channels[1].value[0]` is a predicate that is always 1 when the operation is a `JUMP`.
We therefore set the memory value to 1 outside of the `if` condition in `generate_jump`. 