### PR TITLE
feat: make generate_partial_witness available outside the crate

### DIFF
--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -16,7 +16,7 @@ use crate::util::serialization::{Buffer, IoResult, Read, Write};
 
 /// Given a `PartitionWitness` that has only inputs set, populates the rest of the witness using the
 /// given set of generators.
-pub(crate) fn generate_partial_witness<
+pub fn generate_partial_witness<
     'a,
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,


### PR DESCRIPTION
This PR makes `generate_partial_witness` available outside of the crate. This is useful for reading intermediate values in the witness and for debugging circuits.