### PR TITLE
Connect SHL/SHR operations to the Arithmetic table

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -108,7 +108,10 @@ pub(crate) fn all_cross_table_lookups<F: Field>() -> Vec<CrossTableLookup<F>> {
 
 fn ctl_arithmetic<F: Field>() -> CrossTableLookup<F> {
     CrossTableLookup::new(
-        vec![cpu_stark::ctl_arithmetic_rows()],
+        vec![
+            cpu_stark::ctl_arithmetic_base_rows(),
+            cpu_stark::ctl_arithmetic_shift_rows(),
+        ],
         arithmetic_stark::ctl_arithmetic_rows(),
     )
 }

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -59,9 +59,17 @@ fn ctl_data_binops<F: Field>(ops: &[usize]) -> Vec<Column<F>> {
 }
 
 /// Create the vector of Columns corresponding to the three inputs and
-/// one output of a ternary operation.
-/// If `is_shift` is `true`, we offset the memory_channels indices used for the inputs
-/// by 1. It will only be valid if the associated filter is one of the two shift flags.
+/// one output of a ternary operation. By default, ternary operations use
+/// the first three memory channels, and the last one for the result (binary
+/// operations do not use the third inputs).
+///
+/// Shift operations are different, as they are simulated with `MUL` or `DIV`
+/// on the arithmetic side. We first convert the shift into the multiplicand
+/// (in case of `SHL`) or the divisor (in case of `SHR`), making the first memory
+/// channel not directly usable. We overcome this by adding an offset of 1 in
+/// case of shift operations, which will skip the first memory channel and use the
+/// next three as ternary inputs. Because both `MUL` and `DIV` are binary operations,
+/// the last memory channel used for the inputs will be safely ignored.
 fn ctl_data_ternops<F: Field>(ops: &[usize], is_shift: bool) -> Vec<Column<F>> {
     let offset = is_shift as usize;
     let mut res = Column::singles(ops).collect_vec();

--- a/evm/src/cpu/shift.rs
+++ b/evm/src/cpu/shift.rs
@@ -54,7 +54,7 @@ pub(crate) fn eval_packed<P: PackedField>(
     // (in the case of left shift) or DIV (in the case of right shift)
     // in the arithmetic table. Specifically, the mapping is
     //
-    // 0 -> 0  (value to be shifted is the same)
+    // 1 -> 0  (value to be shifted is the same)
     // 2 -> 1  (two_exp becomes the multiplicand (resp. divisor))
     // last -> last  (output is the same)
 }

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -492,7 +492,11 @@ fn append_shift<F: Field>(
     }
 
     // Convert the shift, and log the corresponding arithmetic operation.
-    let input0 = U256::from(2).pow(input0);
+    let input0 = if input0 > U256::from(255u64) {
+        U256::zero()
+    } else {
+        U256::one() << input0
+    };
     let operator = if row.op.shl.is_one() {
         BinaryOperator::Mul
     } else {

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -3,6 +3,7 @@ use itertools::Itertools;
 use keccak_hash::keccak;
 use plonky2::field::types::Field;
 
+use crate::arithmetic::BinaryOperator;
 use crate::cpu::columns::CpuColumnsView;
 use crate::cpu::kernel::aggregator::KERNEL;
 use crate::cpu::kernel::assembler::BYTES_PER_OFFSET;
@@ -470,6 +471,7 @@ fn append_shift<F: Field>(
     state: &mut GenerationState<F>,
     mut row: CpuColumnsView<F>,
     input0: U256,
+    input1: U256,
     log_in0: MemoryOp,
     log_in1: MemoryOp,
     result: U256,
@@ -489,6 +491,16 @@ fn append_shift<F: Field>(
         channel.addr_virtual = F::from_canonical_usize(lookup_addr.virt);
     }
 
+    // Convert the shift, and log the corresponding arithmetic operation.
+    let input0 = U256::from(2).pow(input0);
+    let operator = if row.op.shl.is_one() {
+        BinaryOperator::Mul
+    } else {
+        BinaryOperator::Div
+    };
+    let operation = arithmetic::Operation::binary(operator, input1, input0);
+
+    state.traces.push_arithmetic(operation);
     state.traces.push_memory(log_in0);
     state.traces.push_memory(log_in1);
     state.traces.push_memory(log_out);
@@ -508,7 +520,7 @@ pub(crate) fn generate_shl<F: Field>(
     } else {
         input1 << input0
     };
-    append_shift(state, row, input0, log_in0, log_in1, result)
+    append_shift(state, row, input0, input1, log_in0, log_in1, result)
 }
 
 pub(crate) fn generate_shr<F: Field>(
@@ -523,7 +535,7 @@ pub(crate) fn generate_shr<F: Field>(
     } else {
         input1 >> input0
     };
-    append_shift(state, row, input0, log_in0, log_in1, result)
+    append_shift(state, row, input0, input1, log_in0, log_in1, result)
 }
 
 pub(crate) fn generate_syscall<F: Field>(


### PR DESCRIPTION
This PR addresses a point in https://github.com/mir-protocol/plonky2/issues/1150.

@unzvfu would you mind reviewing this PR, as you implemented the related operations?
Upon difficulties in getting the Arithmetic CTL to work, I realized (unless I missed something obvious) that we were not logging the corresponding MUL/DIV arithmetic operations when performing a shift.
I also updated the comment on the memory mapping, as I believe it is erroneous. We instead have

```
- mem_channel 0: shift
- mem_channel 1: value to be shifted (was referred as channel 0 previously)
- mem_channel 2: 2^shift
- mem_channel 5 (last): result
```

Let me know if I misunderstood anything! 🙏🏼 