### PR TITLE
Add type 1 and 2 txn for RLP encoding support

### DIFF
--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -34,6 +34,12 @@ impl Default for AccountRlp {
 }
 
 #[derive(RlpEncodable, RlpDecodable, Debug)]
+pub struct AccessListItemRlp {
+    pub address: Address,
+    pub storage_keys: Vec<U256>,
+}
+
+#[derive(RlpEncodable, RlpDecodable, Debug)]
 pub struct LegacyTransactionRlp {
     pub nonce: U256,
     pub gas_price: U256,
@@ -42,6 +48,37 @@ pub struct LegacyTransactionRlp {
     pub value: U256,
     pub data: Bytes,
     pub v: U256,
+    pub r: U256,
+    pub s: U256,
+}
+
+#[derive(RlpEncodable, RlpDecodable, Debug)]
+pub struct AccessListTransactionRlp {
+    pub chain_id: u64,
+    pub nonce: U256,
+    pub gas_price: U256,
+    pub gas: U256,
+    pub to: Address,
+    pub value: U256,
+    pub data: Bytes,
+    pub access_list: Vec<AccessListItemRlp>,
+    pub y_parity: U256,
+    pub r: U256,
+    pub s: U256,
+}
+
+#[derive(RlpEncodable, RlpDecodable, Debug)]
+pub struct FeeMarketTransactionRlp {
+    pub chain_id: u64,
+    pub nonce: U256,
+    pub max_priority_fee_per_gas: U256,
+    pub max_fee_per_gas: U256,
+    pub gas: U256,
+    pub to: Address,
+    pub value: U256,
+    pub data: Bytes,
+    pub access_list: Vec<AccessListItemRlp>,
+    pub y_parity: U256,
     pub r: U256,
     pub s: U256,
 }

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -17,7 +17,9 @@ use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
-use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp, LegacyTransactionRlp, LogRlp};
+use plonky2_evm::generation::mpt::{
+    AccountRlp, AddressOption, LegacyReceiptRlp, LegacyTransactionRlp, LogRlp,
+};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
 use plonky2_evm::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
 use plonky2_evm::prover::prove;
@@ -631,7 +633,7 @@ fn test_txn_and_receipt_trie_hash() -> anyhow::Result<()> {
         nonce: 157823u64.into(),
         gas_price: 1000000000u64.into(),
         gas: 250000u64.into(),
-        to: hex!("7ef66b77759e12Caf3dDB3E4AFF524E577C59D8D").into(),
+        to: AddressOption(Some(hex!("7ef66b77759e12Caf3dDB3E4AFF524E577C59D8D").into())),
         value: 0u64.into(),
         data: hex!("e9c6c176000000000000000000000000000000000000000000000000000000000000002a0000000000000000000000000000000000000000000000000000000000bd9fe6f7af1cc94b1aef2e0fa15f1b4baefa86eb60e78fa4bd082372a0a446d197fb58")
             .to_vec()
@@ -651,7 +653,7 @@ fn test_txn_and_receipt_trie_hash() -> anyhow::Result<()> {
         nonce: 157824u64.into(),
         gas_price: 1000000000u64.into(),
         gas: 250000u64.into(),
-        to: hex!("7ef66b77759e12Caf3dDB3E4AFF524E577C59D8D").into(),
+        to: AddressOption(Some(hex!("7ef66b77759e12Caf3dDB3E4AFF524E577C59D8D").into())),
         value: 0u64.into(),
         data: hex!("e9c6c176000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000004920eaa814f7df6a2203dc0e472e8828be95957c6b329fee8e2b1bb6f044c1eb4fc243")
             .to_vec()


### PR DESCRIPTION
Needed for upgrading evm-tests runner.