### PR TITLE
feat: implement serde Serialize and Deserialize for Target

### DIFF
--- a/plonky2/src/iop/target.rs
+++ b/plonky2/src/iop/target.rs
@@ -1,12 +1,14 @@
 use alloc::vec::Vec;
 use core::ops::Range;
 
+use serde::{Deserialize, Serialize};
+
 use crate::iop::ext_target::ExtensionTarget;
 use crate::iop::wire::Wire;
 use crate::plonk::circuit_data::CircuitConfig;
 
 /// A location in the witness.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub enum Target {
     Wire(Wire),
     /// A target that doesn't have any inherent location in the witness (but it can be copied to

--- a/plonky2/src/iop/wire.rs
+++ b/plonky2/src/iop/wire.rs
@@ -1,10 +1,12 @@
 use alloc::vec::Vec;
 use core::ops::Range;
 
+use serde::{Deserialize, Serialize};
+
 use crate::plonk::circuit_data::CircuitConfig;
 
 /// Represents a wire in the circuit, seen as a `degree x num_wires` table.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
 pub struct Wire {
     /// Row index of the wire.
     pub row: usize,


### PR DESCRIPTION
This PR adds support for adding the Serialize and Deserialize macro to targets. It addresses issue #1197.

Implementing automatic serialization/deserialization allows for types composed of targets to also support serde serialization/deserialization. This means that a lot of the manual code written to serialize generator structs can be fully automated with serde.