### PR TITLE
Patch `eth_trie_utils` to use a non crates-io version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ incremental = true
 opt-level = 3
 
 [patch.crates-io]
+eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 plonky2_evm = { path = "evm" }
 plonky2_field = { path = "field" }
 plonky2_maybe_rayon = { path = "maybe_rayon" }

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -73,7 +73,7 @@ fn prepare_interpreter(
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, trie_data_len);
     interpreter.push(0xDEADBEEFu32.into());
     interpreter.push(value_ptr.into()); // value_ptr
-    interpreter.push(k.packed); // key
+    interpreter.push(k.try_into_u256().unwrap()); // key
 
     interpreter.run()?;
     assert_eq!(

--- a/evm/src/cpu/kernel/tests/balance.rs
+++ b/evm/src/cpu/kernel/tests/balance.rs
@@ -64,7 +64,7 @@ fn prepare_interpreter(
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, trie_data_len);
     interpreter.push(0xDEADBEEFu32.into());
     interpreter.push(value_ptr.into()); // value_ptr
-    interpreter.push(k.packed); // key
+    interpreter.push(k.try_into_u256().unwrap()); // key
 
     interpreter.run()?;
     assert_eq!(

--- a/evm/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm/src/cpu/kernel/tests/mpt/delete.rs
@@ -85,7 +85,7 @@ fn test_state_trie(
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, trie_data_len);
     interpreter.push(0xDEADBEEFu32.into());
     interpreter.push(value_ptr.into()); // value_ptr
-    interpreter.push(k.packed); // key
+    interpreter.push(k.try_into_u256().unwrap()); // key
     interpreter.run()?;
     assert_eq!(
         interpreter.stack().len(),
@@ -98,7 +98,7 @@ fn test_state_trie(
     let state_trie_ptr = interpreter.get_global_metadata_field(GlobalMetadata::StateTrieRoot);
     interpreter.generation_state.registers.program_counter = mpt_delete;
     interpreter.push(0xDEADBEEFu32.into());
-    interpreter.push(k.packed);
+    interpreter.push(k.try_into_u256().unwrap());
     interpreter.push(64.into());
     interpreter.push(state_trie_ptr);
     interpreter.run()?;

--- a/evm/src/cpu/kernel/tests/mpt/insert.rs
+++ b/evm/src/cpu/kernel/tests/mpt/insert.rs
@@ -198,7 +198,7 @@ fn test_state_trie(
     interpreter.set_global_metadata_field(GlobalMetadata::TrieDataSize, trie_data_len);
     interpreter.push(0xDEADBEEFu32.into());
     interpreter.push(value_ptr.into()); // value_ptr
-    interpreter.push(k.packed); // key
+    interpreter.push(k.try_into_u256().unwrap()); // key
 
     interpreter.run()?;
     assert_eq!(

--- a/evm/src/cpu/kernel/tests/mpt/mod.rs
+++ b/evm/src/cpu/kernel/tests/mpt/mod.rs
@@ -13,13 +13,19 @@ mod load;
 mod read;
 
 pub(crate) fn nibbles_64<T: Into<U256>>(v: T) -> Nibbles {
-    let packed = v.into();
-    Nibbles { count: 64, packed }
+    let packed: U256 = v.into();
+    Nibbles {
+        count: 64,
+        packed: packed.into(),
+    }
 }
 
 pub(crate) fn nibbles_count<T: Into<U256>>(v: T, count: usize) -> Nibbles {
-    let packed = v.into();
-    Nibbles { count, packed }
+    let packed: U256 = v.into();
+    Nibbles {
+        count,
+        packed: packed.into(),
+    }
 }
 
 pub(crate) fn test_account_1() -> AccountRlp {

--- a/evm/src/generation/outputs.rs
+++ b/evm/src/generation/outputs.rs
@@ -48,7 +48,7 @@ pub(crate) fn get_outputs<F: Field>(state: &mut GenerationState<F>) -> Generatio
                 state_key_nibbles.count, 64,
                 "Each state key should have 64 nibbles = 256 bits"
             );
-            let state_key_h256 = H256::from_uint(&state_key_nibbles.packed);
+            let state_key_h256 = H256::from_uint(&state_key_nibbles.try_into_u256().unwrap());
 
             let addr_or_state_key =
                 if let Some(address) = state.state_key_to_address.get(&state_key_h256) {
@@ -98,7 +98,7 @@ fn get_storage<F: Field>(state: &GenerationState<F>, storage_ptr: usize) -> Hash
                 storage_key_nibbles.count, 64,
                 "Each storage key should have 64 nibbles = 256 bits"
             );
-            (storage_key_nibbles.packed, value)
+            (storage_key_nibbles.try_into_u256().unwrap(), value)
         })
         .collect()
 }

--- a/evm/src/generation/trie_extractor.rs
+++ b/evm/src/generation/trie_extractor.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use eth_trie_utils::nibbles::Nibbles;
-use ethereum_types::{BigEndianHash, H256, U256};
+use ethereum_types::{BigEndianHash, H256, U256, U512};
 
 use crate::cpu::kernel::constants::trie_type::PartialTrieType;
 use crate::memory::segments::Segment;
@@ -39,7 +39,7 @@ pub(crate) fn read_trie<V>(
     let mut res = HashMap::new();
     let empty_nibbles = Nibbles {
         count: 0,
-        packed: U256::zero(),
+        packed: U512::zero(),
     };
     read_trie_helper::<V>(memory, ptr, read_value, empty_nibbles, &mut res);
     res
@@ -75,7 +75,10 @@ pub(crate) fn read_trie_helper<V>(
         PartialTrieType::Extension => {
             let count = load(ptr + 1).as_usize();
             let packed = load(ptr + 2);
-            let nibbles = Nibbles { count, packed };
+            let nibbles = Nibbles {
+                count,
+                packed: packed.into(),
+            };
             let child_ptr = load(ptr + 3).as_usize();
             read_trie_helper::<V>(
                 memory,
@@ -88,7 +91,10 @@ pub(crate) fn read_trie_helper<V>(
         PartialTrieType::Leaf => {
             let count = load(ptr + 1).as_usize();
             let packed = load(ptr + 2);
-            let nibbles = Nibbles { count, packed };
+            let nibbles = Nibbles {
+                count,
+                packed: packed.into(),
+            };
             let value_ptr = load(ptr + 3).as_usize();
             res.insert(
                 prefix.merge_nibbles(&nibbles),


### PR DESCRIPTION
There was an edge case uncovered by the prover scheduler where storage trie keys could be `260` bits long, and `eth_trie_utils` can only support `256` bit keys. `eth_trie_utils` was quickly patched to support longer keys, but the solution is temporary and a better one should be implemented before we publish a new `crates.io` version.

Previously I had a temporary branch in `plonky2` that switched `plonky2` to use this patch, but this isn't the best for reproducible builds over time (unless we want to keep the branch forever). It might be better to instead push the patch directly to `plonky2` and then later bump it again once we have a proper fix.