### PR TITLE
Reduce reallocations

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -492,16 +492,16 @@ where
             vec![vec![builder.constant(F::ONE); stark_config.num_challenges]; NUM_TABLES - 1];
 
         // Memory
-        extra_looking_products.push(Vec::new());
-        for c in 0..stark_config.num_challenges {
-            extra_looking_products[Table::Memory as usize].push(
+        let memory_looking_products = (0..stark_config.num_challenges)
+            .map(|c| {
                 Self::get_memory_extra_looking_products_circuit(
                     &mut builder,
                     &public_values,
                     ctl_challenges.challenges[c],
-                ),
-            );
-        }
+                )
+            })
+            .collect_vec();
+        extra_looking_products.push(memory_looking_products);
 
         // Verify the CTL checks.
         verify_cross_table_lookups_circuit::<F, D>(

--- a/evm/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm/src/keccak_sponge/keccak_sponge_stark.rs
@@ -358,15 +358,13 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
         row.updated_state_u32s = sponge_state.map(F::from_canonical_u32);
         let is_final_block = row.is_final_input_len.iter().copied().sum::<F>() == F::ONE;
         if is_final_block {
-            let mut cur_bytes = vec![F::ZERO; 4];
             for (l, &elt) in row.updated_state_u32s[..8].iter().enumerate() {
                 let mut cur_elt = elt;
-                for i in 0..4 {
-                    cur_bytes[i] =
+                (0..4).for_each(|i| {
+                    row.updated_state_bytes[l * 4 + i] =
                         F::from_canonical_u32((cur_elt.to_canonical_u64() & 0xFF) as u32);
                     cur_elt = F::from_canonical_u64(cur_elt.to_canonical_u64() >> 8);
-                    row.updated_state_bytes[l * 4 + i] = cur_bytes[i];
-                }
+                });
 
                 let mut s = row.updated_state_bytes[l * 4].to_canonical_u64();
                 for i in 1..4 {

--- a/evm/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm/src/keccak_sponge/keccak_sponge_stark.rs
@@ -211,7 +211,11 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
         operations: Vec<KeccakSpongeOp>,
         min_rows: usize,
     ) -> Vec<[F; NUM_KECCAK_SPONGE_COLUMNS]> {
-        let mut rows = Vec::with_capacity(operations.len().max(min_rows).next_power_of_two());
+        let base_len: usize = operations
+            .iter()
+            .map(|op| op.input.len() / KECCAK_RATE_BYTES + 1)
+            .sum();
+        let mut rows = Vec::with_capacity(base_len.max(min_rows).next_power_of_two());
         for op in operations {
             rows.extend(self.generate_rows_for_op(op));
         }

--- a/evm/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm/src/keccak_sponge/keccak_sponge_stark.rs
@@ -25,7 +25,7 @@ use crate::witness::memory::MemoryAddress;
 
 pub(crate) fn ctl_looked_data<F: Field>() -> Vec<Column<F>> {
     let cols = KECCAK_SPONGE_COL_MAP;
-    let mut outputs = vec![];
+    let mut outputs = Vec::with_capacity(8);
     for i in (0..8).rev() {
         let cur_col = Column::linear_combination(
             cols.updated_state_bytes[i * 4..(i + 1) * 4]
@@ -211,7 +211,7 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
         operations: Vec<KeccakSpongeOp>,
         min_rows: usize,
     ) -> Vec<[F; NUM_KECCAK_SPONGE_COLUMNS]> {
-        let mut rows = vec![];
+        let mut rows = Vec::with_capacity(operations.len().max(min_rows).next_power_of_two());
         for op in operations {
             rows.extend(self.generate_rows_for_op(op));
         }
@@ -223,7 +223,7 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
     }
 
     fn generate_rows_for_op(&self, op: KeccakSpongeOp) -> Vec<[F; NUM_KECCAK_SPONGE_COLUMNS]> {
-        let mut rows = vec![];
+        let mut rows = Vec::with_capacity(op.input.len() / KECCAK_RATE_BYTES + 1);
 
         let mut sponge_state = [0u32; KECCAK_WIDTH_U32S];
 
@@ -358,8 +358,8 @@ impl<F: RichField + Extendable<D>, const D: usize> KeccakSpongeStark<F, D> {
         row.updated_state_u32s = sponge_state.map(F::from_canonical_u32);
         let is_final_block = row.is_final_input_len.iter().copied().sum::<F>() == F::ONE;
         if is_final_block {
+            let mut cur_bytes = vec![F::ZERO; 4];
             for (l, &elt) in row.updated_state_u32s[..8].iter().enumerate() {
-                let mut cur_bytes = vec![F::ZERO; 4];
                 let mut cur_elt = elt;
                 for i in 0..4 {
                     cur_bytes[i] =

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -206,8 +206,8 @@ where
     let segment = F::from_canonical_u32(Segment::GlobalMetadata as u32);
     let timestamp = F::ONE;
 
+    let mut row = vec![F::ZERO; 13];
     fields.map(|(field, val)| {
-        let mut row = vec![F::ZERO; 13];
         row[0] = is_read;
         row[1] = context;
         row[2] = segment;

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -283,7 +283,7 @@ pub trait Field:
     }
 
     fn cyclic_subgroup_unknown_order(generator: Self) -> Vec<Self> {
-        let mut subgroup = Vec::with_capacity(Self::TWO_ADICITY);
+        let mut subgroup = Vec::new();
         for power in generator.powers() {
             if power.is_one() && !subgroup.is_empty() {
                 break;

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -283,7 +283,7 @@ pub trait Field:
     }
 
     fn cyclic_subgroup_unknown_order(generator: Self) -> Vec<Self> {
-        let mut subgroup = Vec::new();
+        let mut subgroup = Vec::with_capacity(Self::TWO_ADICITY);
         for power in generator.powers() {
             if power.is_one() && !subgroup.is_empty() {
                 break;

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -194,7 +194,7 @@ impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> FriProof<F, H, 
 
         let mut compressed_query_proofs = CompressedFriQueryRounds {
             indices: indices.to_vec(),
-            initial_trees_proofs: HashMap::new(),
+            initial_trees_proofs: HashMap::with_capacity(indices.len()),
             steps: vec![HashMap::new(); num_reductions],
         };
 

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -72,7 +72,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
     challenger: &mut Challenger<F, C::Hasher>,
     fri_params: &FriParams,
 ) -> FriCommitedTrees<F, C, D> {
-    let mut trees = Vec::new();
+    let mut trees = Vec::with_capacity(fri_params.reduction_arity_bits.len());
 
     let mut shift = F::MULTIPLICATIVE_GROUP_GENERATOR;
     for arity_bits in &fri_params.reduction_arity_bits {

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -1,5 +1,5 @@
+use alloc::format;
 use alloc::vec::Vec;
-use alloc::{format, vec};
 
 use itertools::Itertools;
 
@@ -415,7 +415,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let initial_trees_proof =
             self.add_virtual_fri_initial_trees_proof(num_leaves_per_oracle, merkle_proof_len);
 
-        let mut steps = vec![];
+        let mut steps = Vec::with_capacity(params.reduction_arity_bits.len());
         for &arity_bits in &params.reduction_arity_bits {
             assert!(merkle_proof_len >= arity_bits);
             merkle_proof_len -= arity_bits;

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -73,7 +73,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticGate
         let const_0 = vars.local_constants[0];
         let const_1 = vars.local_constants[1];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.local_wires[Self::wire_ith_multiplicand_0(i)];
             let multiplicand_1 = vars.local_wires[Self::wire_ith_multiplicand_1(i)];
@@ -107,7 +107,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticGate
         let const_0 = vars.local_constants[0];
         let const_1 = vars.local_constants[1];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.local_wires[Self::wire_ith_multiplicand_0(i)];
             let multiplicand_1 = vars.local_wires[Self::wire_ith_multiplicand_1(i)];

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -69,7 +69,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticExte
         let const_0 = vars.local_constants[0];
         let const_1 = vars.local_constants[1];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops * D);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_0(i));
             let multiplicand_1 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_1(i));
@@ -112,7 +112,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ArithmeticExte
         let const_0 = vars.local_constants[0];
         let const_1 = vars.local_constants[1];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops * D);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_0(i));
             let multiplicand_1 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_1(i));

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -275,7 +275,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         let power_bits = (0..num_power_bits)
             .map(|i| get_local_wire(self.gate.wire_power_bit(i)))
             .collect::<Vec<_>>();
-        let mut intermediate_values = Vec::new();
+        let mut intermediate_values = Vec::with_capacity(num_power_bits);
 
         let mut current_intermediate_value = F::ONE;
         for i in 0..num_power_bits {

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -65,7 +65,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGa
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
         let const_0 = vars.local_constants[0];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops * D);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_0(i));
             let multiplicand_1 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_1(i));
@@ -102,7 +102,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for MulExtensionGa
     ) -> Vec<ExtensionTarget<D>> {
         let const_0 = vars.local_constants[0];
 
-        let mut constraints = Vec::new();
+        let mut constraints = Vec::with_capacity(self.num_ops * D);
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_0(i));
             let multiplicand_1 = vars.get_local_ext_algebra(Self::wires_ith_multiplicand_1(i));

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -108,7 +108,7 @@ impl<F: RichField, const N: usize> Hasher<F> for KeccakHash<N> {
     type Permutation = KeccakPermutation<F>;
 
     fn hash_no_pad(input: &[F]) -> Self::Hash {
-        let mut buffer = Vec::new();
+        let mut buffer = Vec::with_capacity(input.len());
         buffer.write_field_vec(input).unwrap();
         let mut arr = [0; N];
         let hash_bytes = keccak(buffer).0;

--- a/plonky2/src/plonk/permutation_argument.rs
+++ b/plonky2/src/plonk/permutation_argument.rs
@@ -137,14 +137,14 @@ impl WirePartition {
         // other words, find the next wire in the given wire's partition. If the given wire is last in
         // its partition, this will loop around. If the given wire has a partition all to itself, it
         // is considered its own neighbor.
-        let mut neighbors = HashMap::new();
+        let mut neighbors = HashMap::with_capacity(self.partition.len());
         for subset in &self.partition {
             for n in 0..subset.len() {
                 neighbors.insert(subset[n], subset[(n + 1) % subset.len()]);
             }
         }
 
-        let mut sigma = Vec::new();
+        let mut sigma = Vec::with_capacity(num_routed_wires * degree);
         for column in 0..num_routed_wires {
             for row in 0..degree {
                 let wire = Wire { row, column };

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -408,7 +408,7 @@ fn wires_permutation_partial_products_and_zs<
         .collect::<Vec<_>>();
 
     let mut z_x = F::ONE;
-    let mut all_partial_products_and_zs = Vec::new();
+    let mut all_partial_products_and_zs = Vec::with_capacity(all_quotient_chunk_products.len());
     for quotient_chunk_products in all_quotient_chunk_products {
         let mut partial_products_and_z_gx =
             partial_products_and_z_gx(z_x, &quotient_chunk_products);

--- a/plonky2/src/plonk/vanishing_poly.rs
+++ b/plonky2/src/plonk/vanishing_poly.rs
@@ -35,7 +35,7 @@ pub(crate) fn get_lut_poly<F: RichField + Extendable<D>, const D: usize>(
     degree: usize,
 ) -> PolynomialCoeffs<F> {
     let b = deltas[LookupChallenges::ChallengeB as usize];
-    let mut coeffs = Vec::new();
+    let mut coeffs = Vec::with_capacity(common_data.luts[lut_index].len());
     let n = common_data.luts[lut_index].len();
     for (input, output) in common_data.luts[lut_index].iter() {
         coeffs.push(F::from_canonical_u16(*input) + b * F::from_canonical_u16(*output));
@@ -832,7 +832,7 @@ pub(crate) fn eval_vanishing_poly_circuit<F: RichField + Extendable<D>, const D:
     let l_0_x = eval_l_0_circuit(builder, common_data.degree(), x, x_pow_deg);
 
     // Holds `k[i] * x`.
-    let mut s_ids = Vec::new();
+    let mut s_ids = Vec::with_capacity(common_data.config.num_routed_wires);
     for j in 0..common_data.config.num_routed_wires {
         let k = builder.constant(common_data.k_is[j]);
         s_ids.push(builder.scalar_mul_ext(k, x));
@@ -866,8 +866,8 @@ pub(crate) fn eval_vanishing_poly_circuit<F: RichField + Extendable<D>, const D:
             vanishing_all_lookup_terms.extend(lookup_constraints);
         }
 
-        let mut numerator_values = Vec::new();
-        let mut denominator_values = Vec::new();
+        let mut numerator_values = Vec::with_capacity(common_data.config.num_routed_wires);
+        let mut denominator_values = Vec::with_capacity(common_data.config.num_routed_wires);
 
         for j in 0..common_data.config.num_routed_wires {
             let wire_value = vars.local_wires[j];

--- a/plonky2/src/util/partial_products.rs
+++ b/plonky2/src/util/partial_products.rs
@@ -27,7 +27,7 @@ pub(crate) fn quotient_chunk_products<F: Field>(
 /// or less elements. This is done until we've computed the product `P` of all elements in the vector.
 pub(crate) fn partial_products_and_z_gx<F: Field>(z_x: F, quotient_chunk_products: &[F]) -> Vec<F> {
     assert!(!quotient_chunk_products.is_empty());
-    let mut res = Vec::new();
+    let mut res = Vec::with_capacity(quotient_chunk_products.len());
     let mut acc = z_x;
     for &quotient_chunk_product in quotient_chunk_products {
         acc *= quotient_chunk_product;


### PR DESCRIPTION
Replaces some empty Vec / HashMap initializations with `with_capacity` to reduce the number of reallocations. Given than an empty vec will reallocate to a capacity of 4 directly on the first push, some tiny vecs are left untouched.

The number of reallocations can be evaluated with an external crate like [alloc_counter](https://docs.rs/alloc_counter/latest/alloc_counter/). Testing against `bench_recursion` example, i.e. replacing the `prove` calls with the code below

```rust
    let mut timing = TimingTree::new("prove", Level::Debug);
    let ((_, realloc, _), proof) =
        count_alloc(|| prove::<F, C, D>(&data.prover_only, &data.common, pw, &mut timing).unwrap());
    timing.print();

    println!("Reallocations for proving: {:?}", realloc);
````

 for both the initial dummy proof and the two recursive layers, a typical run yields the following:
 
 - main branch:
Reallocations for dummy proof: 119064
Reallocations for 1st rec. proof:  48632
Reallocations for 2nd rec. proof: 51235

 - this branch:
Reallocations for dummy proof: 56476 (-52.6%)
Reallocations for 1st rec. proof:  32910 (-32.3%)
Reallocations for 2nd rec. proof: 35394 (-30.9%)

@npwardberkeley Would you mind taking a look?