### PR TITLE
CI: build in subdirectories

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -38,11 +38,44 @@ jobs:
             target/
           key: rustc-test-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
+      - name: Check in plonky2 subdirectory
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path plonky2/Cargo.toml
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+      - name: Check in starky subdirectory
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path starky/Cargo.toml
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+      - name: Check in evm subdirectory
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path evm/Cargo.toml
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --workspace
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1


### PR DESCRIPTION
CI now runs `cargo check` for each of the `plonky2`, `starky`, and `evm` subdirectories. This allows us to check compiling individual crates separately, which sometimes fails when compiling the whole workspace succeeds (because of feature-related issues), brought up in #1138

It seems like GitHub Actions can't actually run commands from path other than root, so this uses the workaround of specifying their `Cargo.toml` as a manifest — see [here](https://github.com/actions-rs/cargo/issues/86#issuecomment-667088617). But in our case I think it's the same thing

I checked that this indeed causes CI to fail prior to #1138's changes