### PR TITLE
Fix prove_root()

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -46,8 +46,8 @@ use crate::proof::{PublicValues, PublicValuesTarget, StarkProofWithMetadata};
 use crate::prover::prove;
 use crate::recursive_verifier::{
     add_common_recursion_gates, add_virtual_public_values, recursive_stark_circuit,
-    set_block_metadata_target, set_trie_roots_target, PlonkWrapperCircuit, PublicInputs,
-    StarkWrapperCircuit,
+    set_block_metadata_target, set_public_value_targets, set_trie_roots_target,
+    PlonkWrapperCircuit, PublicInputs, StarkWrapperCircuit,
 };
 use crate::stark::Stark;
 
@@ -813,25 +813,10 @@ where
             &self.aggregation.circuit.verifier_only,
         );
 
-        set_block_metadata_target(
+        set_public_value_targets(
             &mut root_inputs,
-            &self.root.public_values.block_metadata,
-            &all_proof.public_values.block_metadata,
-        );
-
-        root_inputs.set_target(
-            self.root.public_values.cpu_trace_len,
-            F::from_canonical_usize(all_proof.public_values.cpu_trace_len),
-        );
-        set_trie_roots_target(
-            &mut root_inputs,
-            &self.root.public_values.trie_roots_before,
-            &all_proof.public_values.trie_roots_before,
-        );
-        set_trie_roots_target(
-            &mut root_inputs,
-            &self.root.public_values.trie_roots_after,
-            &all_proof.public_values.trie_roots_after,
+            &self.root.public_values,
+            &all_proof.public_values,
         );
 
         let root_proof = self.root.circuit.prove(root_inputs)?;

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -636,7 +636,6 @@ pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: 
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
-#[allow(unused)] // TODO: used later?
 pub(crate) fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,
@@ -659,6 +658,10 @@ pub(crate) fn set_public_value_targets<F, W, const D: usize>(
         witness,
         &public_values_target.block_metadata,
         &public_values.block_metadata,
+    );
+    witness.set_target(
+        public_values_target.cpu_trace_len,
+        F::from_canonical_usize(public_values.cpu_trace_len),
     );
 }
 

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -734,26 +734,26 @@ pub(crate) fn set_block_metadata_target<F, W, const D: usize>(
     witness.set_target_arr(&block_metadata_target.block_beneficiary, &beneficiary_limbs);
     witness.set_target(
         block_metadata_target.block_timestamp,
-        F::from_canonical_u64(block_metadata.block_timestamp.as_u64()),
+        F::from_canonical_u32(block_metadata.block_timestamp.as_u32()),
     );
     witness.set_target(
         block_metadata_target.block_number,
-        F::from_canonical_u64(block_metadata.block_number.as_u64()),
+        F::from_canonical_u32(block_metadata.block_number.as_u32()),
     );
     witness.set_target(
         block_metadata_target.block_difficulty,
-        F::from_canonical_u64(block_metadata.block_difficulty.as_u64()),
+        F::from_canonical_u32(block_metadata.block_difficulty.as_u32()),
     );
     witness.set_target(
         block_metadata_target.block_gaslimit,
-        F::from_canonical_u64(block_metadata.block_gaslimit.as_u64()),
+        F::from_canonical_u32(block_metadata.block_gaslimit.as_u32()),
     );
     witness.set_target(
         block_metadata_target.block_chain_id,
-        F::from_canonical_u64(block_metadata.block_chain_id.as_u64()),
+        F::from_canonical_u32(block_metadata.block_chain_id.as_u32()),
     );
     witness.set_target(
         block_metadata_target.block_base_fee,
-        F::from_canonical_u64(block_metadata.block_base_fee.as_u64()),
+        F::from_canonical_u32(block_metadata.block_base_fee.as_u32()),
     );
 }

--- a/evm/src/util.rs
+++ b/evm/src/util.rs
@@ -73,6 +73,7 @@ pub(crate) fn h256_limbs<F: Field>(h256: H256) -> [F; 8] {
         .unwrap()
 }
 
+#[allow(unused)]
 /// Returns the 32-bit limbs of a `U160`.
 pub(crate) fn h160_limbs<F: Field>(h160: H160) -> [F; 5] {
     h160.0


### PR DESCRIPTION
This PR fixes an issue introduced by #1026. This wasn't detected as the only usage of `AllRecursiveCircuits` is done with an empty transaction list.
To reproduce it, you can pass the inputs of the `simple_transfer` test to `prove_root()`. You will need to manually alter the `block_gas_limit` field (see below).

Changes:
- fix the endianess of the block beneficiary
- set all other `block_metadata` targets from the first limb of their `U256` counterpart, converted to a u32. This is a safety measure as each should be fitting in 32 bits by design (we're only considering their first limb). Otherwise testing for instance the `simple_transfer` inputs will fail with inconsistent `Target` value.

@npwardberkeley Would you mind reviewing the changes? As you were the one assigned to #1026 you're probably the most familiar with this recent new part. I've also reused the previously unused `set_public_value_targets()` method for clarity.

@BGluth Just FYI, with the changes from #1026 integrated, it is now impossible to handle tests with a gas limit not fitting in 32 bits, which would actually require https://github.com/mir-protocol/evm-tests/pull/30 to be reverted in order to not have new false positives (though, they wouldn't actually return an error per se, the prover would `panic!` when setting the targets with current main / converting to u32 with this PR).