### PR TITLE
Add blockhash opcode

### DIFF
--- a/evm/src/cpu/kernel/asm/core/syscall_stubs.asm
+++ b/evm/src/cpu/kernel/asm/core/syscall_stubs.asm
@@ -1,14 +1,6 @@
 // Labels for unimplemented syscalls to make the kernel assemble.
 // Each label should be removed from this file once it is implemented.
 
-// This is a temporary version that returns 0 on all inputs.
-// TODO: Fix this.
-global sys_blockhash:
-    // stack: kexit_info, block_number
-    %charge_gas_const(@GAS_BLOCKHASH)
-    %stack (kexit_info, block_number) -> (kexit_info, 0)
-    EXIT_KERNEL
-
 // This is a temporary version that returns the block difficulty (i.e. the old version of this opcode).
 // TODO: Fix this.
 // TODO: What semantics will this have for Edge?

--- a/evm/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm/src/cpu/kernel/asm/memory/metadata.asm
@@ -249,7 +249,7 @@ global blockhash:
     // stack: cur_block_number, block_number, retdest
     DUP1 DUP3 %increment GT %jumpi(zero_hash) // if block_number >= cur_block_number
     // stack: cur_block_number, block_number, retdest
-    DUP2 PUSH 256 ADD 
+    DUP2 PUSH 256 %add_or_fault
     // stack: block_number+256, cur_block_number, block_number, retdest
     DUP2 GT %jumpi(zero_hash) // if cur_block_number > block_number + 256
     // If we are here, the provided block number is correct

--- a/evm/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm/src/cpu/kernel/asm/memory/metadata.asm
@@ -247,9 +247,12 @@ global blockhash:
     // stack: block_number, retdest
     %mload_global_metadata(@GLOBAL_METADATA_BLOCK_NUMBER)
     // stack: cur_block_number, block_number, retdest
+    // Check for an overflow, since we're incrementing `block_number` afterwards.
+    DUP2 %eq_const(@U256_MAX) %jumpi(zero_hash)
+    // stack: cur_block_number, block_number, retdest
     DUP1 DUP3 %increment GT %jumpi(zero_hash) // if block_number >= cur_block_number
     // stack: cur_block_number, block_number, retdest
-    DUP2 PUSH 256 %add_or_fault
+    DUP2 PUSH 256 ADD
     // stack: block_number+256, cur_block_number, block_number, retdest
     DUP2 GT %jumpi(zero_hash) // if cur_block_number > block_number + 256
     // If we are here, the provided block number is correct

--- a/evm/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm/src/cpu/kernel/asm/memory/metadata.asm
@@ -235,6 +235,45 @@ global sys_basefee:
     SWAP1
     EXIT_KERNEL
 
+global sys_blockhash:
+    // stack: kexit_info, block_number
+    %charge_gas_const(@GAS_BLOCKHASH)
+    SWAP1
+    // stack: block_number, kexit_info
+    %blockhash
+    EXIT_KERNEL
+
+global blockhash:
+    // stack: block_number, retdest
+    %mload_global_metadata(@GLOBAL_METADATA_BLOCK_NUMBER)
+    // stack: cur_block_number, block_number, retdest
+    DUP1 DUP3 %increment GT %jumpi(zero_hash) // if block_number >= cur_block_number
+    // stack: cur_block_number, block_number, retdest
+    DUP2 PUSH 256 ADD 
+    // stack: block_number+256, cur_block_number, block_number, retdest
+    DUP2 GT %jumpi(zero_hash) // if cur_block_number > block_number + 256
+    // If we are here, the provided block number is correct
+    SUB
+    // stack: cur_block_number - block_number, retdest
+    PUSH 256 SUB
+    // stack: block_hash_number, retdest
+    %mload_kernel(@SEGMENT_BLOCK_HASHES)
+    SWAP1 JUMP
+    JUMP
+
+%macro blockhash
+    // stack: block_number
+    %stack (block_number) -> (block_number, %%after)
+    %jump(blockhash)
+%%after:
+%endmacro
+
+zero_hash:
+    // stack: cur_block_number, block_number, retdest
+    %pop2
+    PUSH 0 SWAP1
+    JUMP
+
 %macro update_mem_words
     // stack: num_words, kexit_info
     %mem_words

