### PR TITLE
deps(serde): use `rc` feature in `plonky2` crate

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -30,7 +30,7 @@ plonky2_field = { version = "0.1.0", default-features = false }
 plonky2_util = { version = "0.1.0", default-features = false }
 rand = { version = "0.8.4", default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 serde_json = "1.0"
 static_assertions = { version = "1.1.0", default-features = false }
 unroll = { version = "0.1.5", default-features = false }


### PR DESCRIPTION
building `plonky2` currently fails:

```console
$ cd plonky2 && cargo build
--> plonky2/src/plonk/circuit_data.rs:348:39
... the trait `Serialize` is not implemented for `Arc<Vec<(u16, u16)>>`
```

We have to enable `rc` feature in `serde`.

Note that this fix is also present in #1114