### PR TITLE
Display actual trace lengths instead of number of ops

### DIFF
--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -159,7 +159,7 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
 
     log::info!(
         "Trace lengths (before padding): {:?}",
-        state.traces.checkpoint()
+        state.traces.get_lengths()
     );
 
     let outputs = get_outputs(&mut state);

--- a/evm/src/witness/traces.rs
+++ b/evm/src/witness/traces.rs
@@ -57,19 +57,8 @@ impl<T: Copy> Traces<T> {
                 .arithmetic_ops
                 .iter()
                 .map(|op| match op {
-                    Operation::TernaryOperation {
-                        operator: _,
-                        input0: _,
-                        input1: _,
-                        input2: _,
-                        result: _,
-                    } => 2,
-                    Operation::BinaryOperation {
-                        operator,
-                        input0: _,
-                        input1: _,
-                        result: _,
-                    } => match operator {
+                    Operation::TernaryOperation { .. } => 2,
+                    Operation::BinaryOperation { operator, .. } => match operator {
                         BinaryOperator::Div | BinaryOperator::Mod => 2,
                         _ => 1,
                     },


### PR DESCRIPTION
The current `TraceCheckpoint` used for logging info only displays the number of operations per STARK module.