### PR TITLE
Change context used in `bignum_modmul`

### DIFF
--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -191,11 +191,12 @@ impl<F: Field> GenerationState<F> {
         b_start_loc: usize,
         m_start_loc: usize,
     ) -> (Vec<U256>, Vec<U256>) {
-        let a = &self.memory.contexts[0].segments[Segment::KernelGeneral as usize].content
+        let n = self.memory.contexts.len();
+        let a = &self.memory.contexts[n - 1].segments[Segment::KernelGeneral as usize].content
             [a_start_loc..a_start_loc + len];
-        let b = &self.memory.contexts[0].segments[Segment::KernelGeneral as usize].content
+        let b = &self.memory.contexts[n - 1].segments[Segment::KernelGeneral as usize].content
             [b_start_loc..b_start_loc + len];
-        let m = &self.memory.contexts[0].segments[Segment::KernelGeneral as usize].content
+        let m = &self.memory.contexts[n - 1].segments[Segment::KernelGeneral as usize].content
             [m_start_loc..m_start_loc + len];
 
         let a_biguint = mem_vec_to_biguint(a);


### PR DESCRIPTION
We noticed that some tests related to `modexp_bignum` were failing in evm-tests with a KernelPanic (such as `modexpTests_62` and `modexpTests_65`, [here](https://github.com/ethereum/tests/blob/0902578614503cb52e9b115f8714a17c39787c58/src/GeneralStateTestsFiller/stPreCompiledContracts/modexpTestsFiller.yml#L4)). 

This was due to the fact that the context used in the ASM code and the one used in `bignum_modmul`, in prover_input.rs, were inconsistent. This PR changes, in `bignum_modmul`, `&self.memory.contexts[0]` into `self.memory.contexts[n - 1]` where `n = self.memory.contexts.len()` to make the tests pass.