### PR TITLE
Remove `LookupGate` and `LookupTableGate` for build optimization

### DIFF
--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -105,9 +105,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 let num_lut_rows = (self.get_luts_idx_length(lut_index) - 1) / num_lut_entries + 1;
                 let num_lut_cells = num_lut_entries * num_lut_rows;
                 for _ in 0..num_lut_cells {
-                    let gate =
-                        LookupTableGate::new_from_table(&self.config, lut.clone(), last_lut_gate);
-                    self.find_slot(gate, &[], &[]);
+                    let gate = LookupTableGate::new_from_table(&self.config, lut.clone());
+                    self.find_slot(gate.clone(), &[], &[]);
                 }
 
                 let first_lut_gate = self.num_gates() - 1;

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -168,9 +168,9 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D> for
 
 #[derive(Clone, Debug, Default)]
 pub struct LookupGenerator {
-    row: usize,
-    lut: LookupTable,
-    slot_nb: usize,
+    pub row: usize,
+    pub lut: LookupTable,
+    pub slot_nb: usize,
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for LookupGenerator {

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -92,17 +92,24 @@ pub fn set_lookup_wires<
             multiplicities[0] += 1;
         }
 
+        // Set all LUT wires.
         // We don't need to pad the last `LookupTableGate`; extra wires are set to 0 by default, which satisfies the constraints.
         for lut_entry in 0..lut_len {
             let row = first_lut_gate - lut_entry / num_lut_entries;
             let col = lut_entry % num_lut_entries;
 
             let mul_target = Target::wire(row, LookupTableGate::wire_ith_multiplicity(col));
+            let inp_target = Target::wire(row, LookupTableGate::wire_ith_looked_inp(col));
+            let out_target = Target::wire(row, LookupTableGate::wire_ith_looked_out(col));
 
             pw.set_target(
                 mul_target,
                 F::from_canonical_usize(multiplicities[lut_entry]),
             );
+
+            let (inp_value, out_value) = common_data.luts[lut_index][lut_entry];
+            pw.set_target(inp_target, F::from_canonical_u16(inp_value));
+            pw.set_target(out_target, F::from_canonical_u16(out_value));
         }
     }
 }

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -103,7 +103,6 @@ pub mod default {
     use crate::gates::coset_interpolation::InterpolationGenerator;
     use crate::gates::exponentiation::ExponentiationGenerator;
     use crate::gates::lookup::LookupGenerator;
-    use crate::gates::lookup_table::LookupTableGenerator;
     use crate::gates::multiplication_extension::MulExtensionGenerator;
     use crate::gates::poseidon::PoseidonGenerator;
     use crate::gates::poseidon_mds::PoseidonMdsGenerator;
@@ -141,7 +140,6 @@ pub mod default {
             ExponentiationGenerator<F, D>,
             InterpolationGenerator<F, D>,
             LookupGenerator,
-            LookupTableGenerator,
             LowHighGenerator,
             MulExtensionGenerator<F, D>,
             NonzeroTestGenerator,


### PR DESCRIPTION
When using lookups with a larger lookup table (of size 2^16), we noticed that `add_all_lookups` incurred a very high overhead in build time, due to `find_slot`. 
This PR addresses this issue as follows:
- We remove `last_lut_row` from `LookupTableGate`.
- Since `LookupTableGate` doesn't have any generators, the previous point enables us to remove the gates from the circuit.
- We also remove `LookupGates`, and only add their generators in `add_all_lookups`.
We still keep the two gate types, since they allow us to use their methods (such as `get_wire_ith_input`).

With these changes, when testing with 500,000 lookups on a lookup table of size 2^16, we go, from ~3100s execution time for `add_all_lookups` to ~0.27s. The tests were carried out on a MacBook Pro with processor: 2,3 GHz Dual-Core Intel Core i5 (using 4 threads on 4 cores).

Please let me know what you think! 