### PR TITLE
Fix trait import in AVX512 tests

### DIFF
--- a/field/src/arch/x86_64/avx512_goldilocks_field.rs
+++ b/field/src/arch/x86_64/avx512_goldilocks_field.rs
@@ -402,7 +402,7 @@ mod tests {
     use crate::goldilocks_field::GoldilocksField;
     use crate::ops::Square;
     use crate::packed::PackedField;
-    use crate::types::Field64;
+    use crate::types::Field;
 
     fn test_vals_a() -> [GoldilocksField; 8] {
         [


### PR DESCRIPTION
PR #1092 introduced some compile errors in the architecture-specific testing code for fields. Some of these errors were fixed in #1134. The remainder of the errors are fixed in this PR.