--- a/evm/src/cpu/kernel/constants/global_metadata.rs
+++ b/evm/src/cpu/kernel/constants/global_metadata.rs
@@ -47,44 +47,47 @@ pub(crate) enum GlobalMetadata {
     BlockGasUsedBefore = 22,
     /// After current transactions block values.
     BlockGasUsedAfter = 23,
+    /// Current block header hash
+    BlockCurrentHash = 24,
+
     /// Gas to refund at the end of the transaction.
-    RefundCounter = 24,
+    RefundCounter = 25,
     /// Length of the addresses access list.
-    AccessedAddressesLen = 25,
+    AccessedAddressesLen = 26,
     /// Length of the storage keys access list.
-    AccessedStorageKeysLen = 26,
+    AccessedStorageKeysLen = 27,
     /// Length of the self-destruct list.
-    SelfDestructListLen = 27,
+    SelfDestructListLen = 28,
     /// Length of the bloom entry buffer.
-    BloomEntryLen = 28,
+    BloomEntryLen = 29,
 
     /// Length of the journal.
-    JournalLen = 29,
+    JournalLen = 30,
     /// Length of the `JournalData` segment.
-    JournalDataLen = 30,
+    JournalDataLen = 31,
     /// Current checkpoint.
-    CurrentCheckpoint = 31,
-    TouchedAddressesLen = 32,
+    CurrentCheckpoint = 32,
+    TouchedAddressesLen = 33,
     // Gas cost for the access list in type-1 txns. See EIP-2930.
-    AccessListDataCost = 33,
+    AccessListDataCost = 34,
     // Start of the access list in the RLP for type-1 txns.
-    AccessListRlpStart = 34,
+    AccessListRlpStart = 35,
     // Length of the access list in the RLP for type-1 txns.
-    AccessListRlpLen = 35,
+    AccessListRlpLen = 36,
     // Boolean flag indicating if the txn is a contract creation txn.
-    ContractCreation = 36,
-    IsPrecompileFromEoa = 37,
-    CallStackDepth = 38,
-    /// Transaction logs list length.
-    LogsLen = 39,
-    LogsDataLen = 40,
-    LogsPayloadLen = 41,
-    TxnNumberBefore = 42,
-    TxnNumberAfter = 43,
+    ContractCreation = 37,
+    IsPrecompileFromEoa = 38,
+    CallStackDepth = 39,
+    /// Transaction logs list length
+    LogsLen = 40,
+    LogsDataLen = 41,
+    LogsPayloadLen = 42,
+    TxnNumberBefore = 43,
+    TxnNumberAfter = 44,
 }
 
 impl GlobalMetadata {
-    pub(crate) const COUNT: usize = 44;
+    pub(crate) const COUNT: usize = 45;
 
     pub(crate) fn all() -> [Self; Self::COUNT] {
         [
@@ -130,6 +133,7 @@ impl GlobalMetadata {
             Self::LogsLen,
             Self::LogsDataLen,
             Self::LogsPayloadLen,
+            Self::BlockCurrentHash,
             Self::TxnNumberBefore,
             Self::TxnNumberAfter,
         ]
@@ -162,6 +166,7 @@ impl GlobalMetadata {
             Self::BlockGasUsed => "GLOBAL_METADATA_BLOCK_GAS_USED",
             Self::BlockGasUsedBefore => "GLOBAL_METADATA_BLOCK_GAS_USED_BEFORE",
             Self::BlockGasUsedAfter => "GLOBAL_METADATA_BLOCK_GAS_USED_AFTER",
+            Self::BlockCurrentHash => "GLOBAL_METADATA_BLOCK_CURRENT_HASH",
             Self::RefundCounter => "GLOBAL_METADATA_REFUND_COUNTER",
             Self::AccessedAddressesLen => "GLOBAL_METADATA_ACCESSED_ADDRESSES_LEN",
             Self::AccessedStorageKeysLen => "GLOBAL_METADATA_ACCESSED_STORAGE_KEYS_LEN",

--- a/evm/src/cpu/kernel/tests/block_hash.rs
+++ b/evm/src/cpu/kernel/tests/block_hash.rs
@@ -97,8 +97,7 @@ fn test_small_index_block_hash() -> Result<()> {
 }
 
 #[test]
-#[should_panic]
-fn test_block_hash_with_overflow() {
+fn test_block_hash_with_overflow() -> Result<()> {
     let blockhash_label = KERNEL.global_labels["blockhash"];
     let retdest = 0xDEADBEEFu32.into();
     let cur_block_number = 1;
@@ -111,5 +110,16 @@ fn test_block_hash_with_overflow() {
     interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
     interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
     interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
-    let _ = interpreter.run();
+    interpreter.run()?;
+
+    let result = interpreter.stack();
+    assert_eq!(
+        result[0],
+        0.into(),
+        "Resulting block hash {:?} different from expected hash {:?}",
+        result[0],
+        0
+    );
+
+    Ok(())
 }

--- a/evm/src/cpu/kernel/tests/block_hash.rs
+++ b/evm/src/cpu/kernel/tests/block_hash.rs
@@ -1,0 +1,97 @@
+use anyhow::Result;
+use ethereum_types::{H256, U256};
+use rand::{thread_rng, Rng};
+
+use crate::cpu::kernel::aggregator::KERNEL;
+use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
+use crate::cpu::kernel::interpreter::Interpreter;
+use crate::memory::segments::Segment;
+
+#[test]
+fn test_correct_block_hash() -> Result<()> {
+    let mut rng = rand::thread_rng();
+
+    let blockhash_label = KERNEL.global_labels["blockhash"];
+    let retdest = 0xDEADBEEFu32.into();
+
+    let block_number: u8 = rng.gen();
+    let initial_stack = vec![retdest, block_number.into()];
+
+    let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
+
+    let mut interpreter = Interpreter::new_with_kernel(blockhash_label, initial_stack);
+    interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, 256.into());
+    interpreter.run()?;
+
+    let result = interpreter.stack();
+    assert_eq!(
+        result[0], hashes[block_number as usize],
+        "Resulting block hash {:?} different from expected hash {:?}",
+        result[0], hashes[block_number as usize]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_big_index_block_hash() -> Result<()> {
+    let mut rng = rand::thread_rng();
+
+    let blockhash_label = KERNEL.global_labels["blockhash"];
+    let retdest = 0xDEADBEEFu32.into();
+    let cur_block_number = 3;
+    let block_number: usize = rng.gen::<u8>() as usize;
+    let actual_block_number = block_number + cur_block_number;
+    let initial_stack = vec![retdest, actual_block_number.into()];
+
+    let hashes: Vec<U256> = vec![U256::from_big_endian(&thread_rng().gen::<H256>().0); 257];
+
+    let mut interpreter = Interpreter::new_with_kernel(blockhash_label, initial_stack);
+    interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
+    interpreter.run()?;
+
+    let result = interpreter.stack();
+    assert_eq!(
+        result[0],
+        0.into(),
+        "Resulting block hash {:?} different from expected hash {:?}",
+        result[0],
+        0
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_small_index_block_hash() -> Result<()> {
+    let mut rng = rand::thread_rng();
+
+    let blockhash_label = KERNEL.global_labels["blockhash"];
+    let retdest = 0xDEADBEEFu32.into();
+    let cur_block_number = 512;
+    let block_number = rng.gen::<u8>() as usize;
+    let initial_stack = vec![retdest, block_number.into()];
+
+    let hashes: Vec<U256> = (20..277).map(|elt| elt.into()).collect();
+
+    let mut interpreter = Interpreter::new_with_kernel(blockhash_label, initial_stack);
+    interpreter.set_memory_segment(Segment::BlockHashes, hashes[0..256].to_vec());
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockCurrentHash, hashes[256]);
+    interpreter.set_global_metadata_field(GlobalMetadata::BlockNumber, cur_block_number.into());
+    interpreter.run()?;
+
+    let result = interpreter.stack();
+    assert_eq!(
+        result[0],
+        0.into(),
+        "Resulting block hash {:?} different from expected hash {:?}",
+        result[0],
+        0
+    );
+
+    Ok(())
+}

--- a/evm/src/cpu/kernel/tests/mod.rs
+++ b/evm/src/cpu/kernel/tests/mod.rs
@@ -2,6 +2,7 @@ mod account_code;
 mod balance;
 mod bignum;
 mod blake2_f;
+mod block_hash;
 mod bls381;
 mod bn254;
 mod core;

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -23,7 +23,7 @@ use crate::generation::state::GenerationState;
 use crate::memory::segments::Segment;
 use crate::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
 use crate::util::h2u;
-use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryOp};
+use crate::witness::memory::{MemoryAddress, MemoryChannel};
 use crate::witness::transition::transition;
 
 pub mod mpt;

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -104,7 +104,7 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
         (GlobalMetadata::BlockBaseFee, metadata.block_base_fee),
         (
             GlobalMetadata::BlockCurrentHash,
-            U256::from_big_endian(&inputs.block_hashes.cur_hash.0),
+            h2u(inputs.block_hashes.cur_hash),
         ),
         (GlobalMetadata::BlockGasUsed, metadata.block_gas_used),
         (GlobalMetadata::BlockGasUsedBefore, inputs.gas_used_before),

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -21,9 +21,9 @@ use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::generation::outputs::{get_outputs, GenerationOutputs};
 use crate::generation::state::GenerationState;
 use crate::memory::segments::Segment;
-use crate::proof::{BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
+use crate::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
 use crate::util::h2u;
-use crate::witness::memory::{MemoryAddress, MemoryChannel};
+use crate::witness::memory::{MemoryAddress, MemoryChannel, MemoryOp};
 use crate::witness::transition::transition;
 
 pub mod mpt;
@@ -54,6 +54,8 @@ pub struct GenerationInputs {
     pub contract_code: HashMap<H256, Vec<u8>>,
 
     pub block_metadata: BlockMetadata,
+
+    pub block_hashes: BlockHashes,
 
     /// A list of known addresses in the input state trie (which itself doesn't hold addresses,
     /// only state keys). This is only useful for debugging, so that we can return addresses in the
@@ -100,6 +102,10 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
         (GlobalMetadata::BlockGasLimit, metadata.block_gaslimit),
         (GlobalMetadata::BlockChainId, metadata.block_chain_id),
         (GlobalMetadata::BlockBaseFee, metadata.block_base_fee),
+        (
+            GlobalMetadata::BlockCurrentHash,
+            U256::from_big_endian(&inputs.block_hashes.cur_hash.0),
+        ),
         (GlobalMetadata::BlockGasUsed, metadata.block_gas_used),
         (GlobalMetadata::BlockGasUsedBefore, inputs.gas_used_before),
         (GlobalMetadata::BlockGasUsedAfter, inputs.gas_used_after),
@@ -181,6 +187,19 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
             })
             .collect::<Vec<_>>(),
     );
+    // Write previous block hashes.
+    ops.extend(
+        (0..256)
+            .map(|i| {
+                mem_write_log(
+                    channel,
+                    MemoryAddress::new(0, Segment::BlockHashes, i),
+                    state,
+                    h2u(inputs.block_hashes.prev_hashes[i]),
+                )
+            })
+            .collect::<Vec<_>>(),
+    );
 
     state.memory.apply_ops(&ops);
     state.traces.memory_ops.extend(ops);
@@ -244,6 +263,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         trie_roots_before,
         trie_roots_after,
         block_metadata: inputs.block_metadata,
+        block_hashes: inputs.block_hashes,
         extra_block_data,
     };
 

--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -39,6 +39,7 @@ impl<F: Field> GenerationState<F> {
             "ffe" => self.run_ffe(input_fn),
             "mpt" => self.run_mpt(),
             "rlp" => self.run_rlp(),
+            "current_hash" => self.run_current_hash(),
             "account_code" => self.run_account_code(input_fn),
             "bignum_modmul" => self.run_bignum_modmul(),
             _ => panic!("Unrecognized prover input function."),
@@ -116,6 +117,10 @@ impl<F: Field> GenerationState<F> {
         self.rlp_prover_inputs
             .pop()
             .unwrap_or_else(|| panic!("Out of RLP data"))
+    }
+
+    fn run_current_hash(&mut self) -> U256 {
+        U256::from_big_endian(&self.inputs.block_hashes.cur_hash.0)
     }
 
     /// Account code.

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -146,6 +146,37 @@ fn observe_extra_block_data_target<
     challenger.observe_elements(&extra_data.block_bloom_after);
 }
 
+fn observe_block_hashes<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    challenger: &mut Challenger<F, C::Hasher>,
+    block_hashes: &BlockHashes,
+) {
+    for i in 0..256 {
+        challenger.observe_elements(
+            &u256_limbs::<F>(U256::from_big_endian(&block_hashes.prev_hashes[i].0))[0..8],
+        );
+    }
+    challenger
+        .observe_elements(&u256_limbs::<F>(U256::from_big_endian(&block_hashes.cur_hash.0))[0..8])
+}
+
+fn observe_block_hashes_target<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    challenger: &mut RecursiveChallenger<F, C::Hasher, D>,
+    block_hashes: &BlockHashesTarget,
+) where
+    C::Hasher: AlgebraicHasher<F>,
+{
+    challenger.observe_elements(&block_hashes.prev_hashes);
+    challenger.observe_elements(&block_hashes.cur_hash);
+}
+
 pub(crate) fn observe_public_values<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
@@ -157,6 +188,7 @@ pub(crate) fn observe_public_values<
     observe_trie_roots::<F, C, D>(challenger, &public_values.trie_roots_before);
     observe_trie_roots::<F, C, D>(challenger, &public_values.trie_roots_after);
     observe_block_metadata::<F, C, D>(challenger, &public_values.block_metadata);
+    observe_block_hashes::<F, C, D>(challenger, &public_values.block_hashes);
     observe_extra_block_data::<F, C, D>(challenger, &public_values.extra_block_data);
 }
 
@@ -173,6 +205,7 @@ pub(crate) fn observe_public_values_target<
     observe_trie_roots_target::<F, C, D>(challenger, &public_values.trie_roots_before);
     observe_trie_roots_target::<F, C, D>(challenger, &public_values.trie_roots_after);
     observe_block_metadata_target::<F, C, D>(challenger, &public_values.block_metadata);
+    observe_block_hashes_target::<F, C, D>(challenger, &public_values.block_hashes);
     observe_extra_block_data_target::<F, C, D>(challenger, &public_values.extra_block_data);
 }
 

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -13,7 +13,7 @@ use crate::permutation::{
     get_n_grand_product_challenge_sets_target,
 };
 use crate::proof::*;
-use crate::util::u256_limbs;
+use crate::util::{h256_limbs, u256_limbs};
 
 fn observe_root<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     challenger: &mut Challenger<F, C::Hasher>,
@@ -155,12 +155,9 @@ fn observe_block_hashes<
     block_hashes: &BlockHashes,
 ) {
     for i in 0..256 {
-        challenger.observe_elements(
-            &u256_limbs::<F>(U256::from_big_endian(&block_hashes.prev_hashes[i].0))[0..8],
-        );
+        challenger.observe_elements(&h256_limbs::<F>(block_hashes.prev_hashes[i])[0..8]);
     }
-    challenger
-        .observe_elements(&u256_limbs::<F>(U256::from_big_endian(&block_hashes.cur_hash.0))[0..8])
+    challenger.observe_elements(&h256_limbs::<F>(block_hashes.cur_hash)[0..8])
 }
 
 fn observe_block_hashes_target<

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -157,7 +157,7 @@ fn observe_block_hashes<
     for i in 0..256 {
         challenger.observe_elements(&h256_limbs::<F>(block_hashes.prev_hashes[i])[0..8]);
     }
