### PR TITLE
Now refers to sub-crates using paths (and removed `patch` section)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,3 @@ incremental = true
 
 [profile.bench]
 opt-level = 3
-
-[patch.crates-io]
-eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
-plonky2_evm = { path = "evm" }
-plonky2_field = { path = "field" }
-plonky2_maybe_rayon = { path = "maybe_rayon" }
-plonky2 = { path = "plonky2" }
-starky = { path = "starky" }
-plonky2_util = { path = "util" }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -13,21 +13,21 @@ edition = "2021"
 anyhow = "1.0.40"
 bytes = "1.4.0"
 env_logger = "0.10.0"
-eth_trie_utils = "0.6.0"
+eth_trie_utils = { git = "https://github.com/mir-protocol/eth_trie_utils.git", rev = "e9ec4ec2aa2ae976b7c699ef40c1ffc716d87ed5" }
 ethereum-types = "0.14.0"
 hex = { version = "0.4.3", optional = true }
 hex-literal = "0.4.1"
 itertools = "0.11.0"
 keccak-hash = "0.10.0"
 log = "0.4.14"
-plonky2_maybe_rayon = "0.1.1"
+plonky2_maybe_rayon = { path = "../maybe_rayon" }
 num = "0.4.0"
 num-bigint = "0.4.3"
 once_cell = "1.13.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"
-plonky2 = { version = "0.1.4", default-features = false, features = ["timing"] }
-plonky2_util = { version = "0.1.1" }
+plonky2 = { path = "../plonky2", default-features = false, features = ["timing"] }
+plonky2_util = { path = "../util" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rlp = "0.5.1"

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 anyhow = { version = "1.0.40", default-features = false }
 itertools = { version = "0.11.0", default-features = false, features = ["use_alloc"] }
 num = { version = "0.4", default-features = false, features = ["alloc", "rand"] }
-plonky2_util = { version = "0.1.0", default-features = false }
+plonky2_util = { path = "../util", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 static_assertions = { version = "1.1.0", default-features = false }

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -24,10 +24,10 @@ hashbrown = { version = "0.14.0", default-features = false, features = ["ahash",
 itertools = { version = "0.11.0", default-features = false }
 keccak-hash = { version = "0.8.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
-plonky2_maybe_rayon = { version = "0.1.1", default-features = false }
+plonky2_maybe_rayon = { path = "../maybe_rayon", default-features = false }
 num = { version = "0.4", default-features = false, features = ["rand"] }
-plonky2_field = { version = "0.1.1", default-features = false }
-plonky2_util = { version = "0.1.1", default-features = false }
+plonky2_field = { path = "../field", default-features = false }
+plonky2_util = { path = "../util", default-features = false }
 rand = { version = "0.8.4", default-features = false }
 rand_chacha = { version = "0.3.1", optional = true, default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -20,8 +20,8 @@ timing = ["plonky2/timing"]
 anyhow = { version = "1.0.40", default-features = false }
 itertools = { version = "0.11.0", default-features = false }
 log = { version = "0.4.14", default-features = false }
-plonky2_maybe_rayon = { version = "0.1.1", default-features = false }
-plonky2 = { version = "0.1.2", default-features = false }
+plonky2_maybe_rayon = { path = "../maybe_rayon", default-features = false }
+plonky2 = { path = "../plonky2", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
- Previously refered to specific `crates.io` versions.
- Motivation for this is to allow external projects to be able use specific revisions of this repo. Without this, a `[patch]` section is almost always required in the external project in order to force the internal plonky2 sub-crates to the same version, an approach which comes with its own issues.