### PR TITLE
Remove need for matching start ranges

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -6,6 +6,7 @@ use hashbrown::HashMap;
 use itertools::{zip_eq, Itertools};
 use plonky2::field::extension::Extendable;
 use plonky2::fri::FriParams;
+use plonky2::gates::constant::ConstantGate;
 use plonky2::gates::noop::NoopGate;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::challenger::RecursiveChallenger;
@@ -490,6 +491,11 @@ where
         // We want EVM root proofs to have the exact same structure as aggregation proofs, so we add
         // public inputs for cyclic verification, even though they'll be ignored.
         let cyclic_vk = builder.add_verifier_data_public_inputs();
+
+        builder.add_gate(
+            ConstantGate::new(inner_common_data[0].config.num_constants),
+            vec![],
+        );
 
         RootCircuitData {
             circuit: builder.build::<C>(),

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -97,7 +97,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
-        &[9..18, 9..15, 9..15, 9..10, 9..12, 9..18], // Minimal ranges to prove an empty list
+        &[16..17, 14..15, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list
         &config,
     );
 

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -26,6 +26,10 @@ pub struct ConstantGate {
 }
 
 impl ConstantGate {
+    pub fn new(num_consts: usize) -> Self {
+        Self { num_consts }
+    }
+
     pub fn const_input(&self, i: usize) -> usize {
         debug_assert!(i < self.num_consts);
         i


### PR DESCRIPTION
Tiny tweak to remove the need for matching start ranges in the `AllRecursiveCircuits` initialization. Allows to scrap out ~4.6GB of useless data when serializing (out of the ~6.5GB for the empty_txn_list example, i.e.  ~72% reduction).
Also fixes some invalid end ranges.