### PR TITLE
Fix resolver warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["evm", "field", "maybe_rayon", "plonky2", "starky", "util"]
+resolver = "2"
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
When running eg `cargo check` or `cargo build` you got greeted with the following warning:

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

This PR fixes this.