### PR TITLE
Fix import in arch tests

### DIFF
--- a/field/src/arch/x86_64/avx2_goldilocks_field.rs
+++ b/field/src/arch/x86_64/avx2_goldilocks_field.rs
@@ -505,7 +505,7 @@ mod tests {
     use crate::goldilocks_field::GoldilocksField;
     use crate::ops::Square;
     use crate::packed::PackedField;
-    use crate::types::Field64;
+    use crate::types::Field;
 
     fn test_vals_a() -> [GoldilocksField; 4] {
         [


### PR DESCRIPTION
PR #1092 moved some methods from `Field64` to `Field` but didn't update the imports in arch files.