### PR TITLE
Fix observe_block_metadata

### DIFF
--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -64,8 +64,8 @@ fn observe_block_metadata<
     challenger.observe_element(u256_to_u32(block_metadata.block_timestamp)?);
     challenger.observe_element(u256_to_u32(block_metadata.block_number)?);
     challenger.observe_element(u256_to_u32(block_metadata.block_difficulty)?);
-    challenger.observe_element(u256_to_u32(block_metadata.block_gaslimit)?);
     challenger.observe_elements(&h256_limbs::<F>(block_metadata.block_random));
+    challenger.observe_element(u256_to_u32(block_metadata.block_gaslimit)?);
     challenger.observe_element(u256_to_u32(block_metadata.block_chain_id)?);
     let basefee = u256_to_u64(block_metadata.block_base_fee)?;
     challenger.observe_element(basefee.0);


### PR DESCRIPTION
We noticed the recursive proofs were failing because the challenges were observed in the a different order in the recursive and non-recursive versions. This PR fixes the issue.