-    challenger.observe_elements(&h256_limbs::<F>(block_hashes.cur_hash)[0..8])
+    challenger.observe_elements(&h256_limbs::<F>(block_hashes.cur_hash)[0..8]);
 }
 
 fn observe_block_hashes_target<

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -155,9 +155,9 @@ fn observe_block_hashes<
     block_hashes: &BlockHashes,
 ) {
     for i in 0..256 {
-        challenger.observe_elements(&h256_limbs::<F>(block_hashes.prev_hashes[i])[0..8]);
+        challenger.observe_elements(&h256_limbs::<F>(block_hashes.prev_hashes[i]));
     }
-    challenger.observe_elements(&h256_limbs::<F>(block_hashes.cur_hash)[0..8]);
+    challenger.observe_elements(&h256_limbs::<F>(block_hashes.cur_hash));
 }
 
 fn observe_block_hashes_target<

--- a/evm/src/memory/segments.rs
+++ b/evm/src/memory/segments.rs
@@ -68,10 +68,12 @@ pub enum Segment {
     TouchedAddresses = 34,
     /// List of checkpoints for the current context. Length in `ContextMetadata`.
     ContextCheckpoints = 35,
+    /// List of 256 previous block hashes.
+    BlockHashes = 36,
 }
 
 impl Segment {
-    pub(crate) const COUNT: usize = 36;
+    pub(crate) const COUNT: usize = 37;
 
     pub(crate) fn all() -> [Self; Self::COUNT] {
         [
@@ -111,6 +113,7 @@ impl Segment {
             Self::JournalCheckpoints,
             Self::TouchedAddresses,
             Self::ContextCheckpoints,
+            Self::BlockHashes,
         ]
     }
 
@@ -153,6 +156,7 @@ impl Segment {
             Segment::JournalCheckpoints => "SEGMENT_JOURNAL_CHECKPOINTS",
             Segment::TouchedAddresses => "SEGMENT_TOUCHED_ADDRESSES",
             Segment::ContextCheckpoints => "SEGMENT_CONTEXT_CHECKPOINTS",
+            Segment::BlockHashes => "SEGMENT_BLOCK_HASHES",
         }
     }
 
@@ -195,6 +199,7 @@ impl Segment {
             Segment::JournalCheckpoints => 256,
             Segment::TouchedAddresses => 256,
             Segment::ContextCheckpoints => 256,
+            Segment::BlockHashes => 256,
         }
     }
 }

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -53,6 +53,7 @@ pub struct PublicValues {
     pub trie_roots_before: TrieRoots,
     pub trie_roots_after: TrieRoots,
     pub block_metadata: BlockMetadata,
+    pub block_hashes: BlockHashes,
     pub extra_block_data: ExtraBlockData,
 }
 
