### PR TITLE
Update clippy in CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -124,5 +124,5 @@ jobs:
           command: clippy
           args: --all-features --all-targets -- -D warnings -A incomplete-features
         env:
-          CARGO_INCREMENTAL: 1
-
+          # Seems necessary until https://github.com/rust-lang/rust/pull/115819 is merged.
+          CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Clippy seems to have a weird bug, known upstream, for which a temporary fix seems to be deactivating incremental compilation. It happened on all the recent branches that have been pushed, probably triggered by the nightly update overnight.

cc @BGluth as you could encounter it in what you're doing if the toolchain isn't fixed.