### PR TITLE
Use 2 limbs for BlockBaseFee

### DIFF
--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -74,7 +74,10 @@ fn observe_block_metadata<
         block_metadata.block_chain_id.as_u32(),
     ));
     challenger.observe_element(F::from_canonical_u32(
-        block_metadata.block_base_fee.as_u32(),
+        block_metadata.block_base_fee.as_u64() as u32,
+    ));
+    challenger.observe_element(F::from_canonical_u32(
+        (block_metadata.block_base_fee.as_u64() >> 32) as u32,
     ));
 }
 
@@ -94,7 +97,7 @@ fn observe_block_metadata_target<
     challenger.observe_element(block_metadata.block_difficulty);
     challenger.observe_element(block_metadata.block_gaslimit);
     challenger.observe_element(block_metadata.block_chain_id);
-    challenger.observe_element(block_metadata.block_base_fee);
+    challenger.observe_elements(&block_metadata.block_base_fee);
 }
 
 pub(crate) fn observe_public_values<

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -28,7 +28,10 @@ use plonky2_util::log2_ceil;
 use crate::all_stark::{Table, NUM_TABLES};
 use crate::config::StarkConfig;
 use crate::constraint_consumer::RecursiveConstraintConsumer;
+use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::cross_table_lookup::{verify_cross_table_lookups, CrossTableLookup, CtlCheckVarsTarget};
+use crate::memory::segments::Segment;
+use crate::memory::VALUE_LIMBS;
 use crate::permutation::{
     get_grand_product_challenge_set, GrandProductChallenge, GrandProductChallengeSet,
     PermutationCheckDataTarget,
@@ -492,6 +495,137 @@ fn verify_stark_proof_with_challenges_circuit<
         &proof.opening_proof,
         &inner_config.fri_params(degree_bits),
     );