@@ -61,6 +62,22 @@ pub struct TrieRoots {
     pub state_root: H256,
     pub transactions_root: H256,
     pub receipts_root: H256,
+}
+
+// There should be 256 previous hashes stored, so the default should also contain 256 values.
+impl Default for BlockHashes {
+    fn default() -> Self {
+        Self {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockHashes {
+    pub prev_hashes: Vec<H256>,
+    pub cur_hash: H256,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -93,6 +110,7 @@ pub struct PublicValuesTarget {
     pub trie_roots_before: TrieRootsTarget,
     pub trie_roots_after: TrieRootsTarget,
     pub block_metadata: BlockMetadataTarget,
+    pub block_hashes: BlockHashesTarget,
     pub extra_block_data: ExtraBlockDataTarget,
 }
 
@@ -140,6 +158,13 @@ impl PublicValuesTarget {
         buffer.write_target(block_gas_used)?;
         buffer.write_target_array(&block_bloom)?;
 
+        let BlockHashesTarget {
+            prev_hashes,
+            cur_hash,
+        } = self.block_hashes;
+        buffer.write_target_array(&prev_hashes)?;
+        buffer.write_target_array(&cur_hash)?;
+
         let ExtraBlockDataTarget {
             txn_number_before,
             txn_number_after,
@@ -183,6 +208,11 @@ impl PublicValuesTarget {
             block_bloom: buffer.read_target_array()?,
         };
 
+        let block_hashes = BlockHashesTarget {
+            prev_hashes: buffer.read_target_array()?,
+            cur_hash: buffer.read_target_array()?,
+        };
+
         let extra_block_data = ExtraBlockDataTarget {
             txn_number_before: buffer.read_target()?,
             txn_number_after: buffer.read_target()?,
@@ -196,6 +226,7 @@ impl PublicValuesTarget {
             trie_roots_before,
             trie_roots_after,
             block_metadata,
+            block_hashes,
             extra_block_data,
         })
     }
@@ -205,6 +236,7 @@ impl PublicValuesTarget {
             pis.len()
                 > TrieRootsTarget::SIZE * 2
                     + BlockMetadataTarget::SIZE
+                    + BlockHashesTarget::BLOCK_HASHES_SIZE
                     + ExtraBlockDataTarget::SIZE
                     - 1
         );
@@ -218,10 +250,17 @@ impl PublicValuesTarget {
                 &pis[TrieRootsTarget::SIZE * 2
                     ..TrieRootsTarget::SIZE * 2 + BlockMetadataTarget::SIZE],
             ),
+            block_hashes: BlockHashesTarget::from_public_inputs(
+                &pis[TrieRootsTarget::SIZE * 2 + BlockMetadataTarget::SIZE
+                    ..TrieRootsTarget::SIZE * 2
+                        + BlockMetadataTarget::SIZE
+                        + BlockHashesTarget::BLOCK_HASHES_SIZE],
+            ),
             extra_block_data: ExtraBlockDataTarget::from_public_inputs(
                 &pis[TrieRootsTarget::SIZE * 2 + BlockMetadataTarget::SIZE
                     ..TrieRootsTarget::SIZE * 2
                         + BlockMetadataTarget::SIZE
+                        + BlockHashesTarget::BLOCK_HASHES_SIZE
                         + ExtraBlockDataTarget::SIZE],
             ),
         }
@@ -251,6 +290,12 @@ impl PublicValuesTarget {
                 condition,
                 pv0.block_metadata,
                 pv1.block_metadata,
+            ),
+            block_hashes: BlockHashesTarget::select(
+                builder,
+                condition,
+                pv0.block_hashes,
+                pv1.block_hashes,
             ),
             extra_block_data: ExtraBlockDataTarget::select(
                 builder,
@@ -407,6 +452,51 @@ impl BlockMetadataTarget {
         }
         for i in 0..64 {
             builder.connect(bm0.block_bloom[i], bm1.block_bloom[i])
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
+pub struct BlockHashesTarget {
+    pub prev_hashes: [Target; 2048],
+    pub cur_hash: [Target; 8],
+}
+
+impl BlockHashesTarget {
+    const BLOCK_HASHES_SIZE: usize = 2056;
+    pub fn from_public_inputs(pis: &[Target]) -> Self {
+        Self {
+            prev_hashes: pis[0..2048].try_into().unwrap(),
+            cur_hash: pis[2048..2056].try_into().unwrap(),
+        }
+    }
+
+    pub fn select<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        condition: BoolTarget,
+        bm0: Self,
+        bm1: Self,
+    ) -> Self {
+        Self {
+            prev_hashes: core::array::from_fn(|i| {
+                builder.select(condition, bm0.prev_hashes[i], bm1.prev_hashes[i])
+            }),
+            cur_hash: core::array::from_fn(|i| {
+                builder.select(condition, bm0.cur_hash[i], bm1.cur_hash[i])
+            }),
+        }
+    }
+
+    pub fn connect<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        bm0: Self,
+        bm1: Self,
+    ) {
+        for i in 0..2048 {
+            builder.connect(bm0.prev_hashes[i], bm1.prev_hashes[i]);
+        }
+        for i in 0..8 {
+            builder.connect(bm0.cur_hash[i], bm1.cur_hash[i]);
         }
     }
 }

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -257,7 +257,9 @@ impl PublicValuesTarget {
                         + BlockHashesTarget::BLOCK_HASHES_SIZE],
             ),
             extra_block_data: ExtraBlockDataTarget::from_public_inputs(
-                &pis[TrieRootsTarget::SIZE * 2 + BlockMetadataTarget::SIZE
+                &pis[TrieRootsTarget::SIZE * 2
+                    + BlockMetadataTarget::SIZE
+                    + BlockHashesTarget::BLOCK_HASHES_SIZE
                     ..TrieRootsTarget::SIZE * 2
                         + BlockMetadataTarget::SIZE
                         + BlockHashesTarget::BLOCK_HASHES_SIZE

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -1057,7 +1057,7 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
     W: Witness<F>,
 {
     for i in 0..256 {
-        let block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.prev_hashes[i])[..8]
+        let block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.prev_hashes[i])
             .try_into()
             .unwrap();
         witness.set_target_arr(
@@ -1065,9 +1065,7 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
             &block_hash_limbs,
         );
     }
-    let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash)[..8]
-        .try_into()
-        .unwrap();
+    let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash).try_into().unwrap();
     witness.set_target_arr(&block_hashes_target.cur_hash, &cur_block_hash_limbs);
 }
 

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -1057,15 +1057,13 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
     W: Witness<F>,
 {
     for i in 0..256 {
-        let block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.prev_hashes[i])
-            .try_into()
-            .unwrap();
+        let block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.prev_hashes[i]);
         witness.set_target_arr(
             &block_hashes_target.prev_hashes[8 * i..8 * (i + 1)],
             &block_hash_limbs,
         );
     }
-    let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash).try_into().unwrap();
+    let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash);
     witness.set_target_arr(&block_hashes_target.cur_hash, &cur_block_hash_limbs);
 }
 

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -43,7 +43,7 @@ use crate::proof::{
     TrieRootsTarget,
 };
 use crate::stark::Stark;
