### PR TITLE
Lookup arg optimizations

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -30,7 +30,7 @@ plonky2_field = { version = "0.1.0", default-features = false }
 plonky2_util = { version = "0.1.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 serde_json = "1.0"
 static_assertions = { version = "1.1.0", default-features = false }
 unroll = { version = "0.1.5", default-features = false }

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -15,6 +15,7 @@ use crate::field::zero_poly_coset::ZeroPolyOnCoset;
 use crate::fri::oracle::PolynomialBatch;
 use crate::gates::lookup::LookupGate;
 use crate::gates::lookup_table::LookupTableGate;
+use crate::gates::selectors::LookupSelectors;
 use crate::hash::hash_types::RichField;
 use crate::iop::challenger::Challenger;
 use crate::iop::generator::generate_partial_witness;
@@ -25,7 +26,7 @@ use crate::plonk::circuit_data::{CommonCircuitData, ProverOnlyCircuitData};
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::plonk_common::PlonkOracle;
 use crate::plonk::proof::{OpeningSet, Proof, ProofWithPublicInputs};
-use crate::plonk::vanishing_poly::eval_vanishing_poly_base_batch;
+use crate::plonk::vanishing_poly::{eval_vanishing_poly_base_batch, get_lut_poly};
 use crate::plonk::vars::EvaluationVarsBaseBatch;
 use crate::timed;
 use crate::util::partial_products::{partial_products_and_z_gx, quotient_chunk_products};
@@ -68,7 +69,9 @@ pub fn set_lookup_wires<
 
         for (inp_target, _) in prover_data.lut_to_lookups[lut_index].iter() {
             let inp_value = pw.get_target(*inp_target);
-            let idx = table_value_to_idx.get(&u16::try_from(inp_value.to_canonical_u64()).unwrap()).unwrap();
+            let idx = table_value_to_idx
+                .get(&u16::try_from(inp_value.to_canonical_u64()).unwrap())
+                .unwrap();
 
             multiplicities[*idx] += 1;
         }
@@ -618,8 +621,45 @@ fn compute_quotient_polys<
 
     let z_h_on_coset = ZeroPolyOnCoset::new(common_data.degree_bits(), quotient_degree_bits);
 
+    // Precompute the lookup table evals on the challenges in delta
+    // These values are used to produce the final RE constraints for each lut,
+    // and are the same each time in check_lookup_constraints_batched.
+    // lut_poly_evals[i][j] gives the eval for the i'th challenge and the j'th lookup table
+    let lut_re_poly_evals: Vec<Vec<F>> = if has_lookup {
+        let num_lut_slots = LookupTableGate::num_slots(&common_data.config);
+        (0..num_challenges)
+            .map(move |i| {
+                let cur_deltas = &deltas[NUM_COINS_LOOKUP * i..NUM_COINS_LOOKUP * (i + 1)];
+                let cur_challenge_delta = cur_deltas[LookupChallenges::ChallengeDelta as usize];
+
+                (LookupSelectors::StartEnd as usize..common_data.num_lookup_selectors)
+                    .map(|r| {
+                        let lut_row_number = ceil_div_usize(
+                            common_data.luts[r - LookupSelectors::StartEnd as usize].len(),
+                            num_lut_slots,
+                        );
+
+                        get_lut_poly(
+                            common_data,
+                            r - LookupSelectors::StartEnd as usize,
+                            cur_deltas,
+                            num_lut_slots * lut_row_number,
+                        )
+                        .eval(cur_challenge_delta)
+                    })
+                    .collect()
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    let lut_re_poly_evals_refs: Vec<&[F]> =
+        lut_re_poly_evals.iter().map(|v| v.as_slice()).collect();
+
     let points_batches = points.par_chunks(BATCH_SIZE);
     let num_batches = ceil_div_usize(points.len(), BATCH_SIZE);
+
     let quotient_values: Vec<Vec<F>> = points_batches
         .enumerate()
         .flat_map(|(batch_i, xs_batch)| {
@@ -729,6 +769,7 @@ fn compute_quotient_polys<
                 deltas,
                 alphas,
                 &z_h_on_coset,
+                &lut_re_poly_evals_refs,
             );
 
             for (&i, quotient_values) in indices_batch.iter().zip(quotient_values_batch.iter_mut())


### PR DESCRIPTION
We've been using lookups downstream for a while, with tables of size 2^16 (for u16 range checks) and hundreds of thousands of lookups in a circuit. This PR addresses the main bottlenecks that were at first producing poor building/proving times (around 100x/3x overall vs. baseline, respectively) at this scale.

Changes: 
- using a linear-time pass to count multiplicities vs. the current O(n^2) implementation
- precomputing the RE poly evaluations, which were being re-computed redundantly. This sped up the [`compute quotient polys`](https://github.com/mir-protocol/plonky2/blob/main/plonky2/src/plonk/prover.rs#L229-L243) step of proving by about 10x for our circuits (size 2^21 with width ~200, using the aforementioned size 2^16 tables)

The remaining significant bottleneck we encountered was also at build time, owing to the fact that the id() of `LookupGate` and `LookupTableGate` includes the full table, and this id is hashed every time another gate gets added to the circuit builder. However, our fix for this was hacky so I didn't include it here—a good solution might have some overlap with the serialization stuff mentioned [here](https://github.com/mir-protocol/plonky2/pull/964#issuecomment-1613105117).

Also, for future reference, I identified [here](https://github.com/mir-protocol/plonky2/blob/main/plonky2/src/plonk/prover.rs#L212-L223) and [here](https://github.com/mir-protocol/plonky2/blob/main/plonky2/src/fri/oracle.rs#L188-L192) as routines that may also have some unneeded performance bloat due to lookups—they are probably worth taking a look at for anyone who wants to improve lookup performance further.

Thanks to @Nashtare and the others who implemented this feature, it's been super helpful :)