### PR TITLE
Fix generate_set_context

### DIFF
--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -315,6 +315,20 @@ pub(crate) fn generate_set_context<F: Field>(
             MemoryOpKind::Read,
             sp_to_save,
         );
+
+        let channel = &mut row.mem_channels[2];
+        assert_eq!(channel.used, F::ZERO);
+        channel.used = F::ONE;
+        channel.is_read = F::ONE;
+        channel.addr_context = F::from_canonical_usize(new_ctx);
+        channel.addr_segment = F::from_canonical_usize(Segment::ContextMetadata as usize);
+        channel.addr_virtual = F::from_canonical_usize(new_sp_addr.virt);
+        let val_limbs: [u64; 4] = sp_to_save.0;
+        for (i, limb) in val_limbs.into_iter().enumerate() {
+            channel.value[2 * i] = F::from_canonical_u32(limb as u32);
+            channel.value[2 * i + 1] = F::from_canonical_u32((limb >> 32) as u32);
+        }
+
         (sp_to_save, op)
     } else {
         mem_read_gp_with_log_and_fill(2, new_sp_addr, state, &mut row)


### PR DESCRIPTION
We noticed in some tests with stack overflows that the macro `set_length` caused `context_ops` constraints to fail, due to the `SET_CONTEXT` instruction.
In the case where the context does not change (which is the case for `set_length`), there is a `MemoryOp` to read the stack length, but the memory channels are not set. The failing constraints concerned the said unset memory channel. Thus, this PR sets the memory channels in that case.