### PR TITLE
Update ranges in empty_txn_list

### DIFF
--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -62,7 +62,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
-        &[16..17, 14..15, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list
+        &[16..17, 15..16, 14..15, 9..10, 12..13, 18..19], // Minimal ranges to prove an empty list
         &config,
     );
 


### PR DESCRIPTION
It seems the CPU table length got a bump following #1097, but the `empty_txn_list` test (although ignored on the CI) didn't get updated. This fixes the minimal ranges with the new CPU size.