+}
+
+/// Recursive version of `get_memory_extra_looking_products`.
+pub(crate) fn get_memory_extra_looking_products_circuit<
+    F: RichField + Extendable<D>,
+    const D: usize,
+>(
+    builder: &mut CircuitBuilder<F, D>,
+    public_values: &PublicValuesTarget,
+    challenge: GrandProductChallenge<Target>,
+) -> Target {
+    let mut product = builder.one();
+
+    // Add metadata writes.
+    let block_fields_without_beneficiary_and_basefee = [
+        (
+            GlobalMetadata::BlockTimestamp as usize,
+            public_values.block_metadata.block_timestamp,
+        ),
+        (
+            GlobalMetadata::BlockNumber as usize,
+            public_values.block_metadata.block_number,
+        ),
+        (
+            GlobalMetadata::BlockDifficulty as usize,
+            public_values.block_metadata.block_difficulty,
+        ),
+        (
+            GlobalMetadata::BlockGasLimit as usize,
+            public_values.block_metadata.block_gaslimit,
+        ),
+        (
+            GlobalMetadata::BlockChainId as usize,
+            public_values.block_metadata.block_chain_id,
+        ),
+    ];
+
+    product = add_metadata_write(
+        builder,
+        challenge,
+        product,
+        GlobalMetadata::BlockBeneficiary as usize,
+        &public_values.block_metadata.block_beneficiary,
+    );
+
+    block_fields_without_beneficiary_and_basefee.map(|(field, target)| {
+        // Each of those fields fit in 32 bits, hence in a single Target.
+        product = add_metadata_write(builder, challenge, product, field, &[target]);
+    });
+
+    product = add_metadata_write(
+        builder,
+        challenge,
+        product,
+        GlobalMetadata::BlockBaseFee as usize,
+        &public_values.block_metadata.block_base_fee,
+    );
+
+    // Add trie roots writes.
+    let trie_fields = [
+        (
+            GlobalMetadata::StateTrieRootDigestBefore as usize,
+            public_values.trie_roots_before.state_root,
+        ),
+        (
+            GlobalMetadata::TransactionTrieRootDigestBefore as usize,
+            public_values.trie_roots_before.transactions_root,
+        ),
+        (
+            GlobalMetadata::ReceiptTrieRootDigestBefore as usize,
+            public_values.trie_roots_before.receipts_root,
+        ),
+        (
+            GlobalMetadata::StateTrieRootDigestAfter as usize,
+            public_values.trie_roots_after.state_root,
+        ),
+        (
+            GlobalMetadata::TransactionTrieRootDigestAfter as usize,
+            public_values.trie_roots_after.transactions_root,
+        ),
+        (
+            GlobalMetadata::ReceiptTrieRootDigestAfter as usize,
+            public_values.trie_roots_after.receipts_root,
+        ),
+    ];
+
+    trie_fields.map(|(field, targets)| {
+        product = add_metadata_write(builder, challenge, product, field, &targets);
+    });
+
+    product
+}
+
+fn add_metadata_write<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    challenge: GrandProductChallenge<Target>,
+    running_product: Target,
+    metadata_idx: usize,
+    metadata: &[Target],
+) -> Target {
+    debug_assert!(metadata.len() <= VALUE_LIMBS);
+    let len = core::cmp::min(metadata.len(), VALUE_LIMBS);
+
+    let zero = builder.zero();
+    let one = builder.one();
+    let segment = builder.constant(F::from_canonical_u32(Segment::GlobalMetadata as u32));
+
+    let row = builder.add_virtual_targets(13);
+    // is_read
+    builder.connect(row[0], zero);
+    // context
+    builder.connect(row[1], zero);
+    // segment
+    builder.connect(row[2], segment);
+    // virtual
+    let field_target = builder.constant(F::from_canonical_usize(metadata_idx));
+    builder.connect(row[3], field_target);
+
+    // values
+    for j in 0..len {
+        builder.connect(row[4 + j], metadata[j]);
+    }
+    for j in len..VALUE_LIMBS {
+        builder.connect(row[4 + j], zero);
+    }
+
+    // timestamp
+    builder.connect(row[12], one);
+
+    let combined = challenge.combine_base_circuit(builder, &row);
+    builder.mul(running_product, combined)
 }
 
 fn eval_l_0_and_l_last_circuit<F: RichField + Extendable<D>, const D: usize>(

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -548,7 +548,7 @@ pub(crate) fn add_virtual_block_metadata<F: RichField + Extendable<D>, const D: 
     let block_difficulty = builder.add_virtual_public_input();
     let block_gaslimit = builder.add_virtual_public_input();
     let block_chain_id = builder.add_virtual_public_input();
-    let block_base_fee = builder.add_virtual_public_input();
+    let block_base_fee = builder.add_virtual_public_input_arr();
     BlockMetadataTarget {
         block_beneficiary,
         block_timestamp,
@@ -749,8 +749,13 @@ pub(crate) fn set_block_metadata_target<F, W, const D: usize>(
         block_metadata_target.block_chain_id,
         F::from_canonical_u32(block_metadata.block_chain_id.as_u32()),
     );
+    // Basefee fits in 2 limbs
     witness.set_target(
-        block_metadata_target.block_base_fee,
-        F::from_canonical_u32(block_metadata.block_base_fee.as_u32()),
+        block_metadata_target.block_base_fee[0],
+        F::from_canonical_u32(block_metadata.block_base_fee.as_u64() as u32),
+    );
+    witness.set_target(
+        block_metadata_target.block_base_fee[1],
+        F::from_canonical_u32((block_metadata.block_base_fee.as_u64() >> 32) as u32),
     );
 }


### PR DESCRIPTION
Allows `BlockBaseFee` to be greater than 32 bits, following discussion in #1193.

@wborgeaud: the actual changes are in the first commit. The second one deals with code duplication removal and moves the `get_memory_extra_looking_products_circuit` method to recursive_verifier.rs where I think it should belong (based on where the other "circuit-version" verification methods are implemented).