### PR TITLE
Remove filter column for KeccakStark

### DIFF
--- a/evm/src/keccak/columns.rs
+++ b/evm/src/keccak/columns.rs
@@ -9,10 +9,6 @@ pub const fn reg_step(i: usize) -> usize {
     i
 }
 
-/// A register which indicates if a row should be included in the CTL. Should be 1 only for certain
-/// rows which are final steps, i.e. with `reg_step(23) = 1`.
-pub const REG_FILTER: usize = NUM_ROUNDS;
-
 /// Registers to hold permutation inputs.
 /// `reg_input_limb(2*i) -> input[i] as u32`
 /// `reg_input_limb(2*i+1) -> input[i] >> 32`
@@ -52,7 +48,7 @@ const R: [[u8; 5]; 5] = [
     [27, 20, 39, 8, 14],
 ];
 
-const START_PREIMAGE: usize = NUM_ROUNDS + 1;
+const START_PREIMAGE: usize = NUM_ROUNDS;
 /// Registers to hold the original input to a permutation, i.e. the input to the first round.
 pub(crate) const fn reg_preimage(x: usize, y: usize) -> usize {
     debug_assert!(x < 5);

--- a/evm/src/keccak/round_flags.rs
+++ b/evm/src/keccak/round_flags.rs
@@ -19,11 +19,21 @@ pub(crate) fn eval_round_flags<F: Field, P: PackedField<Scalar = F>>(
         yield_constr.constraint_first_row(vars.local_values[reg_step(i)]);
     }
 
+    // Flags should circularly increment, or be all zero for padding rows.
+    let next_all_flags = (0..NUM_ROUNDS)
+        .map(|i| vars.next_values[reg_step(i)])
+        .sum::<P>();
     for i in 0..NUM_ROUNDS {
         let current_round_flag = vars.local_values[reg_step(i)];
         let next_round_flag = vars.next_values[reg_step((i + 1) % NUM_ROUNDS)];
-        yield_constr.constraint_transition(next_round_flag - current_round_flag);
+        yield_constr.constraint_transition(next_all_flags * (next_round_flag - current_round_flag));
     }
+
+    // Padding rows should always be followed by padding rows.
+    let current_all_flags = (0..NUM_ROUNDS)
+        .map(|i| vars.local_values[reg_step(i)])
+        .sum::<P>();
+    yield_constr.constraint_transition(next_all_flags * (current_all_flags - F::ONE));
 }
 
 pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D: usize>(
@@ -40,10 +50,20 @@ pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D
         yield_constr.constraint_first_row(builder, vars.local_values[reg_step(i)]);
     }
 
+    // Flags should circularly increment, or be all zero for padding rows.
+    let next_all_flags =
+        builder.add_many_extension((0..NUM_ROUNDS).map(|i| vars.next_values[reg_step(i)]));
     for i in 0..NUM_ROUNDS {
         let current_round_flag = vars.local_values[reg_step(i)];
         let next_round_flag = vars.next_values[reg_step((i + 1) % NUM_ROUNDS)];
         let diff = builder.sub_extension(next_round_flag, current_round_flag);
-        yield_constr.constraint_transition(builder, diff);
+        let constraint = builder.mul_extension(next_all_flags, diff);
+        yield_constr.constraint_transition(builder, constraint);
     }
+
+    // Padding rows should always be followed by padding rows.
+    let current_all_flags =
+        builder.add_many_extension((0..NUM_ROUNDS).map(|i| vars.local_values[reg_step(i)]));
+    let constraint = builder.mul_sub_extension(next_all_flags, current_all_flags, next_all_flags);
+    yield_constr.constraint_transition(builder, constraint);
 }

--- a/evm/src/keccak/round_flags.rs
+++ b/evm/src/keccak/round_flags.rs
@@ -20,20 +20,20 @@ pub(crate) fn eval_round_flags<F: Field, P: PackedField<Scalar = F>>(
     }
 
     // Flags should circularly increment, or be all zero for padding rows.
-    let next_all_flags = (0..NUM_ROUNDS)
+    let next_any_flag = (0..NUM_ROUNDS)
         .map(|i| vars.next_values[reg_step(i)])
         .sum::<P>();
     for i in 0..NUM_ROUNDS {
         let current_round_flag = vars.local_values[reg_step(i)];
         let next_round_flag = vars.next_values[reg_step((i + 1) % NUM_ROUNDS)];
-        yield_constr.constraint_transition(next_all_flags * (next_round_flag - current_round_flag));
+        yield_constr.constraint_transition(next_any_flag * (next_round_flag - current_round_flag));
     }
 
     // Padding rows should always be followed by padding rows.
-    let current_all_flags = (0..NUM_ROUNDS)
+    let current_any_flag = (0..NUM_ROUNDS)
         .map(|i| vars.local_values[reg_step(i)])
         .sum::<P>();
-    yield_constr.constraint_transition(next_all_flags * (current_all_flags - F::ONE));
+    yield_constr.constraint_transition(next_any_flag * (current_any_flag - F::ONE));
 }
 
 pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D: usize>(
@@ -51,19 +51,19 @@ pub(crate) fn eval_round_flags_recursively<F: RichField + Extendable<D>, const D
     }
 
     // Flags should circularly increment, or be all zero for padding rows.
-    let next_all_flags =
+    let next_any_flag =
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| vars.next_values[reg_step(i)]));
     for i in 0..NUM_ROUNDS {
         let current_round_flag = vars.local_values[reg_step(i)];
         let next_round_flag = vars.next_values[reg_step((i + 1) % NUM_ROUNDS)];
         let diff = builder.sub_extension(next_round_flag, current_round_flag);
-        let constraint = builder.mul_extension(next_all_flags, diff);
+        let constraint = builder.mul_extension(next_any_flag, diff);
         yield_constr.constraint_transition(builder, constraint);
     }
 
     // Padding rows should always be followed by padding rows.
-    let current_all_flags =
+    let current_any_flag =
         builder.add_many_extension((0..NUM_ROUNDS).map(|i| vars.local_values[reg_step(i)]));
-    let constraint = builder.mul_sub_extension(next_all_flags, current_all_flags, next_all_flags);
+    let constraint = builder.mul_sub_extension(next_any_flag, current_any_flag, next_any_flag);
     yield_constr.constraint_transition(builder, constraint);
 }


### PR DESCRIPTION
This PR removes the filtering column of KeccakStark, and instead replaces it with the latest round register (i.e. `reg(NUM_ROUNDS - 1)`.
To do so, I modified the padding approach so that it doesn't trigger issues either in the CTL or in the `round_flags` consistency check.

Although the reduction in number of columns is only of ~0.04%, it allows to get down to 2480 columns, i.e. 1 less Poseidon permutation per leaf hashing 😄 

@npwardberkeley As you've been heavily involved in the Keccak impl, would you mind reviewing? Sorry for the double request! 🙏🏼 