### PR TITLE
CI Speed-up

### DIFF
--- a/evm/tests/add11_yml.rs
+++ b/evm/tests/add11_yml.rs
@@ -8,7 +8,7 @@ use ethereum_types::Address;
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
-use plonky2::plonk::config::PoseidonGoldilocksConfig;
+use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
@@ -21,7 +21,7 @@ use plonky2_evm::Node;
 
 type F = GoldilocksField;
 const D: usize = 2;
-type C = PoseidonGoldilocksConfig;
+type C = KeccakGoldilocksConfig;
 
 /// The `add11_yml` test case from https://github.com/ethereum/tests
 #[test]

--- a/evm/tests/basic_smart_contract.rs
+++ b/evm/tests/basic_smart_contract.rs
@@ -8,7 +8,7 @@ use ethereum_types::{Address, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
-use plonky2::plonk::config::PoseidonGoldilocksConfig;
+use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
@@ -22,7 +22,7 @@ use plonky2_evm::Node;
 
 type F = GoldilocksField;
 const D: usize = 2;
-type C = PoseidonGoldilocksConfig;
+type C = KeccakGoldilocksConfig;
 
 /// Test a simple token transfer to a new address.
 #[test]

--- a/evm/tests/self_balance_gas_cost.rs
+++ b/evm/tests/self_balance_gas_cost.rs
@@ -9,7 +9,7 @@ use ethereum_types::Address;
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
-use plonky2::plonk::config::PoseidonGoldilocksConfig;
+use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
@@ -22,7 +22,7 @@ use plonky2_evm::Node;
 
 type F = GoldilocksField;
 const D: usize = 2;
-type C = PoseidonGoldilocksConfig;
+type C = KeccakGoldilocksConfig;
 
 /// The `selfBalanceGasCost` test case from https://github.com/ethereum/tests
 #[test]

--- a/evm/tests/simple_transfer.rs
+++ b/evm/tests/simple_transfer.rs
@@ -8,7 +8,7 @@ use ethereum_types::{Address, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
-use plonky2::plonk::config::PoseidonGoldilocksConfig;
+use plonky2::plonk::config::KeccakGoldilocksConfig;
 use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
@@ -21,7 +21,7 @@ use plonky2_evm::Node;
 
 type F = GoldilocksField;
 const D: usize = 2;
-type C = PoseidonGoldilocksConfig;
+type C = KeccakGoldilocksConfig;
 
 /// Test a simple token transfer to a new address.
 #[test]


### PR DESCRIPTION
Runs the non-recursive EVM integration tests with Keccak config instead of Poseidon (now `simple_transfer` / `add11_yml` take ~95 sec each compared to ~140 sec).

Regarding the config used in tests, we're almost always using the `PoseidonGoldilocksConfig`. Given that this one is already checked in recursion-related tests, we may want to switch all others to `KeccakGoldilocksConfig`, to speed-up the CI further?