-use crate::util::u256_limbs;
+use crate::util::{h256_limbs, u256_limbs};
 use crate::vanishing_poly::eval_vanishing_poly_circuit;
 use crate::vars::StarkEvaluationTargets;
 
@@ -1057,19 +1057,17 @@ pub(crate) fn set_block_hashes_target<F, W, const D: usize>(
     W: Witness<F>,
 {
     for i in 0..256 {
-        let block_hash_limbs: [F; 8] =
-            u256_limbs::<F>(U256::from_big_endian(&block_hashes.prev_hashes[i].0))[..8]
-                .try_into()
-                .unwrap();
+        let block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.prev_hashes[i])[..8]
+            .try_into()
+            .unwrap();
         witness.set_target_arr(
             &block_hashes_target.prev_hashes[8 * i..8 * (i + 1)],
             &block_hash_limbs,
         );
     }
-    let cur_block_hash_limbs: [F; 8] =
-        u256_limbs::<F>(U256::from_big_endian(&block_hashes.cur_hash.0))[..8]
-            .try_into()
-            .unwrap();
+    let cur_block_hash_limbs: [F; 8] = h256_limbs::<F>(block_hashes.cur_hash)[..8]
+        .try_into()
+        .unwrap();
     witness.set_target_arr(&block_hashes_target.cur_hash, &cur_block_hash_limbs);
 }
 

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -177,6 +177,10 @@ where
             public_values.block_metadata.block_base_fee,
         ),
         (
+            GlobalMetadata::BlockCurrentHash,
+            U256::from_big_endian(&public_values.block_hashes.cur_hash.0),
+        ),
+        (
             GlobalMetadata::BlockGasUsed,
             public_values.block_metadata.block_gas_used,
         ),
