### PR TITLE
Misc constraints

### DIFF
--- a/evm/src/arithmetic/byte.rs
+++ b/evm/src/arithmetic/byte.rs
@@ -318,8 +318,7 @@ pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     }
     let t = F::Extension::from(F::from_canonical_u64(32));
     let t = builder.constant_extension(t);
-    let idx0_hi = builder.mul_extension(idx_decomp[5], t);
-    let t = builder.add_extension(idx0_lo5, idx0_hi);
+    let t = builder.mul_add_extension(idx_decomp[5], t, idx0_lo5);
     let t = builder.sub_extension(idx[0], t);
     let t = builder.mul_extension(is_byte, t);
     yield_constr.constraint(builder, t);

--- a/evm/src/cpu/membus.rs
+++ b/evm/src/cpu/membus.rs
@@ -49,11 +49,11 @@ pub fn eval_packed<P: PackedField>(
     lv: &CpuColumnsView<P>,
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
-    let is_cpu_cycle: P = COL_MAP.op.iter().map(|&col_i| lv[col_i]).sum();
-    // Validate `lv.code_context`. It should be 0 if in kernel mode and `lv.context` if in user
-    // mode.
-    yield_constr
-        .constraint(is_cpu_cycle * (lv.code_context - (P::ONES - lv.is_kernel_mode) * lv.context));
+    // Validate `lv.code_context`.
+    // It should be 0 if in kernel mode and `lv.context` if in user mode.
+    // Note: This doesn't need to be filtered to CPU cycles, as this should also be satisfied
+    // during Kernel bootstrapping.
+    yield_constr.constraint(lv.code_context - (P::ONES - lv.is_kernel_mode) * lv.context);
 
     // Validate `channel.used`. It should be binary.
     for channel in lv.mem_channels {
@@ -66,13 +66,13 @@ pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     lv: &CpuColumnsView<ExtensionTarget<D>>,
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
 ) {
-    // Validate `lv.code_context`. It should be 0 if in kernel mode and `lv.context` if in user
-    // mode.
+    // Validate `lv.code_context`.
+    // It should be 0 if in kernel mode and `lv.context` if in user mode.
+    // Note: This doesn't need to be filtered to CPU cycles, as this should also be satisfied
+    // during Kernel bootstrapping.
     let diff = builder.sub_extension(lv.context, lv.code_context);
     let constr = builder.mul_sub_extension(lv.is_kernel_mode, lv.context, diff);
-    let is_cpu_cycle = builder.add_many_extension(COL_MAP.op.iter().map(|&col_i| lv[col_i]));
-    let filtered_constr = builder.mul_extension(is_cpu_cycle, constr);
-    yield_constr.constraint(builder, filtered_constr);
+    yield_constr.constraint(builder, constr);
 
     // Validate `channel.used`. It should be binary.
     for channel in lv.mem_channels {

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -399,7 +399,7 @@ pub(crate) fn eval_cross_table_lookup_checks<F, FE, P, S, const D: usize, const 
         consumer.constraint_first_row(*local_z - select(local_filter, combine(vars.local_values)));
         // Check `Z(gw) = combination * Z(w)`
         consumer.constraint_transition(
-            *next_z - *local_z * select(next_filter, combine(vars.next_values)),
+            *local_z * select(next_filter, combine(vars.next_values)) - *next_z,
         );
     }
 }
@@ -524,8 +524,7 @@ pub(crate) fn eval_cross_table_lookup_checks_circuit<
             .collect::<Vec<_>>();
         let combined_next = challenges.combine_circuit(builder, &next_columns_eval);
         let selected_next = select(builder, next_filter, combined_next);
-        let mut transition = builder.mul_extension(*local_z, selected_next);
-        transition = builder.sub_extension(*next_z, transition);
+        let transition = builder.mul_sub_extension(*local_z, selected_next, *next_z);
         consumer.constraint_transition(builder, transition);
     }
 }

--- a/evm/src/memory/memory_stark.rs
+++ b/evm/src/memory/memory_stark.rs
@@ -408,7 +408,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
             let diff = builder.sub_extension(next_addr_context, addr_context);
             builder.sub_extension(diff, one)
         };
-        let context_range_check = builder.mul_extension(context_first_change, context_diff);
         let segment_diff = {
             let diff = builder.sub_extension(next_addr_segment, addr_segment);
             builder.sub_extension(diff, one)
@@ -423,7 +422,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for MemoryStark<F
         let timestamp_range_check = builder.mul_extension(address_unchanged, timestamp_diff);
 
         let computed_range_check = {
-            let mut sum = builder.add_extension(context_range_check, segment_range_check);
+            // context_range_check = context_first_change * context_diff
+            let mut sum =
+                builder.mul_add_extension(context_first_change, context_diff, segment_range_check);
             sum = builder.add_extension(sum, virtual_range_check);
             builder.add_extension(sum, timestamp_range_check)
         };


### PR DESCRIPTION
This PR amortizes a few constraints with `mul_add_extension`, and removes unnecessary filtering in over-constrained statements. 
I removed the TODO comment I had previously written in the decode module, as I thought the op flags were being individually binary constrained elsewhere which is not the case, hence the comment was erroneous.