### PR TITLE
Lookup check

### DIFF
--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -77,7 +77,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn add_all_lookups(&mut self) {
         for lut_index in 0..self.num_luts() {
             assert!(
-                !self.get_lut_lookups(lut_index).is_empty() || lut_index >= self.get_luts_length(),
+                !self.get_lut_lookups(lut_index).is_empty(),
                 "LUT number {:?} is unused",
                 lut_index
             );

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -81,7 +81,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for LookupTableGat
     fn id(&self) -> String {
         // Custom implementation to not have the entire lookup table
         format!(
-            "LookupGate {{num_slots: {}, lut_hash: {:?}, last_lut_row: {}}}",
+            "LookupTableGate {{num_slots: {}, lut_hash: {:?}, last_lut_row: {}}}",
             self.num_slots, self.lut_hash, self.last_lut_row
         )
     }

--- a/plonky2/src/lookup_test.rs
+++ b/plonky2/src/lookup_test.rs
@@ -40,6 +40,49 @@ mod tests {
         Ok(())
     }
 
+    #[should_panic]
+    #[test]
+    fn test_lookup_table_not_used() {
+        LOGGER_INITIALIZED.call_once(|| init_logger().unwrap());
+        use crate::plonk::circuit_builder::CircuitBuilder;
+        use crate::plonk::circuit_data::CircuitConfig;
+        use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        let tip5_table = TIP5_TABLE.to_vec();
+        let table: LookupTable = Arc::new((0..256).zip_eq(tip5_table).collect());
+        builder.add_lookup_table_from_pairs(table);
+
+        builder.build::<C>();
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_lookup_without_table() {
+        LOGGER_INITIALIZED.call_once(|| init_logger().unwrap());
+        use crate::plonk::circuit_builder::CircuitBuilder;
+        use crate::plonk::circuit_data::CircuitConfig;
+        use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+
+        let dummy = builder.add_virtual_target();
+        builder.add_lookup_from_index(dummy, 0);
+
+        builder.build::<C>();
+    }
+
     // Tests two lookups in one lookup table.
     #[test]
     fn test_one_lookup() -> anyhow::Result<()> {

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -244,7 +244,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         self.lut_to_lookups[lut_index].push((looking_in, looking_out));
     }
 
-    pub fn num_luts(&mut self) -> usize {
+    pub fn num_luts(&self) -> usize {
         self.lut_to_lookups.len()
     }
 


### PR DESCRIPTION
@npwardberkeley Another tiny lookup-related PR, just to fix a wrong naming in `LookupTableGate` id, and to remove the second condition in an assertion check.
More specifically, the second condition (`lut_index >= self.get_luts_length()`) in the OR should first be corrected to `lut_index < self.get_luts_length()`. It wasn't caught in unit tests because we were always satisfying the first condition. Secondly, because the `luts` and `lut_to_lookups` are necessarily of the same size, we can't have `lut_index` being greater than the latter (indeed, the only way for it to fail would be for a user to call `add_lookup_from_index()` with an invalid index when designing the circuit, which would be caught prior to reaching `add_all_lookups()`.

Related to this, I added two additional unit tests, to handle the two failing cases mentioned above. I don't know if we want to maintain the assertion of table unused though, as this just prevents inflating needlessly the circuit size, but isn't really an error per se.