@@ -242,6 +246,13 @@ where
         prod = add_data_write(challenge, bloom_segment, prod, index + 16, val);
     }
 
+    // Add Blockhashes writes.
+    let block_hashes_segment = F::from_canonical_u32(Segment::BlockHashes as u32);
+    for index in 0..256 {
+        let val = h2u(public_values.block_hashes.prev_hashes[index]);
+        prod = add_data_write(challenge, block_hashes_segment, prod, index, val);
+    }
+
     prod
 }
 
@@ -267,6 +278,7 @@ where
     row[12] = F::ONE; // timestamp
     running_product * challenge.combine(row.iter())
 }
+
 pub(crate) fn verify_stark_proof_with_challenges<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -178,7 +178,7 @@ where
         ),
         (
             GlobalMetadata::BlockCurrentHash,
-            U256::from_big_endian(&public_values.block_hashes.cur_hash.0),
+            h2u(public_values.block_hashes.cur_hash),
         ),
         (
             GlobalMetadata::BlockGasUsed,

--- a/evm/tests/add11_yml.rs
+++ b/evm/tests/add11_yml.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::nibbles::Nibbles;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
-use ethereum_types::Address;
+use ethereum_types::{Address, H256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -15,7 +15,7 @@ use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -154,6 +154,10 @@ fn add11_yml() -> anyhow::Result<()> {
         gas_used_after: 0xa868u64.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 

--- a/evm/tests/basic_smart_contract.rs
+++ b/evm/tests/basic_smart_contract.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::nibbles::Nibbles;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -16,7 +16,7 @@ use plonky2_evm::config::StarkConfig;
 use plonky2_evm::cpu::kernel::opcodes::{get_opcode, get_push_opcode};
 use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -171,6 +171,10 @@ fn test_basic_smart_contract() -> anyhow::Result<()> {
         gas_used_after: gas_used.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
+use ethereum_types::H256;
 use keccak_hash::keccak;
 use log::info;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -14,7 +15,7 @@ use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use plonky2_evm::Node;
 
 type F = GoldilocksField;
@@ -62,6 +63,10 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         gas_used_after: 0.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::nibbles::Nibbles;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -19,7 +19,7 @@ use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
 use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp, LegacyTransactionRlp, LogRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -232,6 +232,10 @@ fn test_log_opcodes() -> anyhow::Result<()> {
         block_bloom_before: [0.into(); 8],
         block_bloom_after,
 
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 
@@ -425,6 +429,10 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
         gas_used_after: 21000u64.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 
@@ -562,6 +570,10 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
         gas_used_after: receipt.cum_gas_used,
         block_bloom_before: block_bloom_second,
         block_bloom_after: block_bloom_final,
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 
@@ -585,6 +597,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
             block_bloom_after: public_values.extra_block_data.block_bloom_after,
         },
         block_metadata: public_values.block_metadata,
+        block_hashes: public_values.block_hashes,
     };
 
     // We can duplicate the proofs here because the state hasn't mutated.
@@ -857,6 +870,10 @@ fn test_two_txn() -> anyhow::Result<()> {
         gas_used_after: 42000u64.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 

--- a/evm/tests/self_balance_gas_cost.rs
+++ b/evm/tests/self_balance_gas_cost.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::nibbles::Nibbles;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
-use ethereum_types::Address;
+use ethereum_types::{Address, H256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -15,7 +15,7 @@ use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -160,6 +160,10 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
         gas_used_after: gas_used.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 

--- a/evm/tests/simple_transfer.rs
+++ b/evm/tests/simple_transfer.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
 use eth_trie_utils::nibbles::Nibbles;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
 use hex_literal::hex;
 use keccak_hash::keccak;
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -15,7 +15,7 @@ use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
-use plonky2_evm::proof::{BlockMetadata, TrieRoots};
+use plonky2_evm::proof::{BlockHashes, BlockMetadata, TrieRoots};
 use plonky2_evm::prover::prove;
 use plonky2_evm::verifier::verify_proof;
 use plonky2_evm::Node;
@@ -141,6 +141,10 @@ fn test_simple_transfer() -> anyhow::Result<()> {
         gas_used_after: 21032.into(),
         block_bloom_before: [0.into(); 8],
         block_bloom_after: [0.into(); 8],
+        block_hashes: BlockHashes {
+            prev_hashes: vec![H256::default(); 256],
+            cur_hash: H256::default(),
+        },
         addresses: vec![],
     };
 


### PR DESCRIPTION
This PR implements the BLOCKHASH opcode, following @wborgeaud's second suggestion [in this issue](https://github.com/mir-protocol/plonky2/issues/1173). It includes links between proofs, a couple of unit tests and the challenger observing the additional public values (the previous and current block hashes).

closes #1173 