### PR TITLE
Fix nightly version in CI to 2023-06-30

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2023-06-30
           override: true
 
       - name: rust-cache
@@ -62,7 +62,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2023-06-30
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
The latest nightly toolchain broke the build, see #1110. This PR fixes the toolchain version to 2023-06-30 until new versions work.