### PR TITLE
Build issues on Mac M2: add "Itertools/use_std" flag to "std" 

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
-std = ["anyhow/std", "rand/std"]
+std = ["anyhow/std", "rand/std", "itertools/use_std"]
 timing = ["std"]
 
 [dependencies]


### PR DESCRIPTION
I have been having an issue with building the latest version on a Mac M2 Max. 

The compiler was throwing some messages regarding the itertools crate. I found that adding the "use_std" features of the itertools flag (only under the "std" feature of course) solves this problem for me. 