### PR TITLE
Latest nightly fix

### DIFF
--- a/evm/src/cpu/kernel/constants/exc_bitfields.rs
+++ b/evm/src/cpu/kernel/constants/exc_bitfields.rs
@@ -4,7 +4,7 @@ use ethereum_types::U256;
 
 /// Create a U256, where the bits at indices inside the specified ranges are set to 1, and all other
 /// bits are set to 0.
-const fn u256_from_set_index_ranges<const N: usize>(ranges: [RangeInclusive<u8>; N]) -> U256 {
+const fn u256_from_set_index_ranges<const N: usize>(ranges: &[RangeInclusive<u8>; N]) -> U256 {
     let mut j = 0;
     let mut res_limbs = [0u64; 4];
     while j < ranges.len() {
@@ -28,7 +28,7 @@ const fn u256_from_set_index_ranges<const N: usize>(ranges: [RangeInclusive<u8>;
     U256(res_limbs)
 }
 
-pub const STACK_LENGTH_INCREASING_OPCODES_USER: U256 = u256_from_set_index_ranges([
+pub const STACK_LENGTH_INCREASING_OPCODES_USER: U256 = u256_from_set_index_ranges(&[
     0x30..=0x30, // ADDRESS
     0x32..=0x34, // ORIGIN, CALLER, CALLVALUE
     0x36..=0x36, // CALLDATASIZE
@@ -40,7 +40,7 @@ pub const STACK_LENGTH_INCREASING_OPCODES_USER: U256 = u256_from_set_index_range
     0x5f..=0x8f, // PUSH*, DUP*
 ]);
 
-pub const INVALID_OPCODES_USER: U256 = u256_from_set_index_ranges([
+pub const INVALID_OPCODES_USER: U256 = u256_from_set_index_ranges(&[
     0x0c..=0x0f,
     0x1e..=0x1f,
     0x21..=0x2f,

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -136,7 +136,7 @@ fn fri_proof_of_work<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     // obtaining our duplex's post-state which contains the PoW response.
     let mut duplex_intermediate_state = challenger.sponge_state;
     let witness_input_pos = challenger.input_buffer.len();
-    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone().into_iter(), 0);
+    duplex_intermediate_state.set_from_iter(challenger.input_buffer.clone(), 0);
 
     let pow_witness = (0..=F::NEG_ONE.to_canonical_u64())
         .into_par_iter()

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -332,8 +332,8 @@ mod tests {
 
         // These are mostly arbitrary, but we want to test some rounds with enough inputs/outputs to
         // trigger multiple absorptions/squeezes.
-        let num_inputs_per_round = vec![2, 5, 3];
-        let num_outputs_per_round = vec![1, 2, 4];
+        let num_inputs_per_round = [2, 5, 3];
+        let num_outputs_per_round = [1, 2, 4];
 
         // Generate random input messages.
         let inputs_per_round: Vec<Vec<F>> = num_inputs_per_round


### PR DESCRIPTION
There's one compiler error that's preventing us from building on the latest nightly, and I managed to resolve it by making a paremeter into a reference. I tried a few other things before resorting to using a reference (like `#![feature(const_precise_live_drops)]`), but I couldn't get it to compile. I *think* using a reference here should have no performance changes (since it's still a `const fn` at the end of the day), but let me know if there's a better way to fix this error.

For reference, the error was this:
```sh
error[E0493]: destructor of `[std::ops::RangeInclusive<u8>; N]` cannot be evaluated at compile-time
  --> evm/src/cpu/kernel/constants/exc_bitfields.rs:7:53
   |
7  | const fn u256_from_set_index_ranges<const N: usize>(ranges: [RangeInclusive<u8>; N]) -> U256 {
   |                                                     ^^^^^^ the destructor for this type cannot be evaluated in constant functions
...
29 | }
   | - value is dropped here
```

Resolves #1186.