### PR TITLE
Swap ordering in stack macro

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/packing.asm
+++ b/evm/src/cpu/kernel/asm/memory/packing.asm
@@ -43,7 +43,7 @@ global mload_packing_u64_LE:
 global mstore_unpacking:
     // stack: context, segment, offset, value, len, retdest
     %stack(context, segment, offset, value, len, retdest) -> (context, segment, offset, value, len, offset, len, retdest)
-    // stack: context, segment, offset, value, len, len, offset, retdest
+    // stack: context, segment, offset, value, len, offset, len, retdest
     MSTORE_32BYTES
     // stack: offset, len, retdest
     ADD SWAP1

--- a/evm/src/cpu/kernel/asm/memory/packing.asm
+++ b/evm/src/cpu/kernel/asm/memory/packing.asm
@@ -42,10 +42,10 @@ global mload_packing_u64_LE:
 // Post stack: offset'
 global mstore_unpacking:
     // stack: context, segment, offset, value, len, retdest
-    %stack(context, segment, offset, value, len, retdest) -> (context, segment, offset, value, len, len, offset, retdest)
+    %stack(context, segment, offset, value, len, retdest) -> (context, segment, offset, value, len, offset, len, retdest)
     // stack: context, segment, offset, value, len, len, offset, retdest
     MSTORE_32BYTES
-    // stack: len, offset, retdest
+    // stack: offset, len, retdest
     ADD SWAP1
     // stack: retdest, offset'
     JUMP


### PR DESCRIPTION
Slight overlook from #1212, but swapping `offset` and `len` in the stack macro of `mstore_unpacking` removes one `SWAP` from the set of operations it expands to (5 `SWAP` + 2 `DUP` originally).
